### PR TITLE
feat: auto-trigger login when not authenticated

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -62,7 +62,7 @@ export function registerCreateCommand(program: Command): void {
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth(apiUrl);
 
         if (!json) {
           clack.intro('Create a new InsForge project');

--- a/src/commands/db/export.ts
+++ b/src/commands/db/export.ts
@@ -20,7 +20,7 @@ export function registerDbExportCommand(dbCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const body: Record<string, unknown> = {
           format: opts.format,

--- a/src/commands/db/functions.ts
+++ b/src/commands/db/functions.ts
@@ -26,7 +26,7 @@ export function registerDbFunctionsCommand(dbCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/database/functions');
         const raw = await res.json() as unknown;

--- a/src/commands/db/import.ts
+++ b/src/commands/db/import.ts
@@ -14,7 +14,7 @@ export function registerDbImportCommand(dbCmd: Command): void {
     .action(async (file: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
         const config = getProjectConfig();
         if (!config) throw new ProjectNotLinkedError();
 

--- a/src/commands/db/indexes.ts
+++ b/src/commands/db/indexes.ts
@@ -26,7 +26,7 @@ export function registerDbIndexesCommand(dbCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/database/indexes');
         const raw = await res.json() as unknown;

--- a/src/commands/db/policies.ts
+++ b/src/commands/db/policies.ts
@@ -26,7 +26,7 @@ export function registerDbPoliciesCommand(dbCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/database/policies');
         const raw = await res.json() as unknown;

--- a/src/commands/db/query.ts
+++ b/src/commands/db/query.ts
@@ -12,7 +12,7 @@ export function registerDbCommands(dbCmd: Command): void {
     .action(async (sql: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const endpoint = opts.unrestricted
           ? '/api/database/advance/rawsql/unrestricted'

--- a/src/commands/db/rpc.ts
+++ b/src/commands/db/rpc.ts
@@ -12,7 +12,7 @@ export function registerDbRpcCommand(dbCmd: Command): void {
     .action(async (functionName: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const body = opts.data ? JSON.stringify(JSON.parse(opts.data) as unknown) : undefined;
 

--- a/src/commands/db/tables.ts
+++ b/src/commands/db/tables.ts
@@ -11,7 +11,7 @@ export function registerDbTablesCommand(dbCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/database/tables');
         const tables = await res.json() as string[];

--- a/src/commands/db/triggers.ts
+++ b/src/commands/db/triggers.ts
@@ -26,7 +26,7 @@ export function registerDbTriggersCommand(dbCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/database/triggers');
         const raw = await res.json() as unknown;

--- a/src/commands/deployments/cancel.ts
+++ b/src/commands/deployments/cancel.ts
@@ -13,7 +13,7 @@ export function registerDeploymentsCancelCommand(deploymentsCmd: Command): void 
     .action(async (id: string, _opts, cmd) => {
       const { json, yes } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
 
         if (!yes && !json) {

--- a/src/commands/deployments/deploy.ts
+++ b/src/commands/deployments/deploy.ts
@@ -68,7 +68,7 @@ export function registerDeploymentsDeployCommand(deploymentsCmd: Command): void 
     .action(async (directory: string | undefined, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
         const config = getProjectConfig();
         if (!config) throw new ProjectNotLinkedError();
 

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -15,7 +15,7 @@ export function registerDeploymentsListCommand(deploymentsCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
 
         const res = await ossFetch(`/api/deployments?limit=${opts.limit}&offset=${opts.offset}`);

--- a/src/commands/deployments/metadata.ts
+++ b/src/commands/deployments/metadata.ts
@@ -13,7 +13,7 @@ export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): voi
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
 
         const res = await ossFetch('/api/deployments/metadata');

--- a/src/commands/deployments/slug.ts
+++ b/src/commands/deployments/slug.ts
@@ -13,7 +13,7 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
     .action(async (slug: string | undefined, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
 
         const slugValue = opts.remove ? null : (slug ?? null);

--- a/src/commands/deployments/status.ts
+++ b/src/commands/deployments/status.ts
@@ -14,7 +14,7 @@ export function registerDeploymentsStatusCommand(deploymentsCmd: Command): void 
     .action(async (id: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
 
         // Optionally sync status from Vercel first

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -24,7 +24,7 @@ Examples:
     .action(async (feature: string | undefined, language: string | undefined, _opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         // No args → list all docs
         if (!feature) {

--- a/src/commands/functions/code.ts
+++ b/src/commands/functions/code.ts
@@ -23,7 +23,7 @@ export function registerFunctionsCodeCommand(functionsCmd: Command): void {
     .action(async (slug: string, _opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch(`/api/functions/${encodeURIComponent(slug)}`);
         const fn = await res.json() as FunctionDetails;

--- a/src/commands/functions/deploy.ts
+++ b/src/commands/functions/deploy.ts
@@ -16,7 +16,7 @@ export function registerFunctionsDeployCommand(functionsCmd: Command): void {
     .action(async (slug: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         // Resolve source file
         const filePath = opts.file ?? join(process.cwd(), 'insforge', 'functions', slug, 'index.ts');

--- a/src/commands/functions/invoke.ts
+++ b/src/commands/functions/invoke.ts
@@ -13,7 +13,7 @@ export function registerFunctionsInvokeCommand(functionsCmd: Command): void {
     .action(async (slug: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const config = getProjectConfig();
         if (!config) throw new ProjectNotLinkedError();

--- a/src/commands/functions/list.ts
+++ b/src/commands/functions/list.ts
@@ -12,7 +12,7 @@ export function registerFunctionsCommands(functionsCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/functions');
         const data = await res.json() as { functions?: OssFunction[] };

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -11,7 +11,7 @@ export function registerListCommand(program: Command): void {
     .action(async (_opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth(apiUrl);
         const orgs = await listOrganizations(apiUrl);
 
         if (orgs.length === 0) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,16 +1,8 @@
 import type { Command } from 'commander';
 import * as clack from '@clack/prompts';
-import { saveCredentials, getGlobalConfig, getPlatformApiUrl } from '../lib/config.js';
-import { login as platformLogin, getProfile } from '../lib/api/platform.js';
-import {
-  generatePKCE,
-  generateState,
-  buildAuthorizeUrl,
-  exchangeCodeForTokens,
-  startCallbackServer,
-  DEFAULT_CLIENT_ID,
-  OAUTH_SCOPES,
-} from '../lib/auth.js';
+import { saveCredentials, getPlatformApiUrl } from '../lib/config.js';
+import { login as platformLogin } from '../lib/api/platform.js';
+import { performOAuthLogin } from '../lib/auth.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import type { StoredCredentials } from '../types.js';
 
@@ -27,7 +19,7 @@ export function registerLoginCommand(program: Command): void {
         if (opts.email) {
           await loginWithEmail(json, apiUrl);
         } else {
-          await loginWithOAuth(json, apiUrl, opts.clientId);
+          await loginWithOAuth(json, apiUrl);
         }
       } catch (err) {
         if (err instanceof Error && err.message.includes('cancelled')) {
@@ -96,129 +88,16 @@ async function loginWithEmail(json: boolean, apiUrl?: string): Promise<void> {
   }
 }
 
-async function loginWithOAuth(json: boolean, apiUrl?: string, clientIdOverride?: string): Promise<void> {
-  const platformUrl = getPlatformApiUrl(apiUrl);
-  const config = getGlobalConfig();
-  const clientId = clientIdOverride ?? config.oauth_client_id ?? DEFAULT_CLIENT_ID;
-
-  // 1. Generate PKCE and state
-  const pkce = generatePKCE();
-  const state = generateState();
-
-  // 2. Start local callback server
-  const { port, result, close } = await startCallbackServer();
-  const redirectUri = `http://127.0.0.1:${port}/callback`;
-
-  // 3. Build authorization URL
-  const authUrl = buildAuthorizeUrl({
-    platformUrl,
-    clientId,
-    redirectUri,
-    codeChallenge: pkce.code_challenge,
-    state,
-    scopes: OAUTH_SCOPES,
-  });
-
+async function loginWithOAuth(json: boolean, apiUrl?: string): Promise<void> {
   if (!json) {
     clack.intro('InsForge CLI');
-    clack.log.info('Opening browser for authentication...');
-    clack.log.info(`If browser doesn't open, visit:\n${authUrl}`);
   }
 
-  // 4. Open browser
-  try {
-    const open = (await import('open')).default;
-    await open(authUrl);
-  } catch {
-    if (!json) {
-      clack.log.warn(`Could not open browser. Please visit the URL above.`);
-    }
-  }
+  const creds = await performOAuthLogin(apiUrl);
 
-  // 5. Wait for callback
   if (!json) {
-    const s = clack.spinner();
-    s.start('Waiting for authentication...');
-
-    try {
-      const callbackResult = await result;
-      close();
-
-      // Verify state
-      if (callbackResult.state !== state) {
-        s.stop('Authentication failed');
-        throw new Error('State mismatch. Possible CSRF attack.');
-      }
-
-      // 6. Exchange code for tokens
-      s.message('Exchanging authorization code...');
-      const tokens = await exchangeCodeForTokens({
-        platformUrl,
-        code: callbackResult.code,
-        redirectUri,
-        clientId,
-        codeVerifier: pkce.code_verifier,
-      });
-
-      // 7. Fetch user profile with the new token
-      const creds: StoredCredentials = {
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-        user: { id: '', name: '', email: '', avatar_url: null, email_verified: true },
-      };
-      saveCredentials(creds);
-
-      // Try to get user profile
-      try {
-        const profile = await getProfile(apiUrl);
-        creds.user = profile;
-        saveCredentials(creds);
-        s.stop(`Authenticated as ${profile.email}`);
-      } catch {
-        s.stop('Authenticated successfully');
-      }
-
-      clack.outro('Done');
-    } catch (err) {
-      close();
-      s.stop('Authentication failed');
-      throw err;
-    }
+    clack.outro('Done');
   } else {
-    // JSON mode
-    try {
-      const callbackResult = await result;
-      close();
-
-      if (callbackResult.state !== state) {
-        throw new Error('State mismatch.');
-      }
-
-      const tokens = await exchangeCodeForTokens({
-        platformUrl,
-        code: callbackResult.code,
-        redirectUri,
-        clientId,
-        codeVerifier: pkce.code_verifier,
-      });
-
-      const creds: StoredCredentials = {
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-        user: { id: '', name: '', email: '', avatar_url: null, email_verified: true },
-      };
-      saveCredentials(creds);
-
-      try {
-        const profile = await getProfile(apiUrl);
-        creds.user = profile;
-        saveCredentials(creds);
-      } catch {}
-
-      console.log(JSON.stringify({ success: true, user: creds.user }));
-    } catch (err) {
-      close();
-      throw err;
-    }
+    console.log(JSON.stringify({ success: true, user: creds.user }));
   }
 }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -15,7 +15,7 @@ export function registerLogsCommand(program: Command): void {
     .action(async (source: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const resolved = SOURCE_LOOKUP.get(source.toLowerCase());
         if (!resolved) {

--- a/src/commands/orgs/list.ts
+++ b/src/commands/orgs/list.ts
@@ -11,7 +11,7 @@ export function registerOrgsCommands(orgsCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth(apiUrl);
         const orgs = await listOrganizations(apiUrl);
 
         if (json) {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -26,7 +26,7 @@ export function registerProjectLinkCommand(program: Command): void {
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth(apiUrl);
 
         let orgId = opts.orgId;
         let projectId = opts.projectId;

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -14,7 +14,7 @@ export function registerProjectsCommands(projectsCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth(apiUrl);
 
         let orgId = opts.orgId ?? getGlobalConfig().default_org_id;
 

--- a/src/commands/records/create.ts
+++ b/src/commands/records/create.ts
@@ -12,7 +12,7 @@ export function registerRecordsCreateCommand(recordsCmd: Command): void {
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         if (!opts.data) {
           throw new CLIError('--data is required. Example: --data \'{"name":"John"}\'');

--- a/src/commands/records/delete.ts
+++ b/src/commands/records/delete.ts
@@ -12,7 +12,7 @@ export function registerRecordsDeleteCommand(recordsCmd: Command): void {
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         if (!opts.filter) {
           throw new CLIError('--filter is required to prevent accidental deletion of all rows.');

--- a/src/commands/records/list.ts
+++ b/src/commands/records/list.ts
@@ -16,7 +16,7 @@ export function registerRecordsCommands(recordsCmd: Command): void {
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const params = new URLSearchParams();
         if (opts.select) params.set('select', opts.select);

--- a/src/commands/records/update.ts
+++ b/src/commands/records/update.ts
@@ -13,7 +13,7 @@ export function registerRecordsUpdateCommand(recordsCmd: Command): void {
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         if (!opts.filter) {
           throw new CLIError('--filter is required to prevent accidental updates to all rows.');

--- a/src/commands/schedules/create.ts
+++ b/src/commands/schedules/create.ts
@@ -17,7 +17,7 @@ export function registerSchedulesCreateCommand(schedulesCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const body: Record<string, unknown> = {
           name: opts.name,

--- a/src/commands/schedules/delete.ts
+++ b/src/commands/schedules/delete.ts
@@ -12,7 +12,7 @@ export function registerSchedulesDeleteCommand(schedulesCmd: Command): void {
     .action(async (id: string, _opts, cmd) => {
       const { json, yes } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         if (!yes && !json) {
           const confirm = await clack.confirm({

--- a/src/commands/schedules/get.ts
+++ b/src/commands/schedules/get.ts
@@ -11,7 +11,7 @@ export function registerSchedulesGetCommand(schedulesCmd: Command): void {
     .action(async (id: string, _opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch(`/api/schedules/${encodeURIComponent(id)}`);
         const data = await res.json() as Record<string, unknown>;

--- a/src/commands/schedules/list.ts
+++ b/src/commands/schedules/list.ts
@@ -11,7 +11,7 @@ export function registerSchedulesListCommand(schedulesCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/schedules');
         const data = await res.json();

--- a/src/commands/schedules/logs.ts
+++ b/src/commands/schedules/logs.ts
@@ -13,7 +13,7 @@ export function registerSchedulesLogsCommand(schedulesCmd: Command): void {
     .action(async (id: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const limit = parseInt(opts.limit, 10) || 50;
         const offset = parseInt(opts.offset, 10) || 0;

--- a/src/commands/schedules/update.ts
+++ b/src/commands/schedules/update.ts
@@ -18,7 +18,7 @@ export function registerSchedulesUpdateCommand(schedulesCmd: Command): void {
     .action(async (id: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const body: Record<string, unknown> = {};
         if (opts.name !== undefined) body.name = opts.name;

--- a/src/commands/secrets/add.ts
+++ b/src/commands/secrets/add.ts
@@ -13,7 +13,7 @@ export function registerSecretsAddCommand(secretsCmd: Command): void {
     .action(async (key: string, value: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const body: Record<string, unknown> = { key, value };
         if (opts.reserved) body.isReserved = true;

--- a/src/commands/secrets/delete.ts
+++ b/src/commands/secrets/delete.ts
@@ -12,7 +12,7 @@ export function registerSecretsDeleteCommand(secretsCmd: Command): void {
     .action(async (key: string, _opts, cmd) => {
       const { json, yes } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         if (!yes && !json) {
           const confirm = await clack.confirm({

--- a/src/commands/secrets/get.ts
+++ b/src/commands/secrets/get.ts
@@ -11,7 +11,7 @@ export function registerSecretsGetCommand(secretsCmd: Command): void {
     .action(async (key: string, _opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch(`/api/secrets/${encodeURIComponent(key)}`);
         const data = await res.json() as { key: string; value: string };

--- a/src/commands/secrets/list.ts
+++ b/src/commands/secrets/list.ts
@@ -12,7 +12,7 @@ export function registerSecretsListCommand(secretsCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/secrets');
         const data = await res.json() as { secrets: Record<string, unknown>[] };

--- a/src/commands/secrets/update.ts
+++ b/src/commands/secrets/update.ts
@@ -15,7 +15,7 @@ export function registerSecretsUpdateCommand(secretsCmd: Command): void {
     .action(async (key: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const body: Record<string, unknown> = {};
         if (opts.value !== undefined) body.value = opts.value;

--- a/src/commands/storage/buckets.ts
+++ b/src/commands/storage/buckets.ts
@@ -11,7 +11,7 @@ export function registerStorageBucketsCommand(storageCmd: Command): void {
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const res = await ossFetch('/api/storage/buckets');
         const raw = await res.json() as unknown;

--- a/src/commands/storage/create-bucket.ts
+++ b/src/commands/storage/create-bucket.ts
@@ -13,7 +13,7 @@ export function registerStorageCreateBucketCommand(storageCmd: Command): void {
     .action(async (name: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const isPublic = !opts.private;
 

--- a/src/commands/storage/delete-bucket.ts
+++ b/src/commands/storage/delete-bucket.ts
@@ -12,7 +12,7 @@ export function registerStorageDeleteBucketCommand(storageCmd: Command): void {
     .action(async (name: string, _opts, cmd) => {
       const { json, yes } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         if (!yes && !json) {
           const confirm = await clack.confirm({

--- a/src/commands/storage/download.ts
+++ b/src/commands/storage/download.ts
@@ -15,7 +15,7 @@ export function registerStorageDownloadCommand(storageCmd: Command): void {
     .action(async (objectKey: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const config = getProjectConfig();
         if (!config) throw new ProjectNotLinkedError();

--- a/src/commands/storage/list-objects.ts
+++ b/src/commands/storage/list-objects.ts
@@ -29,7 +29,7 @@ export function registerStorageListObjectsCommand(storageCmd: Command): void {
     .action(async (bucket: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const params = new URLSearchParams();
         params.set('limit', opts.limit);

--- a/src/commands/storage/upload.ts
+++ b/src/commands/storage/upload.ts
@@ -15,7 +15,7 @@ export function registerStorageUploadCommand(storageCmd: Command): void {
     .action(async (file: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth();
 
         const config = getProjectConfig();
         if (!config) throw new ProjectNotLinkedError();

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -11,7 +11,7 @@ export function registerWhoamiCommand(program: Command): void {
     .action(async (_opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        requireAuth();
+        await requireAuth(apiUrl);
         const profile = await getProfile(apiUrl);
 
         if (json) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,10 @@
 import { createServer } from 'node:http';
 import { randomBytes, createHash } from 'node:crypto';
 import { URL } from 'node:url';
+import * as clack from '@clack/prompts';
+import { getGlobalConfig, getPlatformApiUrl, saveCredentials } from './config.js';
+import { getProfile } from './api/platform.js';
+import type { StoredCredentials } from '../types.js';
 
 // Default OAuth client for InsForge CLI (pre-registered on the platform)
 export const DEFAULT_CLIENT_ID = 'clf_NK8cMUs41gm8ZcfdtSguVw';
@@ -174,4 +178,92 @@ export function startCallbackServer(): Promise<{
       server.close();
     }, 5 * 60 * 1000).unref();
   });
+}
+
+/**
+ * Perform the full OAuth PKCE login flow:
+ * generate PKCE + state, start callback server, open browser, exchange code, save credentials.
+ * Returns the stored credentials on success.
+ */
+export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredentials> {
+  const platformUrl = getPlatformApiUrl(apiUrl);
+  const config = getGlobalConfig();
+  const clientId = config.oauth_client_id ?? DEFAULT_CLIENT_ID;
+
+  // 1. Generate PKCE and state
+  const pkce = generatePKCE();
+  const state = generateState();
+
+  // 2. Start local callback server
+  const { port, result, close } = await startCallbackServer();
+  const redirectUri = `http://127.0.0.1:${port}/callback`;
+
+  // 3. Build authorization URL
+  const authUrl = buildAuthorizeUrl({
+    platformUrl,
+    clientId,
+    redirectUri,
+    codeChallenge: pkce.code_challenge,
+    state,
+    scopes: OAUTH_SCOPES,
+  });
+
+  clack.log.info('Opening browser for authentication...');
+  clack.log.info(`If browser doesn't open, visit:\n${authUrl}`);
+
+  // 4. Open browser
+  try {
+    const open = (await import('open')).default;
+    await open(authUrl);
+  } catch {
+    clack.log.warn('Could not open browser. Please visit the URL above.');
+  }
+
+  // 5. Wait for callback
+  const s = clack.spinner();
+  s.start('Waiting for authentication...');
+
+  try {
+    const callbackResult = await result;
+    close();
+
+    // Verify state
+    if (callbackResult.state !== state) {
+      s.stop('Authentication failed');
+      throw new Error('State mismatch. Possible CSRF attack.');
+    }
+
+    // 6. Exchange code for tokens
+    s.message('Exchanging authorization code...');
+    const tokens = await exchangeCodeForTokens({
+      platformUrl,
+      code: callbackResult.code,
+      redirectUri,
+      clientId,
+      codeVerifier: pkce.code_verifier,
+    });
+
+    // 7. Save credentials and fetch profile
+    const creds: StoredCredentials = {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      user: { id: '', name: '', email: '', avatar_url: null, email_verified: true },
+    };
+    saveCredentials(creds);
+
+    try {
+      const profile = await getProfile(apiUrl);
+      creds.user = profile;
+      saveCredentials(creds);
+      s.stop(`Authenticated as ${profile.email}`);
+    } catch {
+      s.stop('Authenticated successfully');
+    }
+
+    return creds;
+  } catch (err) {
+    close();
+    s.stop('Authentication failed');
+    throw err;
+  }
 }

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,14 +1,15 @@
 import { getCredentials, getGlobalConfig, getPlatformApiUrl, saveCredentials } from './config.js';
 import { AuthError } from './errors.js';
-import { refreshOAuthToken, DEFAULT_CLIENT_ID } from './auth.js';
+import { refreshOAuthToken, DEFAULT_CLIENT_ID, performOAuthLogin } from './auth.js';
+import * as clack from '@clack/prompts';
 import type { StoredCredentials } from '../types.js';
 
-export function requireAuth(): StoredCredentials {
+export async function requireAuth(apiUrl?: string): Promise<StoredCredentials> {
   const creds = getCredentials();
-  if (!creds || !creds.access_token) {
-    throw new AuthError();
-  }
-  return creds;
+  if (creds && creds.access_token) return creds;
+
+  clack.log.info('You need to log in to continue.');
+  return await performOAuthLogin(apiUrl);
 }
 
 export async function refreshAccessToken(apiUrl?: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Extracts reusable `performOAuthLogin()` into `src/lib/auth.ts` from the duplicated OAuth logic in `login.ts`
- Makes `requireAuth()` async — if no credentials exist, it seamlessly starts the browser OAuth flow instead of throwing an error
- Updates all 48 command files to `await requireAuth()`

## Test plan
- [x] `npm run build` passes
- [x] Run any command without being logged in → browser opens for OAuth, command continues after auth
- [x] Run any command while already logged in → works as before (no login prompt)
- [x] `insforge login` still works standalone with intro/outro messaging
- [x] `insforge login --email` still works for email/password flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)