### PR TITLE
fix: filter skill install to only insforge and insforge-cli

### DIFF
--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -37,13 +37,13 @@ function updateGitignore(): void {
 export async function installSkills(json: boolean): Promise<void> {
   try {
     if (!json) clack.log.info('Installing InsForge agent skills...');
-    await execAsync('npx skills add insforge/agent-skills -y -a antigravity -a augment -a claude-code -a cline -a codex -a cursor -a gemini-cli -a github-copilot -a kilo -a qoder -a qwen-code -a roo -a trae -a windsurf', {
+    await execAsync('npx skills add insforge/agent-skills -y -s insforge -s insforge-cli -a antigravity -a augment -a claude-code -a cline -a codex -a cursor -a gemini-cli -a github-copilot -a kilo -a qoder -a qwen-code -a roo -a trae -a windsurf', {
       cwd: process.cwd(),
       timeout: 60_000,
     });
     if (!json) clack.log.success('InsForge agent skills installed.');
   } catch {
-    if (!json) clack.log.warn('Failed to install agent skills. You can run manually: npx skills add insforge/agent-skills');
+    if (!json) clack.log.warn('Failed to install agent skills. You can run manually: npx skills add insforge/agent-skills -s insforge -s insforge-cli');
   }
 
   try {


### PR DESCRIPTION
## Summary
- Added `-s insforge -s insforge-cli` flags to the `npx skills add` command in `installSkills()`
- Without these flags, all skills from the repo are installed — including `skill-creator`, which is a dev tool not meant for end users
- Also updated the fallback warning message with the correct flags

## Test plan
- [x] Verified `npx skills add insforge/agent-skills -s insforge -s insforge-cli --list` only shows the two InsForge skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The npx skills add command has been enhanced with explicit skill-scoping flags to ensure more accurate and reliable skill installation
  * Error messages have been updated to provide clearer guidance and step-by-step instructions for users who need to perform manual skill installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->