### PR TITLE
[NOT MERGE] chore: remove reportCliUsage calls from create, docs, link

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -17,7 +17,7 @@ import { requireAuth } from '../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../lib/errors.js';
 import { outputJson } from '../lib/output.js';
 import { readEnvFile } from '../lib/env.js';
-import { installSkills, reportCliUsage } from '../lib/skills.js';
+import { installSkills } from '../lib/skills.js';
 import { captureEvent, shutdownAnalytics } from '../lib/analytics.js';
 import { deployProject } from './deployments/deploy.js';
 import type { ProjectConfig } from '../types.js';
@@ -324,7 +324,6 @@ export function registerCreateCommand(program: Command): void {
 
         // Install agent skills
         await installSkills(json);
-        await reportCliUsage('cli.create', true, 6);
 
         // 7. Install npm dependencies (template projects only)
         if (hasTemplate) {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -3,7 +3,6 @@ import { ossFetch } from '../lib/api/oss.js';
 import { requireAuth } from '../lib/credentials.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import { outputJson, outputTable } from '../lib/output.js';
-import { reportCliUsage } from '../lib/skills.js';
 
 const FEATURES = ['db', 'storage', 'functions', 'auth', 'ai', 'realtime'] as const;
 const LANGUAGES = ['typescript', 'swift', 'kotlin', 'rest-api'] as const;
@@ -27,7 +26,6 @@ Examples:
       try {
         await requireAuth();
 
-        await reportCliUsage('cli.docs', true);
         // No args → list all docs
         if (!feature) {
           await listDocs(json);

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -11,7 +11,7 @@ import { getGlobalConfig, saveGlobalConfig, saveProjectConfig } from '../../lib/
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
-import { installSkills, reportCliUsage } from '../../lib/skills.js';
+import { installSkills } from '../../lib/skills.js';
 import type { ProjectConfig } from '../../types.js';
 
 function buildOssHost(appkey: string, region: string): string {
@@ -62,7 +62,6 @@ export function registerProjectLinkCommand(program: Command): void {
 
             // Install agent skills
             await installSkills(json);
-            await reportCliUsage('cli.link_direct', true, 6);
 
             // Report agent-connected event (best-effort)
             try {
@@ -73,7 +72,6 @@ export function registerProjectLinkCommand(program: Command): void {
             } catch { /* ignore */ }
             return;
           } catch (err) {
-            await reportCliUsage('cli.link_direct', false);
             handleError(err, json);
           }
         }
@@ -168,14 +166,12 @@ export function registerProjectLinkCommand(program: Command): void {
 
         // Install agent skills
         await installSkills(json);
-        await reportCliUsage('cli.link', true, 6);
 
         // Report agent-connected event (best-effort)
         try {
           await reportAgentConnected({ project_id: project.id }, apiUrl);
         } catch { /* ignore */ }
       } catch (err) {
-        await reportCliUsage('cli.link', false);
         handleError(err, json);
       }
     });


### PR DESCRIPTION
## Summary
- Remove `reportCliUsage` calls and imports from `create`, `docs`, and `link` commands
- These commands no longer report to the OSS `/api/usage/mcp` endpoint

## Test plan
- [ ] Verify `insforge create`, `insforge docs`, `insforge link` still work normally
- [ ] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `reportCliUsage` calls from `create`, `docs`, and `link` commands
> Removes all `reportCliUsage` telemetry calls from three CLI commands. The `create` command no longer emits `cli.create`, `docs` no longer emits `cli.docs`, and `link` no longer emits `cli.link` or `cli.link_direct` on success or failure paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b2dda2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal telemetry calls from create, docs, and project link commands while maintaining full command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->