### PR TITLE
INS-24: Link CLI should support template and deploy prompts

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -24,7 +24,7 @@ import type { ProjectConfig } from '../types.js';
 
 const execAsync = promisify(exec);
 
-type Framework = 'react' | 'nextjs';
+export type Framework = 'react' | 'nextjs';
 
 function buildOssHost(appkey: string, region: string): string {
   return `https://${appkey}.${region}.insforge.app`;
@@ -135,7 +135,7 @@ function getDefaultProjectName(): string {
   return sanitized.length >= 2 ? sanitized : '';
 }
 
-async function copyDir(src: string, dest: string): Promise<void> {
+export async function copyDir(src: string, dest: string): Promise<void> {
   const entries = await fs.readdir(src, { withFileTypes: true });
   for (const entry of entries) {
     const srcPath = path.join(src, entry.name);
@@ -409,7 +409,7 @@ export function registerCreateCommand(program: Command): void {
     });
 }
 
-async function downloadTemplate(
+export async function downloadTemplate(
   framework: Framework,
   projectConfig: ProjectConfig,
   projectName: string,
@@ -467,7 +467,7 @@ async function downloadTemplate(
   }
 }
 
-async function downloadGitHubTemplate(
+export async function downloadGitHubTemplate(
   templateName: string,
   projectConfig: ProjectConfig,
   json: boolean,

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -25,12 +25,25 @@ import type { ProjectConfig } from '../../types.js';
 
 const execAsync = promisify(exec);
 
-/** Files that don't count as real project content */
-const NOISE_ENTRIES = new Set(['node_modules', 'skills-lock.json', 'LICENSE', 'README.md']);
+/** Files that indicate real project content exists */
+const PROJECT_MARKERS = new Set([
+  'package.json',
+  'index.html',
+  'tsconfig.json',
+  'next.config.js',
+  'next.config.ts',
+  'next.config.mjs',
+  'vite.config.ts',
+  'vite.config.js',
+  'src',
+  'app',
+  'pages',
+  'public',
+]);
 
 async function isDirEmpty(dir: string): Promise<boolean> {
   const entries = await fs.readdir(dir);
-  return entries.every((e) => e.startsWith('.') || NOISE_ENTRIES.has(e));
+  return !entries.some((e) => PROJECT_MARKERS.has(e));
 }
 
 function buildOssHost(appkey: string, region: string): string {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -214,7 +214,7 @@ export function registerProjectLinkCommand(program: Command): void {
             });
             if (clack.isCancel(approach)) process.exit(0);
 
-            captureEvent(orgId, 'link_approach_selected', { approach: approach as string });
+            captureEvent(orgId ?? project.organization_id, 'link_approach_selected', { approach: approach as string });
 
             if (approach === 'template') {
               const selected = await clack.select({
@@ -230,7 +230,7 @@ export function registerProjectLinkCommand(program: Command): void {
               if (clack.isCancel(selected)) process.exit(0);
               const template = selected as string;
 
-              captureEvent(orgId, 'template_selected', { template, source: 'link' });
+              captureEvent(orgId ?? project.organization_id, 'template_selected', { template, source: 'link' });
 
               // Download template
               const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
@@ -239,6 +239,9 @@ export function registerProjectLinkCommand(program: Command): void {
               } else {
                 await downloadTemplate(template as Framework, projectConfig, project.name, json, apiUrl);
               }
+
+              // Only mark as applied if files were actually downloaded
+              templateApplied = !(await isDirEmpty(cwd));
 
               // Install npm dependencies
               const installSpinner = clack.spinner();
@@ -251,8 +254,6 @@ export function registerProjectLinkCommand(program: Command): void {
                 clack.log.warn(`npm install failed: ${(err as Error).message}`);
                 clack.log.info('Run `npm install` manually to install dependencies.');
               }
-
-              templateApplied = true;
             } else {
               // Blank project: seed .env.local
               try {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -1,4 +1,8 @@
 import type { Command } from 'commander';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import * as clack from '@clack/prompts';
 import {
   listOrganizations,
@@ -7,13 +11,27 @@ import {
   getProjectApiKey,
   reportAgentConnected,
 } from '../../lib/api/platform.js';
-import { getGlobalConfig, saveGlobalConfig, saveProjectConfig } from '../../lib/config.js';
+import { getAnonKey } from '../../lib/api/oss.js';
+import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { readEnvFile } from '../../lib/env.js';
 import { installSkills, reportCliUsage } from '../../lib/skills.js';
-import { trackCommand, shutdownAnalytics } from '../../lib/analytics.js';
+import { captureEvent, trackCommand, shutdownAnalytics } from '../../lib/analytics.js';
+import { deployProject } from '../deployments/deploy.js';
+import { downloadGitHubTemplate, downloadTemplate, type Framework } from '../create.js';
 import type { ProjectConfig } from '../../types.js';
+
+const execAsync = promisify(exec);
+
+/** Files that don't count as real project content */
+const NOISE_ENTRIES = new Set(['node_modules', 'skills-lock.json', 'LICENSE', 'README.md']);
+
+async function isDirEmpty(dir: string): Promise<boolean> {
+  const entries = await fs.readdir(dir);
+  return entries.every((e) => e.startsWith('.') || NOISE_ENTRIES.has(e));
+}
 
 function buildOssHost(appkey: string, region: string): string {
   return `https://${appkey}.${region}.insforge.app`;
@@ -179,6 +197,133 @@ export function registerProjectLinkCommand(program: Command): void {
         try {
           await reportAgentConnected({ project_id: project.id }, apiUrl);
         } catch { /* ignore */ }
+
+        // Smart template & deploy prompts (interactive mode only)
+        if (!json) {
+          const cwd = process.cwd();
+          let templateApplied = false;
+
+          // Template prompt: offer if directory is empty
+          if (await isDirEmpty(cwd)) {
+            const approach = await clack.select({
+              message: 'How would you like to start?',
+              options: [
+                { value: 'blank', label: 'Blank project', hint: 'Start from scratch with .env.local ready' },
+                { value: 'template', label: 'Start from a template', hint: 'Pre-built starter apps' },
+              ],
+            });
+            if (clack.isCancel(approach)) process.exit(0);
+
+            captureEvent(orgId, 'link_approach_selected', { approach: approach as string });
+
+            if (approach === 'template') {
+              const selected = await clack.select({
+                message: 'Choose a starter template:',
+                options: [
+                  { value: 'react', label: 'Web app template with React' },
+                  { value: 'nextjs', label: 'Web app template with Next.js' },
+                  { value: 'chatbot', label: 'AI Chatbot with Next.js' },
+                  { value: 'crm', label: 'CRM with Next.js' },
+                  { value: 'e-commerce', label: 'E-Commerce store with Next.js' },
+                ],
+              });
+              if (clack.isCancel(selected)) process.exit(0);
+              const template = selected as string;
+
+              captureEvent(orgId, 'template_selected', { template, source: 'link' });
+
+              // Download template
+              const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
+              if (githubTemplates.includes(template)) {
+                await downloadGitHubTemplate(template, projectConfig, json);
+              } else {
+                await downloadTemplate(template as Framework, projectConfig, project.name, json, apiUrl);
+              }
+
+              // Install npm dependencies
+              const installSpinner = clack.spinner();
+              installSpinner.start('Installing dependencies...');
+              try {
+                await execAsync('npm install', { cwd, maxBuffer: 10 * 1024 * 1024 });
+                installSpinner.stop('Dependencies installed');
+              } catch (err) {
+                installSpinner.stop('Failed to install dependencies');
+                clack.log.warn(`npm install failed: ${(err as Error).message}`);
+                clack.log.info('Run `npm install` manually to install dependencies.');
+              }
+
+              templateApplied = true;
+            } else {
+              // Blank project: seed .env.local
+              try {
+                const anonKey = await getAnonKey();
+                if (!anonKey) {
+                  clack.log.warn('Could not retrieve anon key. You can add it to .env.local manually.');
+                } else {
+                  const envPath = path.join(cwd, '.env.local');
+                  const envContent = [
+                    '# InsForge',
+                    `NEXT_PUBLIC_INSFORGE_URL=${projectConfig.oss_host}`,
+                    `NEXT_PUBLIC_INSFORGE_ANON_KEY=${anonKey}`,
+                    '',
+                  ].join('\n');
+                  await fs.writeFile(envPath, envContent, { flag: 'wx' });
+                  clack.log.success('Created .env.local with your InsForge credentials');
+                }
+              } catch (err) {
+                const error = err as NodeJS.ErrnoException;
+                if (error.code === 'EEXIST') {
+                  clack.log.warn('.env.local already exists; skipping InsForge key seeding.');
+                } else {
+                  clack.log.warn(`Failed to create .env.local: ${error.message}`);
+                }
+              }
+            }
+          }
+
+          // Deploy prompt: only offer when a template was applied
+          if (templateApplied) {
+            const shouldDeploy = await clack.confirm({
+              message: 'Would you like to deploy now?',
+            });
+
+            if (!clack.isCancel(shouldDeploy) && shouldDeploy) {
+              try {
+                const envVars = await readEnvFile(cwd);
+                const startBody: { envVars?: Array<{ key: string; value: string }> } = {};
+                if (envVars.length > 0) {
+                  startBody.envVars = envVars;
+                }
+
+                const deploySpinner = clack.spinner();
+                const result = await deployProject({
+                  sourceDir: cwd,
+                  startBody,
+                  spinner: deploySpinner,
+                });
+
+                if (result.isReady) {
+                  deploySpinner.stop('Deployment complete');
+                  const liveUrl = result.liveUrl;
+                  if (liveUrl) {
+                    clack.log.success(`Live site: ${liveUrl}`);
+                  }
+                } else {
+                  deploySpinner.stop('Deployment is still building');
+                  clack.log.info(`Deployment ID: ${result.deploymentId}`);
+                  clack.log.warn('Deployment did not finish within 5 minutes.');
+                  clack.log.info(`Check status with: npx @insforge/cli deployments status ${result.deploymentId}`);
+                }
+              } catch (err) {
+                clack.log.warn(`Deploy failed: ${(err as Error).message}`);
+              }
+            }
+          }
+
+          // Show dashboard link
+          const dashboardUrl = `${getFrontendUrl()}/dashboard/project/${project.id}`;
+          clack.log.step(`Dashboard: ${dashboardUrl}`);
+        }
       } catch (err) {
         await reportCliUsage('cli.link', false);
         handleError(err, json);


### PR DESCRIPTION
Test Plan:
- [x] insforge link in an empty directory, shows template/blank project selection prompt  
- [x] After template applied, shows deploy prompt
- [x] Non-empty directory, skips template and deploy prompts

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add template selection and deploy prompts to the `link` CLI command
> - After a successful `link` in interactive mode, if the current directory appears empty (checked via a new `isDirEmpty` utility using `PROJECT_MARKERS`), the user is prompted to start from a template or a blank project.
> - For template selection, the command downloads a starter template via `downloadGitHubTemplate` or `downloadTemplate`, then runs `npm install` and optionally triggers an immediate deploy via `deployProject`.
> - For blank project selection, a `.env.local` file is seeded with `NEXT_PUBLIC_INSFORGE_URL` and `NEXT_PUBLIC_INSFORGE_ANON_KEY` credentials.
> - Analytics events are captured for approach and template selection choices.
> - All new prompts are gated to interactive (non-JSON) mode; existing link and OAuth flows are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ee5dfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive project-link now can initialize the current directory (blank or from starter templates), downloads/apply templates, and optionally runs installation with progress feedback and clear warnings on failures.
  * After initialization, deployment can be offered immediately (if files applied), showing live URL or build guidance/deployment ID.
  * Dashboard URL is displayed after successful linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->