### PR TITLE
Ins-48  feat: improve create & link UX — auto-org, subdirectories, next steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@insforge/cli",
 
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import * as path from 'node:path';
+
+/**
+ * Unit tests for create command logic extracted into pure functions.
+ * These test the validation and normalization rules without needing
+ * to mock the full CLI command handler.
+ */
+
+// Mirrors the sanitization logic in create.ts line ~281
+function sanitizeDirName(input: string): string {
+  return path.basename(input).replace(/[^a-zA-Z0-9._-]/g, '-');
+}
+
+// Mirrors the validation logic in create.ts lines ~274-278
+function validateDirInput(v: string): string | undefined {
+  if (v.length < 1) return 'Directory name is required';
+  const normalized = path.basename(v).replace(/[^a-zA-Z0-9._-]/g, '-');
+  if (!normalized || normalized === '.' || normalized === '..') return 'Invalid directory name';
+  return undefined;
+}
+
+// Mirrors the post-normalization check in create.ts lines ~283-285
+function isValidNormalizedDir(dirName: string): boolean {
+  return !!dirName && dirName !== '.' && dirName !== '..';
+}
+
+describe('create command: directory name validation', () => {
+  it('accepts a simple name', () => {
+    expect(validateDirInput('my-app')).toBeUndefined();
+    expect(sanitizeDirName('my-app')).toBe('my-app');
+  });
+
+  it('accepts names with dots and underscores', () => {
+    expect(validateDirInput('my_app.v2')).toBeUndefined();
+    expect(sanitizeDirName('my_app.v2')).toBe('my_app.v2');
+  });
+
+  it('rejects empty input', () => {
+    expect(validateDirInput('')).toBe('Directory name is required');
+  });
+
+  it('rejects . and ..', () => {
+    expect(validateDirInput('.')).toBe('Invalid directory name');
+    expect(validateDirInput('..')).toBe('Invalid directory name');
+  });
+
+  it('rejects / which normalizes to empty string', () => {
+    // path.basename('/') returns '' which becomes '' after sanitization
+    expect(validateDirInput('/')).toBe('Invalid directory name');
+  });
+
+  it('rejects ./ which normalizes to .', () => {
+    expect(validateDirInput('./')).toBe('Invalid directory name');
+  });
+
+  it('sanitizes special characters to hyphens', () => {
+    expect(sanitizeDirName('my app!')).toBe('my-app-');
+    expect(sanitizeDirName('hello@world')).toBe('hello-world');
+  });
+
+  it('extracts basename from path input', () => {
+    expect(sanitizeDirName('/some/path/my-app')).toBe('my-app');
+    expect(sanitizeDirName('../../my-app')).toBe('my-app');
+  });
+
+  it('post-normalization check rejects empty and dot names', () => {
+    expect(isValidNormalizedDir('')).toBe(false);
+    expect(isValidNormalizedDir('.')).toBe(false);
+    expect(isValidNormalizedDir('..')).toBe(false);
+  });
+
+  it('post-normalization check accepts valid names', () => {
+    expect(isValidNormalizedDir('my-app')).toBe(true);
+    expect(isValidNormalizedDir('test.project')).toBe(true);
+  });
+});
+
+describe('create command: org auto-select logic', () => {
+  // Mirrors the org selection logic in create.ts
+  function selectOrg(
+    orgs: Array<{ id: string; name: string }>,
+    json: boolean,
+    providedOrgId?: string,
+  ): { orgId: string | null; error: string | null; autoSelected: boolean } {
+    if (providedOrgId) {
+      return { orgId: providedOrgId, error: null, autoSelected: false };
+    }
+    if (orgs.length === 0) {
+      return { orgId: null, error: 'No organizations found.', autoSelected: false };
+    }
+    if (orgs.length === 1) {
+      return { orgId: orgs[0].id, error: null, autoSelected: true };
+    }
+    // Multiple orgs
+    if (json) {
+      return { orgId: null, error: 'Multiple organizations found. Specify --org-id.', autoSelected: false };
+    }
+    // Would prompt interactively
+    return { orgId: null, error: null, autoSelected: false };
+  }
+
+  it('uses provided org-id directly', () => {
+    const result = selectOrg([{ id: 'org1', name: 'Org 1' }], false, 'org-provided');
+    expect(result.orgId).toBe('org-provided');
+    expect(result.autoSelected).toBe(false);
+  });
+
+  it('errors when no orgs exist', () => {
+    const result = selectOrg([], false);
+    expect(result.error).toBe('No organizations found.');
+  });
+
+  it('auto-selects single org in interactive mode', () => {
+    const result = selectOrg([{ id: 'org1', name: 'My Org' }], false);
+    expect(result.orgId).toBe('org1');
+    expect(result.autoSelected).toBe(true);
+  });
+
+  it('auto-selects single org in JSON mode', () => {
+    const result = selectOrg([{ id: 'org1', name: 'My Org' }], true);
+    expect(result.orgId).toBe('org1');
+    expect(result.autoSelected).toBe(true);
+  });
+
+  it('errors in JSON mode with multiple orgs', () => {
+    const result = selectOrg(
+      [{ id: 'org1', name: 'Org 1' }, { id: 'org2', name: 'Org 2' }],
+      true,
+    );
+    expect(result.error).toBe('Multiple organizations found. Specify --org-id.');
+  });
+
+  it('returns null orgId for multiple orgs in interactive mode (would prompt)', () => {
+    const result = selectOrg(
+      [{ id: 'org1', name: 'Org 1' }, { id: 'org2', name: 'Org 2' }],
+      false,
+    );
+    expect(result.orgId).toBeNull();
+    expect(result.error).toBeNull();
+  });
+});

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -265,37 +265,43 @@ export function registerCreateCommand(program: Command): void {
           approach: template === 'empty' ? 'blank' : 'template',
         });
 
-        // 4. Choose directory name for the project
-        let dirName = projectName;
-        if (!json) {
-          const inputDir = await clack.text({
-            message: 'Directory name:',
-            initialValue: projectName,
-            validate: (v) => {
-              if (v.length < 1) return 'Directory name is required';
-              const normalized = path.basename(v).replace(/[^a-zA-Z0-9._-]/g, '-');
-              if (!normalized || normalized === '.' || normalized === '..') return 'Invalid directory name';
-              return undefined;
-            },
-          });
-          if (clack.isCancel(inputDir)) process.exit(0);
-          dirName = path.basename(inputDir as string).replace(/[^a-zA-Z0-9._-]/g, '-');
-        }
-
-        // Validate normalized dirName
-        if (!dirName || dirName === '.' || dirName === '..') {
-          throw new CLIError('Invalid directory name.');
-        }
-
-        // Create the project directory and switch into it
+        // 4. Choose directory (templates need a subdirectory, blank uses cwd)
+        const hasTemplate = template !== 'empty';
+        let dirName: string | null = null;
         const originalCwd = process.cwd();
-        const projectDir = path.resolve(originalCwd, dirName);
-        const dirExists = await fs.stat(projectDir).catch(() => null);
-        if (dirExists) {
-          throw new CLIError(`Directory "${dirName}" already exists.`);
+        let projectDir = originalCwd;
+
+        if (hasTemplate) {
+          dirName = projectName;
+          if (!json) {
+            const inputDir = await clack.text({
+              message: 'Directory name:',
+              initialValue: projectName,
+              validate: (v) => {
+                if (v.length < 1) return 'Directory name is required';
+                const normalized = path.basename(v).replace(/[^a-zA-Z0-9._-]/g, '-');
+                if (!normalized || normalized === '.' || normalized === '..') return 'Invalid directory name';
+                return undefined;
+              },
+            });
+            if (clack.isCancel(inputDir)) process.exit(0);
+            dirName = path.basename(inputDir as string).replace(/[^a-zA-Z0-9._-]/g, '-');
+          }
+
+          // Validate normalized dirName
+          if (!dirName || dirName === '.' || dirName === '..') {
+            throw new CLIError('Invalid directory name.');
+          }
+
+          // Create the project directory and switch into it
+          projectDir = path.resolve(originalCwd, dirName);
+          const dirExists = await fs.stat(projectDir).catch(() => null);
+          if (dirExists) {
+            throw new CLIError(`Directory "${dirName}" already exists.`);
+          }
+          await fs.mkdir(projectDir);
+          process.chdir(projectDir);
         }
-        await fs.mkdir(projectDir);
-        process.chdir(projectDir);
 
         // 5. Create project via Platform API
         let projectLinked = false;
@@ -325,7 +331,6 @@ export function registerCreateCommand(program: Command): void {
         s?.stop(`Project "${project.name}" created and linked`);
 
         // 7. Download template or seed env for blank projects
-        const hasTemplate = template !== 'empty';
         const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
         if (githubTemplates.includes(template!)) {
           await downloadGitHubTemplate(template!, projectConfig, json);
@@ -429,7 +434,7 @@ export function registerCreateCommand(program: Command): void {
             success: true,
             project: { id: project.id, name: project.name, appkey: project.appkey, region: project.region },
             template,
-            directory: dirName,
+            ...(dirName ? { directory: dirName } : {}),
             urls: {
               dashboard: dashboardUrl,
               ...(liveUrl ? { liveSite: liveUrl } : {}),
@@ -450,8 +455,6 @@ export function registerCreateCommand(program: Command): void {
             clack.note(steps.join('\n'), 'Next steps');
             clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
           } else {
-            clack.note(`cd ${dirName}`, 'Next steps');
-
             const prompts = [
               'Build a todo app with Google OAuth sign-in',
               'Build an Instagram clone where users can upload photos, like, and comment',
@@ -466,7 +469,7 @@ export function registerCreateCommand(program: Command): void {
         }
         } catch (err) {
           // Clean up the project directory if it was created but linking failed
-          if (!projectLinked) {
+          if (!projectLinked && hasTemplate && projectDir !== originalCwd) {
             process.chdir(originalCwd);
             await fs.rm(projectDir, { recursive: true, force: true }).catch(() => {});
           }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -288,7 +288,8 @@ export function registerCreateCommand(program: Command): void {
         }
 
         // Create the project directory and switch into it
-        const projectDir = path.resolve(process.cwd(), dirName);
+        const originalCwd = process.cwd();
+        const projectDir = path.resolve(originalCwd, dirName);
         const dirExists = await fs.stat(projectDir).catch(() => null);
         if (dirExists) {
           throw new CLIError(`Directory "${dirName}" already exists.`);
@@ -297,8 +298,10 @@ export function registerCreateCommand(program: Command): void {
         process.chdir(projectDir);
 
         // 5. Create project via Platform API
+        let projectLinked = false;
         const s = !json ? clack.spinner() : null;
-        s?.start('Creating project...');
+        try {
+          s?.start('Creating project...');
 
         const project = await createProject(orgId, projectName, opts.region, apiUrl);
 
@@ -317,6 +320,7 @@ export function registerCreateCommand(program: Command): void {
           oss_host: buildOssHost(project.appkey, project.region),
         };
         saveProjectConfig(projectConfig);
+        projectLinked = true;
 
         s?.stop(`Project "${project.name}" created and linked`);
 
@@ -459,6 +463,14 @@ export function registerCreateCommand(program: Command): void {
             );
           }
           clack.outro('Done!');
+        }
+        } catch (err) {
+          // Clean up the project directory if it was created but linking failed
+          if (!projectLinked) {
+            process.chdir(originalCwd);
+            await fs.rm(projectDir, { recursive: true, force: true }).catch(() => {});
+          }
+          throw err;
         }
       } catch (err) {
         handleError(err, json);

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -444,26 +444,17 @@ export function registerCreateCommand(program: Command): void {
               'npm run dev',
             ];
             clack.note(steps.join('\n'), 'Next steps');
-
-            const prompts = [
-              'Add an admin dashboard with analytics charts',
-              'Add a Stripe checkout flow for premium plans',
-              'Add real-time notifications with InsForge Realtime',
-            ];
-            clack.note(
-              `Open your agent (Claude Code, Codex, Cursor, etc.) and try:\n\n${prompts.map((p) => `• "${p}"`).join('\n')}`,
-              'Keep building',
-            );
+            clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
           } else {
             clack.note(`cd ${dirName}`, 'Next steps');
 
             const prompts = [
               'Build a todo app with Google OAuth sign-in',
               'Build an Instagram clone where users can upload photos, like, and comment',
-              'Build an AI chatbot with conversation history and streaming responses',
+              'Build an AI chatbot with conversation history',
             ];
             clack.note(
-              `Open your agent (Claude Code, Codex, Cursor, etc.) and try:\n\n${prompts.map((p) => `• "${p}"`).join('\n')}`,
+              `Open your coding agent (Claude Code, Codex, Cursor, etc.) and try:\n\n${prompts.map((p) => `• "${p}"`).join('\n')}`,
               'Start building',
             );
           }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -167,7 +167,7 @@ export function registerCreateCommand(program: Command): void {
           clack.intro("Let's build something great");
         }
 
-        // 1. Select organization
+        // 1. Select organization (auto-select if only one)
         let orgId = opts.orgId;
         if (!orgId) {
           const orgs = await listOrganizations(apiUrl);
@@ -177,15 +177,20 @@ export function registerCreateCommand(program: Command): void {
           if (json) {
             throw new CLIError('Specify --org-id in JSON mode.');
           }
-          const selected = await clack.select({
-            message: 'Select an organization:',
-            options: orgs.map((o) => ({
-              value: o.id,
-              label: o.name,
-            })),
-          });
-          if (clack.isCancel(selected)) process.exit(0);
-          orgId = selected as string;
+          if (orgs.length === 1) {
+            orgId = orgs[0].id;
+            clack.log.info(`Using organization: ${orgs[0].name}`);
+          } else {
+            const selected = await clack.select({
+              message: 'Select an organization:',
+              options: orgs.map((o) => ({
+                value: o.id,
+                label: o.name,
+              })),
+            });
+            if (clack.isCancel(selected)) process.exit(0);
+            orgId = selected as string;
+          }
         }
 
         // Save default org
@@ -260,7 +265,28 @@ export function registerCreateCommand(program: Command): void {
           approach: template === 'empty' ? 'blank' : 'template',
         });
 
-        // 4. Create project via Platform API
+        // 4. Choose directory name for the project
+        let dirName = projectName;
+        if (!json) {
+          const inputDir = await clack.text({
+            message: 'Directory name:',
+            initialValue: projectName,
+            validate: (v) => {
+              if (v.length < 1) return 'Directory name is required';
+              if (v === '.' || v === '..') return 'Invalid directory name';
+              return undefined;
+            },
+          });
+          if (clack.isCancel(inputDir)) process.exit(0);
+          dirName = path.basename(inputDir as string).replace(/[^a-zA-Z0-9._-]/g, '-');
+        }
+
+        // Create the project directory and switch into it
+        const projectDir = path.resolve(process.cwd(), dirName);
+        await fs.mkdir(projectDir, { recursive: true });
+        process.chdir(projectDir);
+
+        // 5. Create project via Platform API
         const s = !json ? clack.spinner() : null;
         s?.start('Creating project...');
 
@@ -269,7 +295,7 @@ export function registerCreateCommand(program: Command): void {
         s?.message('Waiting for project to become active...');
         await waitForProjectActive(project.id, apiUrl);
 
-        // 5. Fetch API key and link project
+        // 6. Fetch API key and link project
         const apiKey = await getProjectApiKey(project.id, apiUrl);
         const projectConfig: ProjectConfig = {
           project_id: project.id,
@@ -284,7 +310,7 @@ export function registerCreateCommand(program: Command): void {
 
         s?.stop(`Project "${project.name}" created and linked`);
 
-        // 6. Download template or seed env for blank projects
+        // 7. Download template or seed env for blank projects
         const hasTemplate = template !== 'empty';
         const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
         if (githubTemplates.includes(template!)) {
@@ -327,7 +353,7 @@ export function registerCreateCommand(program: Command): void {
         trackCommand('create', orgId);
         await reportCliUsage('cli.create', true, 6);
 
-        // 7. Install npm dependencies (template projects only)
+        // 8. Install npm dependencies (template projects only)
         if (hasTemplate) {
           const installSpinner = !json ? clack.spinner() : null;
           installSpinner?.start('Installing dependencies...');
@@ -343,7 +369,7 @@ export function registerCreateCommand(program: Command): void {
           }
         }
 
-        // 8. Offer to deploy (template projects, interactive mode only)
+        // 9. Offer to deploy (template projects, interactive mode only)
         let liveUrl: string | null = null;
         if (hasTemplate && !json) {
           const shouldDeploy = await clack.confirm({
@@ -381,7 +407,7 @@ export function registerCreateCommand(program: Command): void {
           }
         }
 
-        // 9. Show links
+        // 10. Show links and next steps
         const dashboardUrl = `${getFrontendUrl()}/dashboard/project/${project.id}`;
 
         if (json) {
@@ -389,6 +415,7 @@ export function registerCreateCommand(program: Command): void {
             success: true,
             project: { id: project.id, name: project.name, appkey: project.appkey, region: project.region },
             template,
+            directory: dirName,
             urls: {
               dashboard: dashboardUrl,
               ...(liveUrl ? { liveSite: liveUrl } : {}),
@@ -398,6 +425,37 @@ export function registerCreateCommand(program: Command): void {
           clack.log.step(`Dashboard: ${dashboardUrl}`);
           if (liveUrl) {
             clack.log.success(`Live site: ${liveUrl}`);
+          }
+
+          // Next steps
+          if (hasTemplate) {
+            const steps = [
+              `cd ${dirName}`,
+              'npm run dev',
+            ];
+            clack.note(steps.join('\n'), 'Next steps');
+
+            const prompts = [
+              'Add an admin dashboard with analytics charts',
+              'Add a Stripe checkout flow for premium plans',
+              'Add real-time notifications with InsForge Realtime',
+            ];
+            clack.note(
+              `Open your agent (Claude Code, Codex, Cursor, etc.) and try:\n\n${prompts.map((p) => `• "${p}"`).join('\n')}`,
+              'Keep building',
+            );
+          } else {
+            clack.note(`cd ${dirName}`, 'Next steps');
+
+            const prompts = [
+              'Build a todo app with Google OAuth sign-in',
+              'Build an Instagram clone where users can upload photos, like, and comment',
+              'Build an AI chatbot with conversation history and streaming responses',
+            ];
+            clack.note(
+              `Open your agent (Claude Code, Codex, Cursor, etc.) and try:\n\n${prompts.map((p) => `• "${p}"`).join('\n')}`,
+              'Start building',
+            );
           }
           clack.outro('Done!');
         }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -372,8 +372,12 @@ export function registerCreateCommand(program: Command): void {
         trackCommand('create', orgId);
         await reportCliUsage('cli.create', true, 6);
 
-        // 8. Install npm dependencies (template projects only)
-        if (hasTemplate) {
+        // 8. Install npm dependencies (template projects only, if download succeeded)
+        const templateDownloaded = hasTemplate
+          ? await fs.stat(path.join(process.cwd(), 'package.json')).catch(() => null)
+          : null;
+
+        if (templateDownloaded) {
           const installSpinner = !json ? clack.spinner() : null;
           installSpinner?.start('Installing dependencies...');
           try {
@@ -390,7 +394,7 @@ export function registerCreateCommand(program: Command): void {
 
         // 9. Offer to deploy (template projects, interactive mode only)
         let liveUrl: string | null = null;
-        if (hasTemplate && !json) {
+        if (templateDownloaded && !json) {
           const shouldDeploy = await clack.confirm({
             message: 'Would you like to deploy now?',
           });
@@ -447,13 +451,15 @@ export function registerCreateCommand(program: Command): void {
           }
 
           // Next steps
-          if (hasTemplate) {
+          if (templateDownloaded) {
             const steps = [
               `cd ${dirName}`,
               'npm run dev',
             ];
             clack.note(steps.join('\n'), 'Next steps');
             clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
+          } else if (hasTemplate && !templateDownloaded) {
+            clack.log.warn('Template download failed. You can retry or set up manually.');
           } else {
             const prompts = [
               'Build a todo app with Google OAuth sign-in',

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -174,13 +174,13 @@ export function registerCreateCommand(program: Command): void {
           if (orgs.length === 0) {
             throw new CLIError('No organizations found.');
           }
-          if (json) {
-            throw new CLIError('Specify --org-id in JSON mode.');
-          }
           if (orgs.length === 1) {
             orgId = orgs[0].id;
-            clack.log.info(`Using organization: ${orgs[0].name}`);
+            if (!json) clack.log.info(`Using organization: ${orgs[0].name}`);
           } else {
+            if (json) {
+              throw new CLIError('Multiple organizations found. Specify --org-id.');
+            }
             const selected = await clack.select({
               message: 'Select an organization:',
               options: orgs.map((o) => ({
@@ -273,7 +273,8 @@ export function registerCreateCommand(program: Command): void {
             initialValue: projectName,
             validate: (v) => {
               if (v.length < 1) return 'Directory name is required';
-              if (v === '.' || v === '..') return 'Invalid directory name';
+              const normalized = path.basename(v).replace(/[^a-zA-Z0-9._-]/g, '-');
+              if (!normalized || normalized === '.' || normalized === '..') return 'Invalid directory name';
               return undefined;
             },
           });
@@ -281,9 +282,18 @@ export function registerCreateCommand(program: Command): void {
           dirName = path.basename(inputDir as string).replace(/[^a-zA-Z0-9._-]/g, '-');
         }
 
+        // Validate normalized dirName
+        if (!dirName || dirName === '.' || dirName === '..') {
+          throw new CLIError('Invalid directory name.');
+        }
+
         // Create the project directory and switch into it
         const projectDir = path.resolve(process.cwd(), dirName);
-        await fs.mkdir(projectDir, { recursive: true });
+        const dirExists = await fs.stat(projectDir).catch(() => null);
+        if (dirExists) {
+          throw new CLIError(`Directory "${dirName}" already exists.`);
+        }
+        await fs.mkdir(projectDir);
         process.chdir(projectDir);
 
         // 5. Create project via Platform API

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -265,10 +265,19 @@ export function registerProjectLinkCommand(program: Command): void {
             clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
           }
         } else if (!json) {
-          // No template — just show dashboard link
+          // No template — show dashboard link and suggest prompts
           const dashboardUrl = `${getFrontendUrl()}/dashboard/project/${project.id}`;
           clack.log.step(`Dashboard: ${dashboardUrl}`);
-          clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to start building.', 'Start building');
+
+          const prompts = [
+            'Build a todo app with Google OAuth sign-in',
+            'Build an Instagram clone where users can upload photos, like, and comment',
+            'Build an AI chatbot with conversation history',
+          ];
+          clack.note(
+            `Open your coding agent (Claude Code, Codex, Cursor, etc.) and try:\n\n${prompts.map((p) => `• "${p}"`).join('\n')}`,
+            'Start building',
+          );
         }
       } catch (err) {
         await reportCliUsage('cli.link', false);

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -11,40 +11,16 @@ import {
   getProjectApiKey,
   reportAgentConnected,
 } from '../../lib/api/platform.js';
-import { getAnonKey } from '../../lib/api/oss.js';
 import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
-import { readEnvFile } from '../../lib/env.js';
 import { installSkills, reportCliUsage } from '../../lib/skills.js';
 import { captureEvent, trackCommand, shutdownAnalytics } from '../../lib/analytics.js';
-import { deployProject } from '../deployments/deploy.js';
 import { downloadGitHubTemplate, downloadTemplate, type Framework } from '../create.js';
 import type { ProjectConfig } from '../../types.js';
 
 const execAsync = promisify(exec);
-
-/** Files that indicate real project content exists */
-const PROJECT_MARKERS = new Set([
-  'package.json',
-  'index.html',
-  'tsconfig.json',
-  'next.config.js',
-  'next.config.ts',
-  'next.config.mjs',
-  'vite.config.ts',
-  'vite.config.js',
-  'src',
-  'app',
-  'pages',
-  'public',
-]);
-
-async function isDirEmpty(dir: string): Promise<boolean> {
-  const entries = await fs.readdir(dir);
-  return !entries.some((e) => PROJECT_MARKERS.has(e));
-}
 
 function buildOssHost(appkey: string, region: string): string {
   return `https://${appkey}.${region}.insforge.app`;
@@ -56,6 +32,7 @@ export function registerProjectLinkCommand(program: Command): void {
     .description('Link current directory to an InsForge project')
     .option('--project-id <id>', 'Project ID to link')
     .option('--org-id <id>', 'Organization ID')
+    .option('--template <template>', 'Download a template after linking: react, nextjs, chatbot, crm, e-commerce')
     .option('--api-base-url <url>', 'API Base URL for direct linking (OSS/Self-hosted)')
     .option('--api-key <key>', 'API Key for direct linking (OSS/Self-hosted)')
     .action(async (opts, cmd) => {
@@ -117,24 +94,29 @@ export function registerProjectLinkCommand(program: Command): void {
         let orgId = opts.orgId;
         let projectId = opts.projectId;
 
-        // Show organization selection
+        // Show organization selection (auto-select if only one)
         if (!orgId && !projectId) {
           const orgs = await listOrganizations(apiUrl);
           if (orgs.length === 0) {
             throw new CLIError('No organizations found.');
           }
-          if (json) {
-            throw new CLIError('Specify --org-id in JSON mode.');
+          if (orgs.length === 1) {
+            orgId = orgs[0].id;
+            if (!json) clack.log.info(`Using organization: ${orgs[0].name}`);
+          } else {
+            if (json) {
+              throw new CLIError('Multiple organizations found. Specify --org-id.');
+            }
+            const selected = await clack.select({
+              message: 'Select an organization:',
+              options: orgs.map((o) => ({
+                value: o.id,
+                label: o.name,
+              })),
+            });
+            if (clack.isCancel(selected)) process.exit(0);
+            orgId = selected as string;
           }
-          const selected = await clack.select({
-            message: 'Select an organization:',
-            options: orgs.map((o) => ({
-              value: o.id,
-              label: o.name,
-            })),
-          });
-          if (clack.isCancel(selected)) process.exit(0);
-          orgId = selected as string;
         }
 
         // Save default org
@@ -211,132 +193,82 @@ export function registerProjectLinkCommand(program: Command): void {
           await reportAgentConnected({ project_id: project.id }, apiUrl);
         } catch { /* ignore */ }
 
-        // Smart template & deploy prompts (interactive mode only)
-        if (!json) {
-          const cwd = process.cwd();
-          let templateApplied = false;
+        // Template download (only when --template flag is passed)
+        const template = opts.template as string | undefined;
+        if (template) {
+          const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce'];
+          if (!validTemplates.includes(template)) {
+            throw new CLIError(`Invalid template "${template}". Valid options: ${validTemplates.join(', ')}`);
+          }
 
-          // Template prompt: offer if directory is empty
-          if (await isDirEmpty(cwd)) {
-            const approach = await clack.select({
-              message: 'How would you like to start?',
-              options: [
-                { value: 'blank', label: 'Blank project', hint: 'Start from scratch with .env.local ready' },
-                { value: 'template', label: 'Start from a template', hint: 'Pre-built starter apps' },
-              ],
+          // Ask for directory name
+          let dirName = project.name;
+          if (!json) {
+            const inputDir = await clack.text({
+              message: 'Directory name:',
+              initialValue: project.name,
+              validate: (v) => {
+                if (v.length < 1) return 'Directory name is required';
+                const normalized = path.basename(v).replace(/[^a-zA-Z0-9._-]/g, '-');
+                if (!normalized || normalized === '.' || normalized === '..') return 'Invalid directory name';
+                return undefined;
+              },
             });
-            if (clack.isCancel(approach)) process.exit(0);
+            if (clack.isCancel(inputDir)) process.exit(0);
+            dirName = path.basename(inputDir as string).replace(/[^a-zA-Z0-9._-]/g, '-');
+          }
 
-            captureEvent(orgId ?? project.organization_id, 'link_approach_selected', { approach: approach as string });
+          if (!dirName || dirName === '.' || dirName === '..') {
+            throw new CLIError('Invalid directory name.');
+          }
 
-            if (approach === 'template') {
-              const selected = await clack.select({
-                message: 'Choose a starter template:',
-                options: [
-                  { value: 'react', label: 'Web app template with React' },
-                  { value: 'nextjs', label: 'Web app template with Next.js' },
-                  { value: 'chatbot', label: 'AI Chatbot with Next.js' },
-                  { value: 'crm', label: 'CRM with Next.js' },
-                  { value: 'e-commerce', label: 'E-Commerce store with Next.js' },
-                ],
-              });
-              if (clack.isCancel(selected)) process.exit(0);
-              const template = selected as string;
+          const templateDir = path.resolve(process.cwd(), dirName);
+          const dirExists = await fs.stat(templateDir).catch(() => null);
+          if (dirExists) {
+            throw new CLIError(`Directory "${dirName}" already exists.`);
+          }
+          await fs.mkdir(templateDir);
+          process.chdir(templateDir);
 
-              captureEvent(orgId ?? project.organization_id, 'template_selected', { template, source: 'link' });
+          // Save project config in the new directory
+          saveProjectConfig(projectConfig);
 
-              // Download template
-              const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
-              if (githubTemplates.includes(template)) {
-                await downloadGitHubTemplate(template, projectConfig, json);
-              } else {
-                await downloadTemplate(template as Framework, projectConfig, project.name, json, apiUrl);
-              }
+          captureEvent(orgId ?? project.organization_id, 'template_selected', { template, source: 'link' });
 
-              // Only mark as applied if files were actually downloaded
-              templateApplied = !(await isDirEmpty(cwd));
+          // Download template
+          const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
+          if (githubTemplates.includes(template)) {
+            await downloadGitHubTemplate(template, projectConfig, json);
+          } else {
+            await downloadTemplate(template as Framework, projectConfig, project.name, json, apiUrl);
+          }
 
-              // Install npm dependencies
-              const installSpinner = clack.spinner();
-              installSpinner.start('Installing dependencies...');
-              try {
-                await execAsync('npm install', { cwd, maxBuffer: 10 * 1024 * 1024 });
-                installSpinner.stop('Dependencies installed');
-              } catch (err) {
-                installSpinner.stop('Failed to install dependencies');
-                clack.log.warn(`npm install failed: ${(err as Error).message}`);
-                clack.log.info('Run `npm install` manually to install dependencies.');
-              }
-            } else {
-              // Blank project: seed .env.local
-              try {
-                const anonKey = await getAnonKey();
-                if (!anonKey) {
-                  clack.log.warn('Could not retrieve anon key. You can add it to .env.local manually.');
-                } else {
-                  const envPath = path.join(cwd, '.env.local');
-                  const envContent = [
-                    '# InsForge',
-                    `NEXT_PUBLIC_INSFORGE_URL=${projectConfig.oss_host}`,
-                    `NEXT_PUBLIC_INSFORGE_ANON_KEY=${anonKey}`,
-                    '',
-                  ].join('\n');
-                  await fs.writeFile(envPath, envContent, { flag: 'wx' });
-                  clack.log.success('Created .env.local with your InsForge credentials');
-                }
-              } catch (err) {
-                const error = err as NodeJS.ErrnoException;
-                if (error.code === 'EEXIST') {
-                  clack.log.warn('.env.local already exists; skipping InsForge key seeding.');
-                } else {
-                  clack.log.warn(`Failed to create .env.local: ${error.message}`);
-                }
-              }
+          // Install npm dependencies
+          if (!json) {
+            const installSpinner = clack.spinner();
+            installSpinner.start('Installing dependencies...');
+            try {
+              await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
+              installSpinner.stop('Dependencies installed');
+            } catch (err) {
+              installSpinner.stop('Failed to install dependencies');
+              clack.log.warn(`npm install failed: ${(err as Error).message}`);
+              clack.log.info('Run `npm install` manually to install dependencies.');
             }
           }
 
-          // Deploy prompt: only offer when a template was applied
-          if (templateApplied) {
-            const shouldDeploy = await clack.confirm({
-              message: 'Would you like to deploy now?',
-            });
-
-            if (!clack.isCancel(shouldDeploy) && shouldDeploy) {
-              try {
-                const envVars = await readEnvFile(cwd);
-                const startBody: { envVars?: Array<{ key: string; value: string }> } = {};
-                if (envVars.length > 0) {
-                  startBody.envVars = envVars;
-                }
-
-                const deploySpinner = clack.spinner();
-                const result = await deployProject({
-                  sourceDir: cwd,
-                  startBody,
-                  spinner: deploySpinner,
-                });
-
-                if (result.isReady) {
-                  deploySpinner.stop('Deployment complete');
-                  const liveUrl = result.liveUrl;
-                  if (liveUrl) {
-                    clack.log.success(`Live site: ${liveUrl}`);
-                  }
-                } else {
-                  deploySpinner.stop('Deployment is still building');
-                  clack.log.info(`Deployment ID: ${result.deploymentId}`);
-                  clack.log.warn('Deployment did not finish within 5 minutes.');
-                  clack.log.info(`Check status with: npx @insforge/cli deployments status ${result.deploymentId}`);
-                }
-              } catch (err) {
-                clack.log.warn(`Deploy failed: ${(err as Error).message}`);
-              }
-            }
+          if (!json) {
+            const dashboardUrl = `${getFrontendUrl()}/dashboard/project/${project.id}`;
+            clack.log.step(`Dashboard: ${dashboardUrl}`);
+            const steps = [`cd ${dirName}`, 'npm run dev'];
+            clack.note(steps.join('\n'), 'Next steps');
+            clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
           }
-
-          // Show dashboard link
+        } else if (!json) {
+          // No template — just show dashboard link
           const dashboardUrl = `${getFrontendUrl()}/dashboard/project/${project.id}`;
           clack.log.step(`Dashboard: ${dashboardUrl}`);
+          clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to start building.', 'Start building');
         }
       } catch (err) {
         await reportCliUsage('cli.link', false);

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -174,7 +174,10 @@ export function registerProjectLinkCommand(program: Command): void {
           oss_host: buildOssHost(project.appkey, project.region),
         };
 
-        saveProjectConfig(projectConfig);
+        // Save config in cwd only if not using --template (template flow saves in subdirectory)
+        if (!opts.template) {
+          saveProjectConfig(projectConfig);
+        }
 
         trackCommand('link', project.organization_id);
 
@@ -243,8 +246,10 @@ export function registerProjectLinkCommand(program: Command): void {
             await downloadTemplate(template as Framework, projectConfig, project.name, json, apiUrl);
           }
 
-          // Install npm dependencies
-          if (!json) {
+          // Only proceed with install/next steps if template actually downloaded
+          const templateDownloaded = await fs.stat(path.join(process.cwd(), 'package.json')).catch(() => null);
+
+          if (templateDownloaded && !json) {
             const installSpinner = clack.spinner();
             installSpinner.start('Installing dependencies...');
             try {
@@ -260,9 +265,13 @@ export function registerProjectLinkCommand(program: Command): void {
           if (!json) {
             const dashboardUrl = `${getFrontendUrl()}/dashboard/project/${project.id}`;
             clack.log.step(`Dashboard: ${dashboardUrl}`);
-            const steps = [`cd ${dirName}`, 'npm run dev'];
-            clack.note(steps.join('\n'), 'Next steps');
-            clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
+            if (templateDownloaded) {
+              const steps = [`cd ${dirName}`, 'npm run dev'];
+              clack.note(steps.join('\n'), 'Next steps');
+              clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
+            } else {
+              clack.log.warn('Template download failed. You can retry or set up manually.');
+            }
           }
         } else if (!json) {
           // No template — show dashboard link and suggest prompts


### PR DESCRIPTION
## Summary
- **Auto-select org** when user has only one organization (both `create` and `link`)
- **`create` with template** prompts for directory name, creates subdirectory, downloads template
- **`create` blank** uses current directory, shows coding agent prompt suggestions
- **`link --template <name>`** downloads template into a new subdirectory (same UX as create)
- **`link`** (no template) just links in current directory, shows prompt suggestions
- **Directory validation** — rejects invalid names (`/`, `.`, `..`), rejects existing dirs, cleans up on failure
- **Next steps messages** — template projects show `cd` + `npm run dev` + agent nudge; blank/raw link shows app idea prompts
- Bumps version to 0.1.44
- Adds unit tests for org selection and directory validation logic

## Test plan
- [ ] `insforge create --template react` — prompts for dir, creates subdir, downloads, shows next steps
- [ ] `insforge create` (blank) — uses cwd, shows prompt suggestions
- [ ] `insforge link --template nextjs` — links project, prompts for dir, downloads template
- [ ] `insforge link` — links in cwd, shows prompt suggestions
- [ ] Single org account skips org selection in both commands
- [ ] Invalid directory names are rejected
- [ ] Existing directory name is rejected
- [ ] `npm run test:unit` passes (16 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve `create` and `link` UX with auto-org selection, subdirectory creation, and next steps
> - Both `create` and `link` commands now auto-select an organization when the account has exactly one org; in JSON mode with multiple orgs, an error is thrown requiring `--org-id`.
> - Template-based `create` flows now prompt for a directory name, create a subdirectory under cwd, and run subsequent steps inside it; blank projects use cwd.
> - The `link` command gains a `--template` flag that downloads a starter template into a new subdirectory and installs dependencies; without the flag, it saves config in cwd and prints suggested prompts.
> - After a successful template download, both commands print "next steps" guidance (e.g. `cd <dir> && npm run dev`).
> - `create` cleans up the newly created directory if project linking fails, and only runs `npm install` / deploy prompts when a `package.json` is present.
> - Behavioral Change: `link` no longer prompts interactively to choose templates, seeds `.env.local`, or offers a deploy prompt post-link.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8d2d28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->