### PR TITLE
INS-51: Support PostHog A/B testing in new onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@insforge/cli",
 
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -156,7 +156,7 @@ export function registerCreateCommand(program: Command): void {
     .option('--name <name>', 'Project name')
     .option('--org-id <id>', 'Organization ID')
     .option('--region <region>', 'Deployment region (us-east, us-west, eu-central, ap-southeast)')
-    .option('--template <template>', 'Template to use: react, nextjs, chatbot, crm, e-commerce, or empty')
+    .option('--template <template>', 'Template to use: react, nextjs, chatbot, crm, e-commerce, todo, or empty')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
@@ -219,7 +219,7 @@ export function registerCreateCommand(program: Command): void {
         }
 
         // 3. Select template (two-step: blank vs template, then pick template)
-        const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce', 'empty'];
+        const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce', 'todo', 'empty'];
         let template = opts.template as string | undefined;
         if (template && !validTemplates.includes(template)) {
           throw new CLIError(`Invalid template "${template}". Valid options: ${validTemplates.join(', ')}`);
@@ -252,6 +252,7 @@ export function registerCreateCommand(program: Command): void {
                   { value: 'chatbot', label: 'AI Chatbot with Next.js' },
                   { value: 'crm', label: 'CRM with Next.js' },
                   { value: 'e-commerce', label: 'E-Commerce store with Next.js' },
+                  { value: 'todo', label: 'Todo app with Next.js' },
                 ],
               });
               if (clack.isCancel(selected)) process.exit(0);
@@ -331,7 +332,7 @@ export function registerCreateCommand(program: Command): void {
         s?.stop(`Project "${project.name}" created and linked`);
 
         // 7. Download template or seed env for blank projects
-        const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
+        const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
         if (githubTemplates.includes(template!)) {
           await downloadGitHubTemplate(template!, projectConfig, json);
         } else if (hasTemplate) {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -32,7 +32,7 @@ export function registerProjectLinkCommand(program: Command): void {
     .description('Link current directory to an InsForge project')
     .option('--project-id <id>', 'Project ID to link')
     .option('--org-id <id>', 'Organization ID')
-    .option('--template <template>', 'Download a template after linking: react, nextjs, chatbot, crm, e-commerce')
+    .option('--template <template>', 'Download a template after linking: react, nextjs, chatbot, crm, e-commerce, todo')
     .option('--api-base-url <url>', 'API Base URL for direct linking (OSS/Self-hosted)')
     .option('--api-key <key>', 'API Key for direct linking (OSS/Self-hosted)')
     .action(async (opts, cmd) => {
@@ -199,7 +199,7 @@ export function registerProjectLinkCommand(program: Command): void {
         // Template download (only when --template flag is passed)
         const template = opts.template as string | undefined;
         if (template) {
-          const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce'];
+          const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce', 'todo'];
           if (!validTemplates.includes(template)) {
             throw new CLIError(`Invalid template "${template}". Valid options: ${validTemplates.join(', ')}`);
           }
@@ -239,7 +239,7 @@ export function registerProjectLinkCommand(program: Command): void {
           captureEvent(orgId ?? project.organization_id, 'template_selected', { template, source: 'link' });
 
           // Download template
-          const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react'];
+          const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
           if (githubTemplates.includes(template)) {
             await downloadGitHubTemplate(template, projectConfig, json);
           } else {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add 'todo' template to `create` and `link` commands
- Adds `todo` to the valid templates list in both [`create.ts`](https://github.com/InsForge/CLI/pull/61/files#diff-b6d810b0306723c2b160e529addd463ae24be806303358ff1f6a2209bc13357d) and [`link.ts`](https://github.com/InsForge/CLI/pull/61/files#diff-6269c2fca99bb2d083ae08500308831e3517ee388ca483fcf29fe05fa226fb2b), including CLI help text and interactive selection menus.
- The `todo` template is fetched via the existing `downloadGitHubTemplate` path, consistent with other GitHub-hosted templates.
- Bumps package version from `0.1.44` to `0.1.45`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d319579.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Todo app with Next.js" as a new template option.

* **Chores**
  * Bumped version to 0.1.45.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->