### PR TITLE
fix: actionable error messages + fire cli.link event on --template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,11 @@ jobs:
 
       - run: npm ci
 
-      - name: Lint
+      - name: Test & lint
         run: npm run lint
 
       - name: Build
         run: npm run build
-
-      - name: Unit tests
-        run: npm run test:unit
 
       - name: Notify owner on failure
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run lint
+      - name: Test & lint
+        run: npm run lint
 
       - run: npm run build
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@insforge/cli",
 
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {
@@ -13,7 +13,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint && npm run test:unit && npm run build",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",
     "test:integration:real": "npm run build && vitest run src/integration/real-project.test.ts"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint src/",
+    "lint": "vitest run --passWithNoTests && eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "prepublishOnly": "npm run lint && npm run test:unit && npm run build",
+    "prepublishOnly": "npm run lint && npm run build",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",
     "test:integration:real": "npm run build && vitest run src/integration/real-project.test.ts"

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -73,7 +73,7 @@ export function registerProjectLinkCommand(program: Command): void {
 
             // Install agent skills
             await installSkills(json);
-            await reportCliUsage('cli.link_direct', true, 6);
+            await reportCliUsage('cli.link_direct', true, 6, projectConfig);
 
             // Report agent-connected event (best-effort)
             try {
@@ -189,7 +189,7 @@ export function registerProjectLinkCommand(program: Command): void {
 
         // Install agent skills
         await installSkills(json);
-        await reportCliUsage('cli.link', true, 6);
+        await reportCliUsage('cli.link', true, 6, projectConfig);
 
         // Report agent-connected event (best-effort)
         try {

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -1,5 +1,5 @@
 import { getAccessToken, getPlatformApiUrl } from '../config.js';
-import { AuthError, CLIError } from '../errors.js';
+import { AuthError, CLIError, formatFetchError } from '../errors.js';
 import { refreshAccessToken } from '../credentials.js';
 import type {
   ApiKeyResponse,
@@ -26,13 +26,24 @@ export async function platformFetch(
     ...(options.headers as Record<string, string> ?? {}),
   };
 
-  const res = await fetch(`${baseUrl}${path}`, { ...options, headers });
+  const fullUrl = `${baseUrl}${path}`;
+  let res: Response;
+  try {
+    res = await fetch(fullUrl, { ...options, headers });
+  } catch (err) {
+    throw new CLIError(formatFetchError(err, fullUrl));
+  }
 
   // Auto-refresh on 401
   if (res.status === 401) {
     const newToken = await refreshAccessToken(apiUrl);
     headers.Authorization = `Bearer ${newToken}`;
-    const retryRes = await fetch(`${baseUrl}${path}`, { ...options, headers });
+    let retryRes: Response;
+    try {
+      retryRes = await fetch(fullUrl, { ...options, headers });
+    } catch (err) {
+      throw new CLIError(formatFetchError(err, fullUrl));
+    }
     if (!retryRes.ok) {
       const err = await retryRes.json().catch(() => ({})) as { error?: string };
       throw new CLIError(err.error ?? `Request failed: ${retryRes.status}`, retryRes.status === 403 ? 5 : 1);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import { URL } from 'node:url';
 import * as clack from '@clack/prompts';
 import { getGlobalConfig, getPlatformApiUrl, saveCredentials } from './config.js';
 import { getProfile } from './api/platform.js';
+import { formatFetchError } from './errors.js';
 import type { StoredCredentials } from '../types.js';
 
 // Default OAuth client for InsForge CLI (pre-registered on the platform)
@@ -68,21 +69,27 @@ export async function exchangeCodeForTokens(params: {
   clientId: string;
   codeVerifier: string;
 }): Promise<{ access_token: string; refresh_token: string; expires_in: number; scope: string }> {
-  const res = await fetch(`${params.platformUrl}/api/oauth/v1/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      grant_type: 'authorization_code',
-      code: params.code,
-      redirect_uri: params.redirectUri,
-      client_id: params.clientId,
-      code_verifier: params.codeVerifier,
-    }),
-  });
+  const tokenUrl = `${params.platformUrl}/api/oauth/v1/token`;
+  let res: Response;
+  try {
+    res = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: params.code,
+        redirect_uri: params.redirectUri,
+        client_id: params.clientId,
+        code_verifier: params.codeVerifier,
+      }),
+    });
+  } catch (err) {
+    throw new Error(`Token exchange failed — ${formatFetchError(err, tokenUrl)}`, { cause: err });
+  }
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({})) as { error_description?: string; error?: string };
-    throw new Error(err.error_description ?? err.error ?? 'Token exchange failed');
+    throw new Error(err.error_description ?? err.error ?? `Token exchange failed (HTTP ${res.status})`);
   }
 
   return await res.json() as { access_token: string; refresh_token: string; expires_in: number; scope: string };
@@ -96,19 +103,25 @@ export async function refreshOAuthToken(params: {
   refreshToken: string;
   clientId: string;
 }): Promise<{ access_token: string; refresh_token?: string; expires_in: number }> {
-  const res = await fetch(`${params.platformUrl}/api/oauth/v1/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      grant_type: 'refresh_token',
-      refresh_token: params.refreshToken,
-      client_id: params.clientId,
-    }),
-  });
+  const tokenUrl = `${params.platformUrl}/api/oauth/v1/token`;
+  let res: Response;
+  try {
+    res = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: params.refreshToken,
+        client_id: params.clientId,
+      }),
+    });
+  } catch (err) {
+    throw new Error(`Token refresh failed — ${formatFetchError(err, tokenUrl)}`, { cause: err });
+  }
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({})) as { error_description?: string; error?: string };
-    throw new Error(err.error_description ?? err.error ?? 'Token refresh failed');
+    throw new Error(err.error_description ?? err.error ?? `Token refresh failed (HTTP ${res.status})`);
   }
 
   return await res.json() as { access_token: string; refresh_token?: string; expires_in: number };

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { formatFetchError } from './errors.js';
+
+function fetchError(causeCode?: string, causeMessage?: string): Error {
+  const err = new Error('fetch failed');
+  if (causeCode || causeMessage) {
+    const cause = new Error(causeMessage ?? '');
+    if (causeCode) (cause as { code?: string }).code = causeCode;
+    (err as { cause?: unknown }).cause = cause;
+  }
+  return err;
+}
+
+describe('formatFetchError', () => {
+  const url = 'https://api.example.com/v1/things';
+
+  it('handles ENOTFOUND as DNS failure with host', () => {
+    const msg = formatFetchError(fetchError('ENOTFOUND'), url);
+    expect(msg).toContain('api.example.com');
+    expect(msg).toContain('DNS');
+  });
+
+  it('handles EAI_AGAIN as DNS failure', () => {
+    const msg = formatFetchError(fetchError('EAI_AGAIN'), url);
+    expect(msg).toContain('DNS');
+  });
+
+  it('handles ECONNREFUSED', () => {
+    const msg = formatFetchError(fetchError('ECONNREFUSED'), url);
+    expect(msg).toContain('refused');
+    expect(msg).toContain('api.example.com');
+  });
+
+  it('handles ETIMEDOUT', () => {
+    const msg = formatFetchError(fetchError('ETIMEDOUT'), url);
+    expect(msg).toContain('timed out');
+  });
+
+  it('handles UND_ERR_CONNECT_TIMEOUT as timeout', () => {
+    const msg = formatFetchError(fetchError('UND_ERR_CONNECT_TIMEOUT'), url);
+    expect(msg).toContain('timed out');
+  });
+
+  it('handles ECONNRESET', () => {
+    const msg = formatFetchError(fetchError('ECONNRESET'), url);
+    expect(msg).toContain('reset');
+  });
+
+  it('handles TLS cert errors', () => {
+    const msg = formatFetchError(fetchError('CERT_HAS_EXPIRED'), url);
+    expect(msg).toContain('TLS');
+    expect(msg).toContain('CERT_HAS_EXPIRED');
+  });
+
+  it('falls back to the cause code when unknown', () => {
+    const msg = formatFetchError(fetchError('WEIRD_CODE', 'boom'), url);
+    expect(msg).toContain('WEIRD_CODE');
+    expect(msg).toContain('boom');
+  });
+
+  it('falls back to cause message when no code', () => {
+    const msg = formatFetchError(fetchError(undefined, 'socket hang up'), url);
+    expect(msg).toContain('socket hang up');
+  });
+
+  it('passes through non-"fetch failed" errors unchanged', () => {
+    const err = new Error('something else');
+    expect(formatFetchError(err, url)).toBe('something else');
+  });
+
+  it('handles non-Error values', () => {
+    expect(formatFetchError('bad thing', url)).toContain('bad thing');
+  });
+
+  it('handles a URL that is just a host string', () => {
+    const msg = formatFetchError(fetchError('ENOTFOUND'), 'broken-host');
+    expect(msg).toContain('broken-host');
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -36,6 +36,53 @@ export class PermissionError extends CLIError {
 }
 
 /**
+ * Format a Node fetch error with actionable context.
+ *
+ * Node's undici-based fetch throws a generic Error with `message: 'fetch failed'`
+ * for any network-layer failure (DNS, connect, TLS, reset, timeout). The real
+ * reason sits on `err.cause` with a `code` like ENOTFOUND / ECONNREFUSED /
+ * ETIMEDOUT / UND_ERR_CONNECT_TIMEOUT / CERT_HAS_EXPIRED, etc. Unpack it so
+ * users see something actionable instead of "fetch failed".
+ */
+export function formatFetchError(err: unknown, url: string): string {
+  if (!(err instanceof Error)) return `Network request to ${url} failed: ${String(err)}`;
+  if (err.message !== 'fetch failed') return err.message;
+
+  const cause = (err as { cause?: unknown }).cause;
+  const code =
+    (cause as { code?: string } | undefined)?.code ??
+    (cause as { errno?: string } | undefined)?.errno;
+  const causeMsg =
+    cause instanceof Error ? cause.message : typeof cause === 'string' ? cause : undefined;
+
+  let host = url;
+  try { host = new URL(url).host; } catch { /* url may already be a host */ }
+
+  switch (code) {
+    case 'ENOTFOUND':
+    case 'EAI_AGAIN':
+      return `Cannot resolve ${host} (DNS lookup failed: ${code}). Check your internet connection or DNS settings.`;
+    case 'ECONNREFUSED':
+      return `Connection to ${host} refused. The server may be down or blocked by a firewall.`;
+    case 'ETIMEDOUT':
+    case 'UND_ERR_CONNECT_TIMEOUT':
+      return `Connection to ${host} timed out. Check your network, VPN, or proxy settings.`;
+    case 'ECONNRESET':
+    case 'UND_ERR_SOCKET':
+      return `Connection to ${host} was reset. A proxy, VPN, or firewall may be interfering.`;
+    case 'CERT_HAS_EXPIRED':
+    case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE':
+    case 'SELF_SIGNED_CERT_IN_CHAIN':
+    case 'DEPTH_ZERO_SELF_SIGNED_CERT':
+      return `TLS certificate error contacting ${host} (${code}). Your network may be intercepting HTTPS (corporate proxy / VPN).`;
+  }
+
+  if (code) return `Network error contacting ${host}: ${code}${causeMsg ? ` — ${causeMsg}` : ''}`;
+  if (causeMsg) return `Network error contacting ${host}: ${causeMsg}`;
+  return `Network error contacting ${host}.`;
+}
+
+/**
  * Extract error message from a deployment's metadata field.
  * DeploymentSchema stores errors in metadata.error.errorMessage rather than a top-level field.
  */

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describeExecError, reportCliUsage } from './skills.js';
+
+function execError(opts: {
+  killed?: boolean;
+  signal?: string;
+  code?: number | string;
+  stderr?: string;
+  message?: string;
+}): Error {
+  const err = new Error(opts.message ?? 'Command failed');
+  Object.assign(err, opts);
+  return err;
+}
+
+describe('describeExecError', () => {
+  it('classifies a SIGTERM-killed process as a timeout', () => {
+    const msg = describeExecError(execError({ killed: true, signal: 'SIGTERM' }));
+    expect(msg).toContain('timed out');
+    expect(msg).toContain('60s');
+  });
+
+  it('classifies a SIGKILL-killed process as a timeout', () => {
+    const msg = describeExecError(execError({ killed: true, signal: 'SIGKILL' }));
+    expect(msg).toContain('timed out');
+  });
+
+  it('reports missing npx (ENOENT)', () => {
+    const msg = describeExecError(execError({ code: 'ENOENT' }));
+    expect(msg).toContain('npx');
+    expect(msg).toContain('PATH');
+  });
+
+  it('detects DNS failure in stderr', () => {
+    const stderr = 'npm ERR! network request to https://registry.npmjs.org failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org';
+    const msg = describeExecError(execError({ code: 1, stderr }));
+    expect(msg).toContain('DNS');
+  });
+
+  it('detects connection refused', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'ECONNREFUSED 127.0.0.1:443' }));
+    expect(msg).toContain('refused');
+  });
+
+  it('detects network timeout in stderr', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'npm ERR! network timeout at: https://registry.npmjs.org' }));
+    expect(msg).toContain('timed out');
+  });
+
+  it('detects TLS interception', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' }));
+    expect(msg).toContain('TLS');
+  });
+
+  it('detects 404 package not found', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'npm ERR! 404 Not Found - GET https://registry.npmjs.org/skills' }));
+    expect(msg).toContain('404');
+  });
+
+  it('detects permission denied', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'EACCES: permission denied, mkdir /usr/local/lib/node_modules' }));
+    expect(msg).toContain('permission');
+  });
+
+  it('detects disk full', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'ENOSPC: no space left on device' }));
+    expect(msg).toContain('disk');
+  });
+
+  it('detects npm auth failure', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'npm ERR! code E401\nnpm ERR! authentication required' }));
+    expect(msg).toContain('authentication');
+  });
+
+  it('falls back to exit code for unrecognized failures', () => {
+    const msg = describeExecError(execError({ code: 42, stderr: 'some weird unclassified error' }));
+    expect(msg).toContain('42');
+  });
+
+  it('falls back to error message when no other info', () => {
+    const msg = describeExecError(execError({ message: 'mystery' }));
+    expect(msg).toContain('mystery');
+  });
+
+  it('prefers timeout classification over a populated stderr', () => {
+    const msg = describeExecError(execError({
+      killed: true,
+      signal: 'SIGTERM',
+      code: 1,
+      stderr: 'ENOTFOUND registry.npmjs.org',
+    }));
+    expect(msg).toContain('timed out');
+    expect(msg).not.toContain('DNS');
+  });
+
+  it('handles Buffer stderr', () => {
+    const err = execError({ code: 1 });
+    (err as unknown as { stderr: Buffer }).stderr = Buffer.from('EACCES: permission denied');
+    expect(describeExecError(err)).toContain('permission');
+  });
+});
+
+describe('reportCliUsage', () => {
+  const explicitConfig = { oss_host: 'https://proj.region.insforge.app', api_key: 'test-key' };
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('uses the explicit config when provided (does not touch filesystem)', async () => {
+    await reportCliUsage('cli.link', true, 1, explicitConfig);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://proj.region.insforge.app/api/usage/mcp');
+
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('test-key');
+    expect(headers['Content-Type']).toBe('application/json');
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.tool_name).toBe('cli.link');
+    expect(body.success).toBe(true);
+    expect(typeof body.timestamp).toBe('string');
+  });
+
+  it('stops retrying once a non-5xx response arrives', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await reportCliUsage('cli.link', true, 5, explicitConfig);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends success=false for failures', async () => {
+    await reportCliUsage('cli.link', false, 1, explicitConfig);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.success).toBe(false);
+  });
+});

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -9,7 +9,7 @@ const execAsync = promisify(exec);
 
 const SKILL_INSTALL_TIMEOUT_MS = 60_000;
 
-function describeExecError(err: unknown): string {
+export function describeExecError(err: unknown): string {
   const e = err as {
     killed?: boolean;
     signal?: string;

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -7,6 +7,39 @@ import { getProjectConfig } from './config.js';
 
 const execAsync = promisify(exec);
 
+const SKILL_INSTALL_TIMEOUT_MS = 60_000;
+
+function describeExecError(err: unknown): string {
+  const e = err as {
+    killed?: boolean;
+    signal?: string;
+    code?: number | string;
+    stderr?: string | Buffer;
+    message?: string;
+  };
+
+  if (e.killed && (e.signal === 'SIGTERM' || e.signal === 'SIGKILL')) {
+    return `timed out after ${SKILL_INSTALL_TIMEOUT_MS / 1000}s — the npm registry may be slow or blocked by your network`;
+  }
+  if (e.code === 'ENOENT') {
+    return '`npx` is not on your PATH — install Node.js 18+ and reopen your shell';
+  }
+
+  const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString()) ?? '';
+  if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(stderr)) return 'cannot reach the npm registry (DNS lookup failed) — check your internet connection';
+  if (/ECONNREFUSED/i.test(stderr)) return 'connection to the npm registry was refused — a proxy or firewall is likely blocking it';
+  if (/ETIMEDOUT|ESOCKETTIMEDOUT|network timeout/i.test(stderr)) return 'the npm registry timed out — check your VPN, proxy, or corporate network';
+  if (/CERT_HAS_EXPIRED|UNABLE_TO_VERIFY_LEAF_SIGNATURE|SELF_SIGNED_CERT/i.test(stderr)) return 'TLS error reaching the npm registry — a corporate proxy may be intercepting HTTPS';
+  if (/\bE404\b|404 Not Found/i.test(stderr)) return 'npm returned 404 — the `skills` package or a dependency could not be found (check your npm registry config)';
+  if (/EACCES|permission denied/i.test(stderr)) return 'permission denied writing files — run from a directory you own, without sudo';
+  if (/ENOSPC|no space left/i.test(stderr)) return 'no disk space left to install the package';
+  if (/\b401\b|EAUTH|authentication/i.test(stderr)) return 'npm authentication failed — check ~/.npmrc';
+
+  if (typeof e.code === 'number') return `npx exited with code ${e.code}`;
+  if (typeof e.code === 'string') return e.code;
+  return e.message ?? 'unknown error';
+}
+
 const GITIGNORE_ENTRIES = [
   '.insforge',
   '.agent',
@@ -40,11 +73,14 @@ export async function installSkills(json: boolean): Promise<void> {
     if (!json) clack.log.info('Installing InsForge agent skills...');
     await execAsync('npx skills add insforge/agent-skills -y -a antigravity -a augment -a claude-code -a cline -a codex -a cursor -a gemini-cli -a github-copilot -a kilo -a qoder -a qwen-code -a roo -a trae -a windsurf', {
       cwd: process.cwd(),
-      timeout: 60_000,
+      timeout: SKILL_INSTALL_TIMEOUT_MS,
     });
     if (!json) clack.log.success('InsForge agent skills installed.');
-  } catch {
-    if (!json) clack.log.warn('Failed to install agent skills. You can run manually: npx skills add insforge/agent-skills');
+  } catch (err) {
+    if (!json) {
+      clack.log.warn(`Could not install agent skills: ${describeExecError(err)}`);
+      clack.log.info('Run `npx skills add insforge/agent-skills` once resolved to see the full output.');
+    }
   }
 
   // Install find-skills from vercel-labs for skill discovery
@@ -52,11 +88,14 @@ export async function installSkills(json: boolean): Promise<void> {
     if (!json) clack.log.info('Installing find-skills...');
     await execAsync('npx skills add https://github.com/vercel-labs/skills --skill find-skills -y', {
       cwd: process.cwd(),
-      timeout: 60_000,
+      timeout: SKILL_INSTALL_TIMEOUT_MS,
     });
     if (!json) clack.log.success('find-skills installed.');
-  } catch {
-    if (!json) clack.log.warn('Failed to install find-skills. You can run manually: npx skills add https://github.com/vercel-labs/skills --skill find-skills');
+  } catch (err) {
+    if (!json) {
+      clack.log.warn(`Could not install find-skills: ${describeExecError(err)}`);
+      clack.log.info('Run `npx skills add https://github.com/vercel-labs/skills --skill find-skills` once resolved.');
+    }
   }
 
   try {
@@ -66,12 +105,19 @@ export async function installSkills(json: boolean): Promise<void> {
   }
 }
 
-export async function reportCliUsage(toolName: string, success: boolean, maxRetries = 1): Promise<void> {
-  let config;
-  try {
-    config = getProjectConfig();
-  } catch {
-    return;
+export async function reportCliUsage(
+  toolName: string,
+  success: boolean,
+  maxRetries = 1,
+  explicitConfig?: { oss_host: string; api_key: string },
+): Promise<void> {
+  let config: { oss_host: string; api_key: string } | null | undefined = explicitConfig;
+  if (!config) {
+    try {
+      config = getProjectConfig();
+    } catch {
+      return;
+    }
   }
   if (!config) return;
 


### PR DESCRIPTION
## Summary

- **Actionable network errors.** `fetch failed` / generic catch-alls now get unwrapped. `formatFetchError` reads the undici `cause.code` (ENOTFOUND, ECONNREFUSED, ETIMEDOUT, CERT_HAS_EXPIRED, etc.) and returns a sentence the user can act on. Wired into `platformFetch` and the OAuth token endpoints in `auth.ts`.
- **Actionable skill-install errors.** `describeExecError` in `skills.ts` classifies `execAsync` failures (timeout, missing `npx`, DNS, TLS, 404, EACCES, ENOSPC, npm auth). Warning now explains the real reason and tells the user to run the manual command *once resolved* — not a useless "try again".
- **Fire `cli.link` on `--template`.** Regression: when `--template` is passed, `saveProjectConfig` is deferred until the template subdirectory is created, so `reportCliUsage('cli.link')` ran before config existed in cwd and returned early with no event. `reportCliUsage` now accepts an explicit config; both link branches pass it through.

## Test plan

- [ ] `insforge link --template react` from an empty dir — confirm the link event reaches the project (previously missing).
- [ ] Simulate offline (`networksetup -setairportpower en0 off` or turn off Wi-Fi) and run `insforge link` — should see a DNS-failure message, not "fetch failed".
- [ ] With no network, run `insforge create` or `link --template` — "Could not install agent skills: cannot reach the npm registry …" instead of generic warn.
- [ ] `insforge link` on a known-good project (no template) — unchanged behavior, `cli.link` still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add actionable network error messages and fire `cli.link` event on `--template`
> - Adds `formatFetchError` in [`src/lib/errors.ts`](https://github.com/InsForge/CLI/pull/62/files#diff-33a1fa952d3520ae3b8ff121fe89f8d401e10efd4cbf34f180663caa16c0f153) to map common network/TLS error codes to user-facing messages; used in `platformFetch` and the OAuth token exchange/refresh flows.
> - Adds `describeExecError` in [`src/lib/skills.ts`](https://github.com/InsForge/CLI/pull/62/files#diff-c9007d25f494c224c301e8731d5b57f357f48a38150b2950cf1e2d310ae34288) to classify npx/npm exec failures (timeout, DNS, TLS, 404, auth, disk full, etc.) into actionable log messages during skill installation.
> - Extends `reportCliUsage` to accept an optional explicit config, allowing `cli.link` to be fired from the `--template` path without reading project config from disk.
> - Merges the unit test run into the `lint` script so `npm run lint` executes Vitest before ESLint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48a70dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, actionable network error messages for DNS, connection, timeout, and TLS failures.
  * More informative OAuth token and skill-install failure messages, including HTTP status codes and actionable retry hints.
* **New Features**
  * CLI usage reporting accepts explicit config to send usage with provided host/key.
  * Skill install timeout made configurable.
* **Tests**
  * Added unit tests covering error formatting, skill install errors, and usage reporting.
* **Chores**
  * CI/workflow labels adjusted; package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->