### PR TITLE
chore(0.1.46): unit tests + publish gate + version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,11 @@ jobs:
 
       - run: npm ci
 
-      - name: Lint
+      - name: Test & lint
         run: npm run lint
 
       - name: Build
         run: npm run build
-
-      - name: Unit tests
-        run: npm run test:unit
 
       - name: Notify owner on failure
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run lint
+      - name: Test & lint
+        run: npm run lint
 
       - run: npm run build
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@insforge/cli",
 
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {
@@ -13,7 +13,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint && npm run test:unit && npm run build",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",
     "test:integration:real": "npm run build && vitest run src/integration/real-project.test.ts"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint src/",
+    "lint": "vitest run --passWithNoTests && eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "prepublishOnly": "npm run lint && npm run test:unit && npm run build",
+    "prepublishOnly": "npm run lint && npm run build",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",
     "test:integration:real": "npm run build && vitest run src/integration/real-project.test.ts"

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { formatFetchError } from './errors.js';
+
+function fetchError(causeCode?: string, causeMessage?: string): Error {
+  const err = new Error('fetch failed');
+  if (causeCode || causeMessage) {
+    const cause = new Error(causeMessage ?? '');
+    if (causeCode) (cause as { code?: string }).code = causeCode;
+    (err as { cause?: unknown }).cause = cause;
+  }
+  return err;
+}
+
+describe('formatFetchError', () => {
+  const url = 'https://api.example.com/v1/things';
+
+  it('handles ENOTFOUND as DNS failure with host', () => {
+    const msg = formatFetchError(fetchError('ENOTFOUND'), url);
+    expect(msg).toContain('api.example.com');
+    expect(msg).toContain('DNS');
+  });
+
+  it('handles EAI_AGAIN as DNS failure', () => {
+    const msg = formatFetchError(fetchError('EAI_AGAIN'), url);
+    expect(msg).toContain('DNS');
+  });
+
+  it('handles ECONNREFUSED', () => {
+    const msg = formatFetchError(fetchError('ECONNREFUSED'), url);
+    expect(msg).toContain('refused');
+    expect(msg).toContain('api.example.com');
+  });
+
+  it('handles ETIMEDOUT', () => {
+    const msg = formatFetchError(fetchError('ETIMEDOUT'), url);
+    expect(msg).toContain('timed out');
+  });
+
+  it('handles UND_ERR_CONNECT_TIMEOUT as timeout', () => {
+    const msg = formatFetchError(fetchError('UND_ERR_CONNECT_TIMEOUT'), url);
+    expect(msg).toContain('timed out');
+  });
+
+  it('handles ECONNRESET', () => {
+    const msg = formatFetchError(fetchError('ECONNRESET'), url);
+    expect(msg).toContain('reset');
+  });
+
+  it('handles TLS cert errors', () => {
+    const msg = formatFetchError(fetchError('CERT_HAS_EXPIRED'), url);
+    expect(msg).toContain('TLS');
+    expect(msg).toContain('CERT_HAS_EXPIRED');
+  });
+
+  it('falls back to the cause code when unknown', () => {
+    const msg = formatFetchError(fetchError('WEIRD_CODE', 'boom'), url);
+    expect(msg).toContain('WEIRD_CODE');
+    expect(msg).toContain('boom');
+  });
+
+  it('falls back to cause message when no code', () => {
+    const msg = formatFetchError(fetchError(undefined, 'socket hang up'), url);
+    expect(msg).toContain('socket hang up');
+  });
+
+  it('passes through non-"fetch failed" errors unchanged', () => {
+    const err = new Error('something else');
+    expect(formatFetchError(err, url)).toBe('something else');
+  });
+
+  it('handles non-Error values', () => {
+    expect(formatFetchError('bad thing', url)).toContain('bad thing');
+  });
+
+  it('handles a URL that is just a host string', () => {
+    const msg = formatFetchError(fetchError('ENOTFOUND'), 'broken-host');
+    expect(msg).toContain('broken-host');
+  });
+});

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describeExecError, reportCliUsage } from './skills.js';
+
+function execError(opts: {
+  killed?: boolean;
+  signal?: string;
+  code?: number | string;
+  stderr?: string;
+  message?: string;
+}): Error {
+  const err = new Error(opts.message ?? 'Command failed');
+  Object.assign(err, opts);
+  return err;
+}
+
+describe('describeExecError', () => {
+  it('classifies a SIGTERM-killed process as a timeout', () => {
+    const msg = describeExecError(execError({ killed: true, signal: 'SIGTERM' }));
+    expect(msg).toContain('timed out');
+    expect(msg).toContain('60s');
+  });
+
+  it('classifies a SIGKILL-killed process as a timeout', () => {
+    const msg = describeExecError(execError({ killed: true, signal: 'SIGKILL' }));
+    expect(msg).toContain('timed out');
+  });
+
+  it('reports missing npx (ENOENT)', () => {
+    const msg = describeExecError(execError({ code: 'ENOENT' }));
+    expect(msg).toContain('npx');
+    expect(msg).toContain('PATH');
+  });
+
+  it('detects DNS failure in stderr', () => {
+    const stderr = 'npm ERR! network request to https://registry.npmjs.org failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org';
+    const msg = describeExecError(execError({ code: 1, stderr }));
+    expect(msg).toContain('DNS');
+  });
+
+  it('detects connection refused', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'ECONNREFUSED 127.0.0.1:443' }));
+    expect(msg).toContain('refused');
+  });
+
+  it('detects network timeout in stderr', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'npm ERR! network timeout at: https://registry.npmjs.org' }));
+    expect(msg).toContain('timed out');
+  });
+
+  it('detects TLS interception', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' }));
+    expect(msg).toContain('TLS');
+  });
+
+  it('detects 404 package not found', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'npm ERR! 404 Not Found - GET https://registry.npmjs.org/skills' }));
+    expect(msg).toContain('404');
+  });
+
+  it('detects permission denied', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'EACCES: permission denied, mkdir /usr/local/lib/node_modules' }));
+    expect(msg).toContain('permission');
+  });
+
+  it('detects disk full', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'ENOSPC: no space left on device' }));
+    expect(msg).toContain('disk');
+  });
+
+  it('detects npm auth failure', () => {
+    const msg = describeExecError(execError({ code: 1, stderr: 'npm ERR! code E401\nnpm ERR! authentication required' }));
+    expect(msg).toContain('authentication');
+  });
+
+  it('falls back to exit code for unrecognized failures', () => {
+    const msg = describeExecError(execError({ code: 42, stderr: 'some weird unclassified error' }));
+    expect(msg).toContain('42');
+  });
+
+  it('falls back to error message when no other info', () => {
+    const msg = describeExecError(execError({ message: 'mystery' }));
+    expect(msg).toContain('mystery');
+  });
+
+  it('prefers timeout classification over a populated stderr', () => {
+    const msg = describeExecError(execError({
+      killed: true,
+      signal: 'SIGTERM',
+      code: 1,
+      stderr: 'ENOTFOUND registry.npmjs.org',
+    }));
+    expect(msg).toContain('timed out');
+    expect(msg).not.toContain('DNS');
+  });
+
+  it('handles Buffer stderr', () => {
+    const err = execError({ code: 1 });
+    (err as unknown as { stderr: Buffer }).stderr = Buffer.from('EACCES: permission denied');
+    expect(describeExecError(err)).toContain('permission');
+  });
+});
+
+describe('reportCliUsage', () => {
+  const explicitConfig = { oss_host: 'https://proj.region.insforge.app', api_key: 'test-key' };
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('uses the explicit config when provided (does not touch filesystem)', async () => {
+    await reportCliUsage('cli.link', true, 1, explicitConfig);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://proj.region.insforge.app/api/usage/mcp');
+
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('test-key');
+    expect(headers['Content-Type']).toBe('application/json');
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.tool_name).toBe('cli.link');
+    expect(body.success).toBe(true);
+    expect(typeof body.timestamp).toBe('string');
+  });
+
+  it('stops retrying once a non-5xx response arrives', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await reportCliUsage('cli.link', true, 5, explicitConfig);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends success=false for failures', async () => {
+    await reportCliUsage('cli.link', false, 1, explicitConfig);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.success).toBe(false);
+  });
+});

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -9,7 +9,7 @@ const execAsync = promisify(exec);
 
 const SKILL_INSTALL_TIMEOUT_MS = 60_000;
 
-function describeExecError(err: unknown): string {
+export function describeExecError(err: unknown): string {
   const e = err as {
     killed?: boolean;
     signal?: string;


### PR DESCRIPTION
Stacked on top of #62.

## Summary

- **Unit tests** for the error-message work in #62:
  - `formatFetchError` — every undici cause code (ENOTFOUND, EAI_AGAIN, ECONNREFUSED, ETIMEDOUT, UND_ERR_CONNECT_TIMEOUT, ECONNRESET, cert errors) plus fallbacks for unknown codes, non-"fetch failed" errors, and non-Error inputs.
  - `describeExecError` — timeout (SIGTERM/SIGKILL), ENOENT, and each stderr classifier (DNS, ECONNREFUSED, network timeout, TLS, 404, EACCES, ENOSPC, npm auth), plus priority (timeout beats a populated stderr) and Buffer stderr handling.
  - `reportCliUsage` with explicit config — verifies the `--template` regression fix sends the event without touching the filesystem, retry stops on non-5xx, success=false propagates.
- **`lint` runs tests first.** `npm run lint` now runs vitest, then eslint — one command gates both. CI and the publish workflow call `npm run lint` before build, so tests gate shipping without a duplicate step.
- **`prepublishOnly`** chains `lint && build`, so npm publish fails if a test fails.
- **Version bump** `0.1.45` → `0.1.46`.

## Test plan

- [x] `npm run lint` — 46 tests pass, eslint clean (preexisting unused-var warning unchanged).
- [x] `npm run prepublishOnly` — full chain green.
- [x] `node dist/index.js --version` prints `0.1.46`.
- [x] `node dist/index.js --api-url https://definitely-not-a-real-host-xyz.example orgs list` produces the new DNS-failure message, not "fetch failed".
- [ ] CI on this PR green on `Test & lint` + `Build`.
- [ ] Confirm publish workflow picks up the new `Test & lint` step on next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)