### PR TITLE
fix(link): polished "What's next" block — numbered, colorized, single copy-paste command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.38",
+  "version": "0.1.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.38",
+      "version": "0.1.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
@@ -15,6 +15,7 @@
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
         "open": "^10.1.0",
+        "picocolors": "^1.1.1",
         "posthog-node": "^5.28.9"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@insforge/cli",
-
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {
@@ -40,6 +39,7 @@
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",
     "open": "^10.1.0",
+    "picocolors": "^1.1.1",
     "posthog-node": "^5.28.9"
   },
   "devDependencies": {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -4,6 +4,7 @@ import { promisify } from 'node:util';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as clack from '@clack/prompts';
+import pc from 'picocolors';
 import {
   listOrganizations,
   listProjects,
@@ -264,11 +265,14 @@ export function registerProjectLinkCommand(program: Command): void {
 
           if (!json) {
             const dashboardUrl = `${getFrontendUrl()}/dashboard/project/${project.id}`;
-            clack.log.step(`Dashboard: ${dashboardUrl}`);
+            clack.log.step(`Dashboard: ${pc.underline(dashboardUrl)}`);
             if (templateDownloaded) {
-              const steps = [`cd ${dirName}`, 'npm run dev'];
-              clack.note(steps.join('\n'), 'Next steps');
-              clack.note('Open your coding agent (Claude Code, Codex, Cursor, etc.) to add new features.', 'Keep building');
+              const runCommand = `${pc.cyan('cd')} ${pc.green(dirName)} ${pc.dim('&&')} ${pc.cyan('npm run dev')}`;
+              const steps = [
+                `${pc.bold('1.')} ${runCommand}`,
+                `${pc.bold('2.')} Open ${pc.cyan('Claude Code')} or ${pc.cyan('Cursor')} and prompt your agent to add more features`,
+              ];
+              clack.note(steps.join('\n'), "What's next");
             } else {
               clack.log.warn('Template download failed. You can retry or set up manually.');
             }


### PR DESCRIPTION
## Summary

After `link --template`, the CLI used to print two adjacent clack notes:

```
┌  Next steps  ───┐
│  cd my-app      │
│  npm run dev    │
└─────────────────┘
┌  Keep building  ──────────────────┐
│  Open your coding agent (Claude…) │
└───────────────────────────────────┘
```

Now it prints one block, numbered, with `cd && npm run dev` joined into a single copy-paste:

```
◇  What's next ──────────────────────────────────────────────────────────────╮
│                                                                            │
│  1. cd my-app && npm run dev                                               │
│  2. Open Claude Code or Cursor and prompt your agent to add more features  │
│                                                                            │
├────────────────────────────────────────────────────────────────────────────╯
```

Tokens are colorized via picocolors: `cd` / `npm run dev` / `Claude Code` / `Cursor` cyan, `my-app` green, `&&` dim, dashboard URL underlined. (Colors don't show in this captured snippet.)

`picocolors` was already in the dep tree transitively via `@clack/prompts`; bumped to a direct dep since we now import it ourselves.

## Test plan

- [ ] `insforge link --project-id <id> --template todo` from a real terminal — confirm the new combined "What's next" block renders with colors and step 1 is a single working copy-paste.
- [ ] Same command from Claude Code's bash — confirm output is still readable when ANSI codes get stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish the `link` command's "What's next" output with numbered steps and colors
> Updates the post-link console output in [`src/commands/projects/link.ts`](https://github.com/InsForge/CLI/pull/65/files#diff-6269c2fca99bb2d083ae08500308831e3517ee388ca483fcf29fe05fa226fb2b) using `picocolors`. The dashboard URL is now underlined, next steps are numbered and color-coded, and the separate "Keep building" note is removed. The combined run command is printed as a single copy-pasteable string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0a40db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced CLI output after template download: colorized, underlined links and a clearer, numbered "What's next" with a single highlighted command and explicit guidance to prompt your agent for more features.

* **Chores**
  * Version bumped to 0.1.48.
  * Added a runtime dependency for colorized terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->