### PR TITLE
feat(prompts): make CLI work in non-TTY shells (Claude Code, Cursor, CI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as clack from '@clack/prompts';
+import * as prompts from '../lib/prompts.js';
 import {
   listOrganizations,
   createProject,
@@ -181,15 +182,15 @@ export function registerCreateCommand(program: Command): void {
             if (json) {
               throw new CLIError('Multiple organizations found. Specify --org-id.');
             }
-            const selected = await clack.select({
+            const selected = await prompts.select<string>({
               message: 'Select an organization:',
               options: orgs.map((o) => ({
                 value: o.id,
                 label: o.name,
               })),
             });
-            if (clack.isCancel(selected)) process.exit(0);
-            orgId = selected as string;
+            if (prompts.isCancel(selected)) process.exit(0);
+            orgId = selected;
           }
         }
 
@@ -203,13 +204,13 @@ export function registerCreateCommand(program: Command): void {
         if (!projectName) {
           if (json) throw new CLIError('--name is required in JSON mode.');
           const defaultName = getDefaultProjectName();
-          const name = await clack.text({
+          const name = await prompts.text({
             message: 'Project name:',
             ...(defaultName ? { initialValue: defaultName } : {}),
             validate: (v) => (v.length >= 2 ? undefined : 'Name must be at least 2 characters'),
           });
-          if (clack.isCancel(name)) process.exit(0);
-          projectName = name as string;
+          if (prompts.isCancel(name)) process.exit(0);
+          projectName = name;
         }
 
         // Sanitize project name to prevent path traversal
@@ -228,23 +229,23 @@ export function registerCreateCommand(program: Command): void {
           if (json) {
             template = 'empty';
           } else {
-            const approach = await clack.select({
+            const approach = await prompts.select<string>({
               message: 'How would you like to start?',
               options: [
                 { value: 'blank', label: 'Blank project', hint: 'Start from scratch with .env.local ready' },
                 { value: 'template', label: 'Start from a template', hint: 'Pre-built starter apps' },
               ],
             });
-            if (clack.isCancel(approach)) process.exit(0);
+            if (prompts.isCancel(approach)) process.exit(0);
 
             captureEvent(orgId, 'create_approach_selected', {
-              approach: approach as string,
+              approach,
             });
 
             if (approach === 'blank') {
               template = 'empty';
             } else {
-              const selected = await clack.select({
+              const selected = await prompts.select<string>({
                 message: 'Choose a starter template:',
                 options: [
                   { value: 'react', label: 'Web app template with React' },
@@ -255,8 +256,8 @@ export function registerCreateCommand(program: Command): void {
                   { value: 'todo', label: 'Todo app with Next.js' },
                 ],
               });
-              if (clack.isCancel(selected)) process.exit(0);
-              template = selected as string;
+              if (prompts.isCancel(selected)) process.exit(0);
+              template = selected;
             }
           }
         }
@@ -275,7 +276,7 @@ export function registerCreateCommand(program: Command): void {
         if (hasTemplate) {
           dirName = projectName;
           if (!json) {
-            const inputDir = await clack.text({
+            const inputDir = await prompts.text({
               message: 'Directory name:',
               initialValue: projectName,
               validate: (v) => {
@@ -285,8 +286,8 @@ export function registerCreateCommand(program: Command): void {
                 return undefined;
               },
             });
-            if (clack.isCancel(inputDir)) process.exit(0);
-            dirName = path.basename(inputDir as string).replace(/[^a-zA-Z0-9._-]/g, '-');
+            if (prompts.isCancel(inputDir)) process.exit(0);
+            dirName = path.basename(inputDir).replace(/[^a-zA-Z0-9._-]/g, '-');
           }
 
           // Validate normalized dirName
@@ -396,11 +397,11 @@ export function registerCreateCommand(program: Command): void {
         // 9. Offer to deploy (template projects, interactive mode only)
         let liveUrl: string | null = null;
         if (templateDownloaded && !json) {
-          const shouldDeploy = await clack.confirm({
+          const shouldDeploy = await prompts.confirm({
             message: 'Would you like to deploy now?',
           });
 
-          if (!clack.isCancel(shouldDeploy) && shouldDeploy) {
+          if (!prompts.isCancel(shouldDeploy) && shouldDeploy) {
             try {
               // Read env vars from .env.local or .env to pass to deployment
               const envVars = await readEnvFile(process.cwd());

--- a/src/commands/deployments/cancel.ts
+++ b/src/commands/deployments/cancel.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import * as clack from '@clack/prompts';
+import * as prompts from '../../lib/prompts.js';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { getProjectConfig } from '../../lib/config.js';
@@ -17,10 +17,10 @@ export function registerDeploymentsCancelCommand(deploymentsCmd: Command): void 
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
 
         if (!yes && !json) {
-          const confirmed = await clack.confirm({
+          const confirmed = await prompts.confirm({
             message: `Cancel deployment ${id}?`,
           });
-          if (clack.isCancel(confirmed) || !confirmed) process.exit(0);
+          if (prompts.isCancel(confirmed) || !confirmed) process.exit(0);
         }
 
         const res = await ossFetch(`/api/deployments/${id}/cancel`, { method: 'POST' });

--- a/src/commands/diagnose/index.ts
+++ b/src/commands/diagnose/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import * as os from 'node:os';
 import * as clack from '@clack/prompts';
+import * as prompts from '../../lib/prompts.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError, ProjectNotLinkedError } from '../../lib/errors.js';
 import { getProjectConfig, FAKE_PROJECT_ID } from '../../lib/config.js';
@@ -255,7 +256,7 @@ export function registerDiagnoseCommands(diagnoseCmd: Command): void {
 
           // Optional rating prompt (interactive only)
           if (!json && sessionId) {
-            const ratingChoice = await clack.select({
+            const ratingChoice = await prompts.select<string>({
               message: 'Was this analysis helpful?',
               options: [
                 { value: 'skip', label: 'Skip', hint: 'no rating' },
@@ -265,7 +266,7 @@ export function registerDiagnoseCommands(diagnoseCmd: Command): void {
               ],
             });
 
-            if (!clack.isCancel(ratingChoice) && ratingChoice !== 'skip') {
+            if (!prompts.isCancel(ratingChoice) && ratingChoice !== 'skip') {
               try {
                 await rateDiagnosticSession(
                   sessionId,

--- a/src/commands/functions/delete.ts
+++ b/src/commands/functions/delete.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import * as clack from '@clack/prompts';
+import * as prompts from '../../lib/prompts.js';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
@@ -17,10 +18,10 @@ export function registerFunctionsDeleteCommand(functionsCmd: Command): void {
         await requireAuth();
 
         if (!yes && !json) {
-          const confirmed = await clack.confirm({
+          const confirmed = await prompts.confirm({
             message: `Delete function "${slug}"? This cannot be undone.`,
           });
-          if (clack.isCancel(confirmed) || !confirmed) {
+          if (prompts.isCancel(confirmed) || !confirmed) {
             clack.log.info('Cancelled.');
             return;
           }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import * as clack from '@clack/prompts';
+import * as prompts from '../lib/prompts.js';
 import { saveCredentials } from '../lib/config.js';
 import { login as platformLogin } from '../lib/api/platform.js';
 import { performOAuthLogin } from '../lib/auth.js';
@@ -37,23 +38,23 @@ async function loginWithEmail(json: boolean, apiUrl?: string): Promise<void> {
 
   const email = json
     ? process.env.INSFORGE_EMAIL
-    : await clack.text({
+    : await prompts.text({
         message: 'Email:',
         validate: (v) => (v.includes('@') ? undefined : 'Please enter a valid email'),
       });
 
-  if (clack.isCancel(email)) {
+  if (prompts.isCancel(email)) {
     clack.cancel('Login cancelled.');
     throw new Error('cancelled');
   }
 
   const password = json
     ? process.env.INSFORGE_PASSWORD
-    : await clack.password({
+    : await prompts.password({
         message: 'Password:',
       });
 
-  if (clack.isCancel(password)) {
+  if (prompts.isCancel(password)) {
     clack.cancel('Login cancelled.');
     throw new Error('cancelled');
   }

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -5,6 +5,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as clack from '@clack/prompts';
 import pc from 'picocolors';
+import * as prompts from '../../lib/prompts.js';
 import {
   listOrganizations,
   listProjects,
@@ -108,15 +109,15 @@ export function registerProjectLinkCommand(program: Command): void {
             if (json) {
               throw new CLIError('Multiple organizations found. Specify --org-id.');
             }
-            const selected = await clack.select({
+            const selected = await prompts.select<string>({
               message: 'Select an organization:',
               options: orgs.map((o) => ({
                 value: o.id,
                 label: o.name,
               })),
             });
-            if (clack.isCancel(selected)) process.exit(0);
-            orgId = selected as string;
+            if (prompts.isCancel(selected)) process.exit(0);
+            orgId = selected;
           }
         }
 
@@ -134,15 +135,15 @@ export function registerProjectLinkCommand(program: Command): void {
           if (json) {
             throw new CLIError('Specify --project-id in JSON mode.');
           }
-          const selected = await clack.select({
+          const selected = await prompts.select<string>({
             message: 'Select a project to link:',
             options: projects.map((p) => ({
               value: p.id,
               label: `${p.name} (${p.region}, ${p.status})`,
             })),
           });
-          if (clack.isCancel(selected)) process.exit(0);
-          projectId = selected as string;
+          if (prompts.isCancel(selected)) process.exit(0);
+          projectId = selected;
         }
 
         // Fetch project details and API key
@@ -204,7 +205,7 @@ export function registerProjectLinkCommand(program: Command): void {
           // Ask for directory name
           let dirName = project.name;
           if (!json) {
-            const inputDir = await clack.text({
+            const inputDir = await prompts.text({
               message: 'Directory name:',
               initialValue: project.name,
               validate: (v) => {
@@ -214,8 +215,8 @@ export function registerProjectLinkCommand(program: Command): void {
                 return undefined;
               },
             });
-            if (clack.isCancel(inputDir)) process.exit(0);
-            dirName = path.basename(inputDir as string).replace(/[^a-zA-Z0-9._-]/g, '-');
+            if (prompts.isCancel(inputDir)) process.exit(0);
+            dirName = path.basename(inputDir).replace(/[^a-zA-Z0-9._-]/g, '-');
           }
 
           if (!dirName || dirName === '.' || dirName === '..') {

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import * as clack from '@clack/prompts';
+import * as prompts from '../../lib/prompts.js';
 import { listOrganizations, listProjects } from '../../lib/api/platform.js';
 import { getGlobalConfig } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
@@ -27,17 +27,17 @@ export function registerProjectsCommands(projectsCmd: Command): void {
           if (orgs.length === 1) {
             orgId = orgs[0].id;
           } else if (!json) {
-            const selected = await clack.select({
+            const selected = await prompts.select<string>({
               message: 'Select an organization:',
               options: orgs.map((o) => ({
                 value: o.id,
                 label: o.name,
               })),
             });
-            if (clack.isCancel(selected)) {
+            if (prompts.isCancel(selected)) {
               process.exit(0);
             }
-            orgId = selected as string;
+            orgId = selected;
           } else {
             throw new CLIError('Multiple organizations found. Specify --org-id.');
           }

--- a/src/commands/schedules/delete.ts
+++ b/src/commands/schedules/delete.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import * as clack from '@clack/prompts';
+import * as prompts from '../../lib/prompts.js';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
@@ -15,10 +15,10 @@ export function registerSchedulesDeleteCommand(schedulesCmd: Command): void {
         await requireAuth();
 
         if (!yes && !json) {
-          const confirm = await clack.confirm({
+          const confirm = await prompts.confirm({
             message: `Delete schedule "${id}"? This cannot be undone.`,
           });
-          if (!confirm || clack.isCancel(confirm)) {
+          if (prompts.isCancel(confirm) || !confirm) {
             process.exit(0);
           }
         }

--- a/src/commands/secrets/delete.ts
+++ b/src/commands/secrets/delete.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import * as clack from '@clack/prompts';
+import * as prompts from '../../lib/prompts.js';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
@@ -16,10 +16,10 @@ export function registerSecretsDeleteCommand(secretsCmd: Command): void {
         await requireAuth();
 
         if (!yes && !json) {
-          const confirm = await clack.confirm({
+          const confirm = await prompts.confirm({
             message: `Delete secret "${key}"? This cannot be undone.`,
           });
-          if (!confirm || clack.isCancel(confirm)) {
+          if (prompts.isCancel(confirm) || !confirm) {
             process.exit(0);
           }
         }

--- a/src/commands/storage/delete-bucket.ts
+++ b/src/commands/storage/delete-bucket.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import * as clack from '@clack/prompts';
+import * as prompts from '../../lib/prompts.js';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
@@ -15,10 +15,10 @@ export function registerStorageDeleteBucketCommand(storageCmd: Command): void {
         await requireAuth();
 
         if (!yes && !json) {
-          const confirm = await clack.confirm({
+          const confirm = await prompts.confirm({
             message: `Delete bucket "${name}" and all its objects? This cannot be undone.`,
           });
-          if (!confirm || clack.isCancel(confirm)) {
+          if (prompts.isCancel(confirm) || !confirm) {
             process.exit(0);
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import * as clack from '@clack/prompts';
+import * as prompts from './lib/prompts.js';
 import { getCredentials, getProjectConfig } from './lib/config.js';
 import { registerLoginCommand } from './commands/login.js';
 import { registerLogoutCommand } from './commands/logout.js';
@@ -242,12 +243,12 @@ async function showInteractiveMenu(): Promise<void> {
     { value: 'help', label: 'Show all commands' },
   );
 
-  const action = await clack.select({
+  const action = await prompts.select<string>({
     message: 'What would you like to do?',
     options,
   });
 
-  if (clack.isCancel(action)) {
+  if (prompts.isCancel(action)) {
     clack.cancel('Bye!');
     process.exit(0);
   }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -227,8 +227,9 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
     clack.log.info('Opening browser for authentication...');
     clack.log.info(`If browser doesn't open, visit:\n${authUrl}`);
   } else {
-    // Non-TTY (agent shell): surface the URL prominently so the agent can relay it to the human
-    process.stdout.write(`\nTo sign in, open this URL in your browser:\n\n  ${pc.cyan(pc.underline(authUrl))}\n\n`);
+    // Non-TTY (agent shell): surface the URL prominently via stderr so it stays out of
+    // any JSON stdout stream but is still visible to agents and humans.
+    process.stderr.write(`\nTo sign in, open this URL in your browser:\n\n  ${pc.cyan(pc.underline(authUrl))}\n\n`);
   }
 
   // 4. Open browser (best effort — often works even from agent shells since we're on the same machine)
@@ -242,7 +243,7 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
   // 5. Wait for callback — use clack spinner only in TTY (non-TTY spinner renders garbage)
   const s = isInteractive ? clack.spinner() : null;
   s?.start('Waiting for authentication...');
-  if (!isInteractive) process.stdout.write('Waiting for authentication...\n');
+  if (!isInteractive) process.stderr.write('Waiting for authentication...\n');
 
   try {
     const callbackResult = await result;
@@ -277,17 +278,17 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
       creds.user = profile;
       saveCredentials(creds);
       s?.stop(`Authenticated as ${profile.email}`);
-      if (!isInteractive) process.stdout.write(`Authenticated as ${profile.email}\n`);
+      if (!isInteractive) process.stderr.write(`Authenticated as ${profile.email}\n`);
     } catch {
       s?.stop('Authenticated successfully');
-      if (!isInteractive) process.stdout.write('Authenticated successfully\n');
+      if (!isInteractive) process.stderr.write('Authenticated successfully\n');
     }
 
     return creds;
   } catch (err) {
     close();
     s?.stop('Authentication failed');
-    if (!isInteractive) process.stdout.write('Authentication failed\n');
+    if (!isInteractive) process.stderr.write('Authentication failed\n');
     throw err;
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,8 @@ import { createServer } from 'node:http';
 import { randomBytes, createHash } from 'node:crypto';
 import { URL } from 'node:url';
 import * as clack from '@clack/prompts';
+import pc from 'picocolors';
+import { isInteractive } from './prompts.js';
 import { getGlobalConfig, getPlatformApiUrl, saveCredentials } from './config.js';
 import { getProfile } from './api/platform.js';
 import { formatFetchError } from './errors.js';
@@ -221,20 +223,26 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
     scopes: OAUTH_SCOPES,
   });
 
-  clack.log.info('Opening browser for authentication...');
-  clack.log.info(`If browser doesn't open, visit:\n${authUrl}`);
+  if (isInteractive) {
+    clack.log.info('Opening browser for authentication...');
+    clack.log.info(`If browser doesn't open, visit:\n${authUrl}`);
+  } else {
+    // Non-TTY (agent shell): surface the URL prominently so the agent can relay it to the human
+    process.stdout.write(`\nTo sign in, open this URL in your browser:\n\n  ${pc.cyan(pc.underline(authUrl))}\n\n`);
+  }
 
-  // 4. Open browser
+  // 4. Open browser (best effort — often works even from agent shells since we're on the same machine)
   try {
     const open = (await import('open')).default;
     await open(authUrl);
   } catch {
-    clack.log.warn('Could not open browser. Please visit the URL above.');
+    if (isInteractive) clack.log.warn('Could not open browser. Please visit the URL above.');
   }
 
-  // 5. Wait for callback
-  const s = clack.spinner();
-  s.start('Waiting for authentication...');
+  // 5. Wait for callback — use clack spinner only in TTY (non-TTY spinner renders garbage)
+  const s = isInteractive ? clack.spinner() : null;
+  s?.start('Waiting for authentication...');
+  if (!isInteractive) process.stdout.write('Waiting for authentication...\n');
 
   try {
     const callbackResult = await result;
@@ -242,12 +250,12 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
 
     // Verify state
     if (callbackResult.state !== state) {
-      s.stop('Authentication failed');
+      s?.stop('Authentication failed');
       throw new Error('State mismatch. Possible CSRF attack.');
     }
 
     // 6. Exchange code for tokens
-    s.message('Exchanging authorization code...');
+    s?.message('Exchanging authorization code...');
     const tokens = await exchangeCodeForTokens({
       platformUrl,
       code: callbackResult.code,
@@ -268,15 +276,18 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
       const profile = await getProfile(apiUrl);
       creds.user = profile;
       saveCredentials(creds);
-      s.stop(`Authenticated as ${profile.email}`);
+      s?.stop(`Authenticated as ${profile.email}`);
+      if (!isInteractive) process.stdout.write(`Authenticated as ${profile.email}\n`);
     } catch {
-      s.stop('Authenticated successfully');
+      s?.stop('Authenticated successfully');
+      if (!isInteractive) process.stdout.write('Authenticated successfully\n');
     }
 
     return creds;
   } catch (err) {
     close();
-    s.stop('Authentication failed');
+    s?.stop('Authentication failed');
+    if (!isInteractive) process.stdout.write('Authentication failed\n');
     throw err;
   }
 }

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -2,6 +2,7 @@ import { getCredentials, getGlobalConfig, getPlatformApiUrl, saveCredentials, ge
 import { AuthError } from './errors.js';
 import { refreshOAuthToken, DEFAULT_CLIENT_ID, performOAuthLogin } from './auth.js';
 import * as clack from '@clack/prompts';
+import * as prompts from './prompts.js';
 import type { StoredCredentials } from '../types.js';
 
 export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promise<StoredCredentials> {
@@ -34,8 +35,8 @@ export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promi
       const msg = err instanceof Error ? err.message : 'Unknown error';
       clack.log.error(`Login failed: ${msg}`);
 
-      const retry = await clack.confirm({ message: 'Would you like to try again?' });
-      if (clack.isCancel(retry) || !retry) {
+      const retry = await prompts.confirm({ message: 'Would you like to try again?' });
+      if (prompts.isCancel(retry) || !retry) {
         throw new AuthError('Authentication required. Run `npx @insforge/cli login` to authenticate.');
       }
     }

--- a/src/lib/prompts.test.ts
+++ b/src/lib/prompts.test.ts
@@ -67,6 +67,13 @@ describe('nonTtyText', () => {
     h.end();
     expect(await p).toBe(CANCEL);
   });
+
+  it('preserves whitespace when trim is false (for passwords)', async () => {
+    const h = harness();
+    const p = nonTtyText({ message: 'Secret?', trim: false }, { reader: h.reader, stderr: h.stderr });
+    h.write('  spaces matter  \n');
+    expect(await p).toBe('  spaces matter  ');
+  });
 });
 
 describe('nonTtySelect', () => {
@@ -147,6 +154,16 @@ describe('nonTtySelect', () => {
     );
     h.end();
     expect(await p).toBe(CANCEL);
+  });
+
+  it('throws when options list is empty (no infinite loop)', async () => {
+    const h = harness();
+    await expect(
+      nonTtySelect<string>(
+        { message: 'Pick:', options: [] },
+        { reader: h.reader, stdout: h.stdout, stderr: h.stderr },
+      ),
+    ).rejects.toThrow(/No options available/);
   });
 });
 

--- a/src/lib/prompts.test.ts
+++ b/src/lib/prompts.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { nonTtyText, nonTtySelect, nonTtyConfirm, isCancel, CANCEL, LineReader } from './prompts.js';
+
+function harness() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const stderr = new PassThrough();
+  const reader = new LineReader(input, output);
+
+  const outChunks: string[] = [];
+  const errChunks: string[] = [];
+  output.on('data', (c) => outChunks.push(c.toString()));
+  stderr.on('data', (c) => errChunks.push(c.toString()));
+
+  return {
+    reader,
+    stdout: output,
+    stderr,
+    write: (line: string) => input.write(line),
+    end: () => input.end(),
+    stdout_text: () => outChunks.join(''),
+    stderr_text: () => errChunks.join(''),
+  };
+}
+
+describe('nonTtyText', () => {
+  it('reads a single line answer', async () => {
+    const h = harness();
+    const p = nonTtyText({ message: 'Name?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('alice\n');
+    expect(await p).toBe('alice');
+  });
+
+  it('trims whitespace from input', async () => {
+    const h = harness();
+    const p = nonTtyText({ message: 'Name?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('  bob  \n');
+    expect(await p).toBe('bob');
+  });
+
+  it('uses initialValue when input is empty', async () => {
+    const h = harness();
+    const p = nonTtyText({ message: 'Name?', initialValue: 'default' }, { reader: h.reader, stderr: h.stderr });
+    h.write('\n');
+    expect(await p).toBe('default');
+  });
+
+  it('retries when validate returns an error', async () => {
+    const h = harness();
+    const p = nonTtyText(
+      {
+        message: 'Name?',
+        validate: (v) => (v.length < 3 ? 'too short' : undefined),
+      },
+      { reader: h.reader, stderr: h.stderr },
+    );
+    h.write('hi\n');
+    h.write('hello\n');
+    expect(await p).toBe('hello');
+    expect(h.stderr_text()).toContain('too short');
+  });
+
+  it('returns CANCEL on stdin EOF', async () => {
+    const h = harness();
+    const p = nonTtyText({ message: 'Name?' }, { reader: h.reader, stderr: h.stderr });
+    h.end();
+    expect(await p).toBe(CANCEL);
+  });
+});
+
+describe('nonTtySelect', () => {
+  it('resolves numeric answer to the option value', async () => {
+    const h = harness();
+    const p = nonTtySelect<string>(
+      {
+        message: 'Pick:',
+        options: [
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta' },
+          { value: 'c', label: 'Charlie' },
+        ],
+      },
+      { reader: h.reader, stdout: h.stdout, stderr: h.stderr },
+    );
+    h.write('2\n');
+    expect(await p).toBe('b');
+  });
+
+  it('prints numbered list with labels and hints', async () => {
+    const h = harness();
+    const p = nonTtySelect<string>(
+      {
+        message: 'Pick:',
+        options: [
+          { value: 'a', label: 'Alpha', hint: 'the first one' },
+          { value: 'b', label: 'Beta' },
+        ],
+      },
+      { reader: h.reader, stdout: h.stdout, stderr: h.stderr },
+    );
+    h.write('1\n');
+    await p;
+    const out = h.stdout_text();
+    expect(out).toContain('1) Alpha');
+    expect(out).toContain('the first one');
+    expect(out).toContain('2) Beta');
+  });
+
+  it('retries on out-of-range input', async () => {
+    const h = harness();
+    const p = nonTtySelect<string>(
+      {
+        message: 'Pick:',
+        options: [
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta' },
+        ],
+      },
+      { reader: h.reader, stdout: h.stdout, stderr: h.stderr },
+    );
+    h.write('5\n');
+    h.write('1\n');
+    expect(await p).toBe('a');
+    expect(h.stderr_text()).toContain('between 1 and 2');
+  });
+
+  it('retries on non-numeric input', async () => {
+    const h = harness();
+    const p = nonTtySelect<string>(
+      {
+        message: 'Pick:',
+        options: [{ value: 'a', label: 'Alpha' }],
+      },
+      { reader: h.reader, stdout: h.stdout, stderr: h.stderr },
+    );
+    h.write('hello\n');
+    h.write('1\n');
+    expect(await p).toBe('a');
+  });
+
+  it('returns CANCEL on EOF', async () => {
+    const h = harness();
+    const p = nonTtySelect<string>(
+      { message: 'Pick:', options: [{ value: 'a', label: 'Alpha' }] },
+      { reader: h.reader, stdout: h.stdout, stderr: h.stderr },
+    );
+    h.end();
+    expect(await p).toBe(CANCEL);
+  });
+});
+
+describe('nonTtyConfirm', () => {
+  it('returns true for "y"', async () => {
+    const h = harness();
+    const p = nonTtyConfirm({ message: 'OK?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('y\n');
+    expect(await p).toBe(true);
+  });
+
+  it('returns true for "yes"', async () => {
+    const h = harness();
+    const p = nonTtyConfirm({ message: 'OK?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('yes\n');
+    expect(await p).toBe(true);
+  });
+
+  it('returns false for "n"', async () => {
+    const h = harness();
+    const p = nonTtyConfirm({ message: 'OK?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('n\n');
+    expect(await p).toBe(false);
+  });
+
+  it('uses initialValue on empty input', async () => {
+    const h = harness();
+    const p = nonTtyConfirm({ message: 'OK?', initialValue: true }, { reader: h.reader, stderr: h.stderr });
+    h.write('\n');
+    expect(await p).toBe(true);
+  });
+
+  it('is case-insensitive', async () => {
+    const h = harness();
+    const p = nonTtyConfirm({ message: 'OK?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('YES\n');
+    expect(await p).toBe(true);
+  });
+
+  it('retries on unrecognized input', async () => {
+    const h = harness();
+    const p = nonTtyConfirm({ message: 'OK?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('maybe\n');
+    h.write('y\n');
+    expect(await p).toBe(true);
+    expect(h.stderr_text()).toContain('Please answer y or n');
+  });
+
+  it('returns CANCEL on EOF', async () => {
+    const h = harness();
+    const p = nonTtyConfirm({ message: 'OK?' }, { reader: h.reader, stderr: h.stderr });
+    h.end();
+    expect(await p).toBe(CANCEL);
+  });
+});
+
+describe('isCancel', () => {
+  it('recognizes our CANCEL symbol', () => {
+    expect(isCancel(CANCEL)).toBe(true);
+  });
+
+  it('returns false for regular values', () => {
+    expect(isCancel('hello')).toBe(false);
+    expect(isCancel(42)).toBe(false);
+    expect(isCancel(null)).toBe(false);
+  });
+});
+
+describe('multiple prompts sharing one readline interface', () => {
+  it('consumes sequential lines from the same pipe', async () => {
+    const h = harness();
+    const p1 = nonTtyText({ message: 'First?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('one\n');
+    expect(await p1).toBe('one');
+
+    const p2 = nonTtyText({ message: 'Second?' }, { reader: h.reader, stderr: h.stderr });
+    h.write('two\n');
+    expect(await p2).toBe('two');
+
+    const p3 = nonTtySelect<string>(
+      { message: 'Third?', options: [{ value: 'x', label: 'X' }, { value: 'y', label: 'Y' }] },
+      { reader: h.reader, stdout: h.stdout, stderr: h.stderr },
+    );
+    h.write('2\n');
+    expect(await p3).toBe('y');
+  });
+
+  it('handles buffered multi-line input written at once', async () => {
+    const h = harness();
+    h.write('alpha\nbeta\n');
+
+    const p1 = nonTtyText({ message: 'A?' }, { reader: h.reader, stderr: h.stderr });
+    expect(await p1).toBe('alpha');
+
+    const p2 = nonTtyText({ message: 'B?' }, { reader: h.reader, stderr: h.stderr });
+    expect(await p2).toBe('beta');
+  });
+});

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,0 +1,205 @@
+import * as readline from 'node:readline';
+import * as clack from '@clack/prompts';
+
+export const isInteractive = !!(process.stdin.isTTY && process.stdout.isTTY);
+
+/**
+ * A line reader that buffers parsed lines and exposes a pull-based readLine API.
+ *
+ * readline.promises.question() loses 'line' events that fire between question() calls,
+ * and does not reject cleanly on stream close. A buffered queue handles both.
+ */
+export class LineReader {
+  private queue: string[] = [];
+  private waiter: ((line: string | null) => void) | null = null;
+  private closed = false;
+  private rl: readline.Interface;
+
+  constructor(
+    input: NodeJS.ReadableStream,
+    private output: NodeJS.WritableStream,
+  ) {
+    this.rl = readline.createInterface({ input });
+    this.rl.on('line', (line) => {
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        w(line);
+      } else {
+        this.queue.push(line);
+      }
+    });
+    this.rl.on('close', () => {
+      this.closed = true;
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        w(null);
+      }
+    });
+  }
+
+  async readLine(prompt: string): Promise<string | null> {
+    this.output.write(prompt);
+    if (this.queue.length > 0) return this.queue.shift()!;
+    if (this.closed) return null;
+    return new Promise((resolve) => {
+      this.waiter = resolve;
+    });
+  }
+
+  close(): void {
+    this.rl.close();
+  }
+}
+
+let sharedReader: LineReader | null = null;
+function getReader(): LineReader {
+  if (!sharedReader) {
+    sharedReader = new LineReader(process.stdin, process.stdout);
+  }
+  return sharedReader;
+}
+
+export const CANCEL: unique symbol = Symbol('prompt.cancel');
+export type CancelSymbol = typeof CANCEL;
+
+export function isCancel<T>(v: T | CancelSymbol): v is CancelSymbol {
+  return v === CANCEL || clack.isCancel(v);
+}
+
+export interface TextOptions {
+  message: string;
+  initialValue?: string;
+  placeholder?: string;
+  validate?: (value: string) => string | undefined;
+}
+
+export interface SelectOption<T> {
+  value: T;
+  label: string;
+  hint?: string;
+}
+
+export interface SelectOptions<T> {
+  message: string;
+  options: SelectOption<T>[];
+  initialValue?: T;
+}
+
+export interface ConfirmOptions {
+  message: string;
+  initialValue?: boolean;
+}
+
+export async function text(opts: TextOptions): Promise<string | CancelSymbol> {
+  if (isInteractive) {
+    const result = await clack.text({
+      message: opts.message,
+      initialValue: opts.initialValue,
+      placeholder: opts.placeholder,
+      validate: opts.validate,
+    });
+    if (clack.isCancel(result)) return CANCEL;
+    return result;
+  }
+  return nonTtyText(opts);
+}
+
+export async function select<T>(opts: SelectOptions<T>): Promise<T | CancelSymbol> {
+  if (isInteractive) {
+    const result = await clack.select({
+      message: opts.message,
+      options: opts.options as { value: T; label: string; hint?: string }[],
+      initialValue: opts.initialValue,
+    });
+    if (clack.isCancel(result)) return CANCEL;
+    return result as T;
+  }
+  return nonTtySelect(opts);
+}
+
+export async function confirm(opts: ConfirmOptions): Promise<boolean | CancelSymbol> {
+  if (isInteractive) {
+    const result = await clack.confirm({
+      message: opts.message,
+      initialValue: opts.initialValue,
+    });
+    if (clack.isCancel(result)) return CANCEL;
+    return result;
+  }
+  return nonTtyConfirm(opts);
+}
+
+export async function password(opts: { message: string }): Promise<string | CancelSymbol> {
+  if (isInteractive) {
+    const result = await clack.password({ message: opts.message });
+    if (clack.isCancel(result)) return CANCEL;
+    return result;
+  }
+  // Non-TTY: can't mask input over a pipe, just read it
+  return nonTtyText({ message: opts.message });
+}
+
+export async function nonTtyText(
+  opts: TextOptions,
+  io: { reader?: LineReader; stderr?: NodeJS.WritableStream } = {},
+): Promise<string | CancelSymbol> {
+  const reader = io.reader ?? getReader();
+  const stderr = io.stderr ?? process.stderr;
+  const defaultHint = opts.initialValue ? ` [${opts.initialValue}]` : '';
+  for (;;) {
+    const raw = await reader.readLine(`? ${opts.message}${defaultHint} `);
+    if (raw === null) return CANCEL;
+    const value = raw.trim() === '' ? (opts.initialValue ?? '') : raw.trim();
+    if (opts.validate) {
+      const err = opts.validate(value);
+      if (err) {
+        stderr.write(`  ${err}\n`);
+        continue;
+      }
+    }
+    return value;
+  }
+}
+
+export async function nonTtySelect<T>(
+  opts: SelectOptions<T>,
+  io: { reader?: LineReader; stdout?: NodeJS.WritableStream; stderr?: NodeJS.WritableStream } = {},
+): Promise<T | CancelSymbol> {
+  const reader = io.reader ?? getReader();
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  stdout.write(`? ${opts.message}\n`);
+  opts.options.forEach((o, i) => {
+    const hint = o.hint ? ` — ${o.hint}` : '';
+    stdout.write(`  ${i + 1}) ${o.label}${hint}\n`);
+  });
+  for (;;) {
+    const raw = await reader.readLine(`Enter number [1-${opts.options.length}]: `);
+    if (raw === null) return CANCEL;
+    const n = Number.parseInt(raw.trim(), 10);
+    if (Number.isInteger(n) && n >= 1 && n <= opts.options.length) {
+      return opts.options[n - 1].value;
+    }
+    stderr.write(`  Please enter a number between 1 and ${opts.options.length}.\n`);
+  }
+}
+
+export async function nonTtyConfirm(
+  opts: ConfirmOptions,
+  io: { reader?: LineReader; stderr?: NodeJS.WritableStream } = {},
+): Promise<boolean | CancelSymbol> {
+  const reader = io.reader ?? getReader();
+  const stderr = io.stderr ?? process.stderr;
+  const defaultHint = opts.initialValue === true ? ' [Y/n]' : opts.initialValue === false ? ' [y/N]' : ' [y/n]';
+  for (;;) {
+    const raw = await reader.readLine(`? ${opts.message}${defaultHint} `);
+    if (raw === null) return CANCEL;
+    const answer = raw.trim().toLowerCase();
+    if (answer === '' && opts.initialValue !== undefined) return opts.initialValue;
+    if (answer === 'y' || answer === 'yes') return true;
+    if (answer === 'n' || answer === 'no') return false;
+    stderr.write(`  Please answer y or n.\n`);
+  }
+}

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -137,21 +137,24 @@ export async function password(opts: { message: string }): Promise<string | Canc
     if (clack.isCancel(result)) return CANCEL;
     return result;
   }
-  // Non-TTY: can't mask input over a pipe, just read it
-  return nonTtyText({ message: opts.message });
+  // Non-TTY: can't mask input over a pipe, just read the line. Preserve whitespace
+  // since it can be valid in passwords.
+  return nonTtyText({ message: opts.message, trim: false });
 }
 
 export async function nonTtyText(
-  opts: TextOptions,
+  opts: TextOptions & { trim?: boolean },
   io: { reader?: LineReader; stderr?: NodeJS.WritableStream } = {},
 ): Promise<string | CancelSymbol> {
   const reader = io.reader ?? getReader();
   const stderr = io.stderr ?? process.stderr;
+  const shouldTrim = opts.trim ?? true;
   const defaultHint = opts.initialValue ? ` [${opts.initialValue}]` : '';
   for (;;) {
     const raw = await reader.readLine(`? ${opts.message}${defaultHint} `);
     if (raw === null) return CANCEL;
-    const value = raw.trim() === '' ? (opts.initialValue ?? '') : raw.trim();
+    const normalized = shouldTrim ? raw.trim() : raw;
+    const value = normalized === '' ? (opts.initialValue ?? '') : normalized;
     if (opts.validate) {
       const err = opts.validate(value);
       if (err) {
@@ -167,6 +170,9 @@ export async function nonTtySelect<T>(
   opts: SelectOptions<T>,
   io: { reader?: LineReader; stdout?: NodeJS.WritableStream; stderr?: NodeJS.WritableStream } = {},
 ): Promise<T | CancelSymbol> {
+  if (opts.options.length === 0) {
+    throw new Error(`No options available for prompt "${opts.message}".`);
+  }
   const reader = io.reader ?? getReader();
   const stdout = io.stdout ?? process.stdout;
   const stderr = io.stderr ?? process.stderr;


### PR DESCRIPTION
## Summary
- CLI no longer crashes with `uv_tty_init EINVAL` when run from agent shells (Claude Code, Cursor bash tools) or other non-TTY environments
- Adds `src/lib/prompts.ts` abstraction: clack in TTY, buffered `LineReader`-backed readline in non-TTY
- OAuth flow prints the authorize URL prominently via `stdout.write` in non-TTY so agents can relay it to the human

## What changed
- New `src/lib/prompts.ts` with `text` / `select` / `confirm` / `password`, auto-branching on TTY detection
- Custom `LineReader` buffers parsed lines in a queue and returns `null` on stream close — fixes event-loss and EOF handling limitations of `readline.promises.question()`
- Replaced `clack.text/select/confirm` usages across: `link`, `create`, `login`, `diagnose`, `projects/list`, `storage/delete-bucket`, `deployments/cancel`, `schedules/delete`, `secrets/delete`, `functions/delete`, `credentials.ts`, and the root menu
- OAuth in non-TTY: prints `To sign in, open this URL in your browser:\n\n  <url>\n` before `open()` attempt, skips the clack spinner (which rendered junk in non-TTY)
- 21 new unit tests in `src/lib/prompts.test.ts`

## Test plan
- [x] TTY users see the same clack UI as before (arrow-key dropdowns, boxes, spinners)
- [x] `node dist/index.js link < /dev/null` shows a numbered org list instead of crashing
- [x] `printf "8\n1\n" | node dist/index.js link` completes end-to-end: org selected, project selected, config saved, skills installed
- [x] Live OAuth test in non-TTY: URL printed, user clicks, callback fires, CLI prints `Authenticated as <email>` and continues
- [x] `npm run lint` passes (67 tests, 4 files)
- [x] `npm run build` succeeds

Bumps version to 0.1.50.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make CLI prompts work in non-TTY shells by adding stdin fallbacks
> - Introduces [src/lib/prompts.ts](https://github.com/InsForge/CLI/pull/67/files#diff-198f9c6e4714f4c1819b759cdd66ece2a658ef58c9797c084b86cba0e0224e3f), a new prompts module that wraps `@clack/prompts` with non-TTY fallbacks for `text`, `select`, `confirm`, and `password`.
> - In non-TTY environments, select prompts render a numbered list to stdout and read a numeric choice from stdin; confirm prompts accept `y/n` input; text prompts read plain lines with validation.
> - All interactive prompt calls across commands (`create`, `login`, `projects/link`, `diagnose`, etc.) are migrated from direct `clack.*` calls to this new module.
> - The OAuth login flow in [src/lib/auth.ts](https://github.com/InsForge/CLI/pull/67/files#diff-486994d46df34c53636a706a1ca6a05bd8261ccde47463ea2c739af56f090b78) detects non-interactive mode and prints the authorization URL and status as plain text instead of using clack spinners.
> - Behavioral Change: password input is unmasked in non-TTY contexts since terminal masking is unavailable.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #67 opened
>
> - Redirected OAuth PKCE flow informational messages to stderr in non-interactive mode [6c2d821]
> - Added optional whitespace preservation to non-interactive text input and enabled it for password input [6c2d821]
> - Added validation to prevent `nonTtySelect` from accepting empty options lists [6c2d821]
> - Added test coverage for whitespace preservation and empty options validation in non-TTY prompts [6c2d821]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df3dbed.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified interactive prompt system with robust non‑TTY behavior and consistent cancel handling.
  * Improved authentication output for non‑interactive terminals and scripts.

* **Tests**
  * Added comprehensive tests for prompt utilities covering interactive and non‑interactive flows.

* **Chores**
  * Package version bumped to 0.1.50.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->