### PR TITLE
fix(analytics): flush PostHog before process.exit in error paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -484,6 +484,7 @@ export function registerCreateCommand(program: Command): void {
           throw err;
         }
       } catch (err) {
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();

--- a/src/commands/diagnose/advisor.ts
+++ b/src/commands/diagnose/advisor.ts
@@ -112,6 +112,7 @@ export function registerDiagnoseAdvisorCommand(diagnoseCmd: Command): void {
         await reportCliUsage('cli.diagnose.advisor', true);
       } catch (err) {
         await reportCliUsage('cli.diagnose.advisor', false);
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();

--- a/src/commands/diagnose/db.ts
+++ b/src/commands/diagnose/db.ts
@@ -207,6 +207,7 @@ export function registerDiagnoseDbCommand(diagnoseCmd: Command): void {
         await reportCliUsage('cli.diagnose.db', true);
       } catch (err) {
         await reportCliUsage('cli.diagnose.db', false);
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();

--- a/src/commands/diagnose/index.ts
+++ b/src/commands/diagnose/index.ts
@@ -363,6 +363,7 @@ export function registerDiagnoseCommands(diagnoseCmd: Command): void {
         await reportCliUsage(usageEvent, true);
       } catch (err) {
         await reportCliUsage(usageEvent, false);
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();

--- a/src/commands/diagnose/logs.ts
+++ b/src/commands/diagnose/logs.ts
@@ -121,6 +121,7 @@ export function registerDiagnoseLogsCommand(diagnoseCmd: Command): void {
         await reportCliUsage('cli.diagnose.logs', true);
       } catch (err) {
         await reportCliUsage('cli.diagnose.logs', false);
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();

--- a/src/commands/diagnose/metrics.ts
+++ b/src/commands/diagnose/metrics.ts
@@ -162,6 +162,7 @@ export function registerDiagnoseMetricsCommand(diagnoseCmd: Command): void {
         await reportCliUsage('cli.diagnose.metrics', true);
       } catch (err) {
         await reportCliUsage('cli.diagnose.metrics', false);
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -87,6 +87,7 @@ export function registerProjectLinkCommand(program: Command): void {
             return;
           } catch (err) {
             await reportCliUsage('cli.link_direct', false);
+            await shutdownAnalytics();
             handleError(err, json);
           }
         }
@@ -300,6 +301,7 @@ export function registerProjectLinkCommand(program: Command): void {
         }
       } catch (err) {
         await reportCliUsage('cli.link', false);
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();


### PR DESCRIPTION
## Summary
- `handleError()` calls `process.exit()` synchronously, terminating the process before the `finally { await shutdownAnalytics() }` block gets a chance to flush PostHog's batched events. On any error path the event was silently dropped.
- This is why `cli_diagnose_invoked` with `subcommand='ai'` never showed up in PostHog — the AI streaming path tends to hit the error handler (e.g. backend returns an error SSE event, or non-TTY interactive rating prompt gets killed), while the other subcommands usually complete successfully and their finally block flushes normally.
- Fix: add `await shutdownAnalytics()` in the catch block *before* `handleError` runs. Applied to every action handler that emits a PostHog event and can reach `handleError` — the 5 diagnose commands, `create`, and `link` (including `link`'s nested OSS direct-connect catch, which previously skipped the outer finally too).
- Bumps version to 0.1.52 for release.

Verified locally: after rebuilding and running `diagnose --ai`, the `subcommand='ai'` event now appears in PostHog.

## Test plan
- [x] `npm run lint` passes (already verified locally)
- [x] Build with `POSTHOG_API_KEY=<real_key> npm run build`
- [x] Run `node dist/index.js diagnose --ai "test question"` against a linked project that triggers the streaming error path, and confirm the `cli_diagnose_invoked` event with `subcommand='ai'` appears in PostHog
- [x] Confirm success-path events (`subcommand='report'`, `db`, `logs`, `advisor`, `metrics`) still appear as before

## Follow-up
The root cause is structural — any new command that follows the same `catch { handleError } finally { shutdownAnalytics }` pattern will silently drop events on error. Consider a follow-up refactor that makes `handleError` async and awaits flushing internally, so call sites can't forget. Left out of this PR to keep the fix surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Flush PostHog analytics before `process.exit` in error paths across CLI commands
> Adds `await shutdownAnalytics()` in the `catch` blocks of `create`, `diagnose`, `diagnose advisor`, `diagnose db`, `diagnose logs`, `diagnose metrics`, and `projects link` commands, immediately before `handleError()` is called. Previously, `shutdownAnalytics()` only ran in `finally`, but `handleError` can call `process.exit` before the `finally` block completes, causing analytics events to be dropped on error paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a817281.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.52
  * Improved error handling consistency and resource cleanup procedures across command handlers
  * Enhanced shutdown reliability during unexpected failures to maintain application stability
  * Optimized error recovery processes to ensure proper cleanup in all execution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->