### PR TITLE
fix(link): install agent skills before creating template subdir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.47",
+  "version": "0.1.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.47",
+      "version": "0.1.51",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -202,6 +202,9 @@ export function registerProjectLinkCommand(program: Command): void {
             throw new CLIError(`Invalid template "${template}". Valid options: ${validTemplates.join(', ')}`);
           }
 
+          // Install agent skills in the current directory before creating the project subdir
+          await installSkills(json);
+
           // Ask for directory name
           let dirName = project.name;
           if (!json) {
@@ -260,8 +263,6 @@ export function registerProjectLinkCommand(program: Command): void {
             }
           }
 
-          // Install agent skills inside the project directory
-          await installSkills(json);
           await reportCliUsage('cli.link', true, 6, projectConfig);
 
           if (!json) {


### PR DESCRIPTION
## Summary
- In `link --template <name>`, move `installSkills()` to run **before** `mkdir`/`chdir`, so skills install in the parent cwd instead of inside the newly-created project subdir.
- Non-template `link` flow is unchanged.

## Why
When the agent (Claude Code, Cursor, etc.) is already driving the CLI from a workspace and `link --template` creates a subproject directory, installing skills inside that subdir hides them from the agent's current session. Moving the install to the parent fixes this.

Per each agent's docs, skills installed in the parent still load from subdirs for: Claude Code, Windsurf, Codex CLI (`AGENTS.md`), Gemini CLI, Qwen, Kilo, Augment, Antigravity, and GitHub Copilot (opt-in).

Caveat: Cursor, Cline, Roo, Qoder, and likely Trae do **not** walk up parent directories. Users of those agents who later open the new project dir as a fresh workspace won't get skills auto-loaded — they'd need to re-run `npx skills add insforge/agent-skills` inside the project.

## Test plan
- [x] `npm run lint` — passes (69 tests)
- [x] `npm run build` — passes
- [ ] Manual: `insforge link --template react` — verify skills install in cwd, then subdir is created and template downloads into it
- [ ] Manual: `insforge link` (no template) — verify behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent skill installation to run in the current directory before creating the template subdirectory
> When `--template` is used in `link`, `installSkills` was previously called inside the newly created project subdirectory. It now runs in the current working directory immediately after template validation, before the project directory is created.
>
> - Behavioral Change: skills are installed in the calling directory rather than the new project subdirectory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26cbed5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.1.51
  * Adjusted the initialization sequence for template-based project linking to install agent skills earlier in the process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->