### PR TITLE
feat(skills): install agent skills globally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.51",
+  "version": "0.1.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.51",
+      "version": "0.1.53",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -70,8 +70,8 @@ function updateGitignore(): void {
 
 export async function installSkills(json: boolean): Promise<void> {
   try {
-    if (!json) clack.log.info('Installing InsForge agent skills...');
-    await execAsync('npx skills add insforge/agent-skills -y -a antigravity -a augment -a claude-code -a cline -a codex -a cursor -a gemini-cli -a github-copilot -a kilo -a qoder -a qwen-code -a roo -a trae -a windsurf', {
+    if (!json) clack.log.info('Installing InsForge agent skills (global)...');
+    await execAsync('npx skills add insforge/agent-skills -g -y -a antigravity -a augment -a claude-code -a cline -a codex -a cursor -a gemini-cli -a github-copilot -a kilo -a qoder -a qwen-code -a roo -a trae -a windsurf', {
       cwd: process.cwd(),
       timeout: SKILL_INSTALL_TIMEOUT_MS,
     });
@@ -85,8 +85,8 @@ export async function installSkills(json: boolean): Promise<void> {
 
   // Install find-skills from vercel-labs for skill discovery
   try {
-    if (!json) clack.log.info('Installing find-skills...');
-    await execAsync('npx skills add https://github.com/vercel-labs/skills --skill find-skills -y', {
+    if (!json) clack.log.info('Installing find-skills (global)...');
+    await execAsync('npx skills add https://github.com/vercel-labs/skills --skill find-skills -g -y', {
       cwd: process.cwd(),
       timeout: SKILL_INSTALL_TIMEOUT_MS,
     });


### PR DESCRIPTION
## Summary
- Pass `-g` to both `npx skills add` invocations in `installSkills()` so InsForge agent skills and find-skills install to the user-level skills store (`~/.agents/skills/`, with per-agent symlinks into `~/.claude/skills/`, `~/.codex/skills/`, etc.) instead of project-local.
- Matches the pattern used by gstack and other agent toolchains: skills are project-agnostic with no per-project state, so one install per machine suffices.
- Side benefit: `cwd` no longer matters for the install, which makes the install-before-mkdir ordering issue in the `--template` flow moot (supersedes #70 in spirit).

## What still lives in the project
Only `./.insforge/project.json` (project_id, appkey, api_key, oss_host). OAuth credentials at `~/.insforge/credentials.json` were already global and are untouched.

## Test plan
- [x] `npm run build` — green
- [x] `npm run lint` — green
- [x] `npx vitest run` — 69 pass, 13 skipped
- [x] Verified bundled `dist/index.js` contains the `-g` flag
- [x] Ran the patched `npx skills add insforge/agent-skills -g -y -a …` (full agent list) in a fresh empty temp dir:
  - cwd stayed empty (no `.claude/`, `.codex/`, `.insforge/` etc. created)
  - Skills landed in `~/.agents/skills/{insforge, insforge-cli, insforge-debug, insforge-integrations}` with symlinks under `~/.claude/skills/`
  - `~/.insforge/credentials.json` mtime unchanged
- [ ] Smoke-test a real `insforge link` end-to-end against a project after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.1.53

* **Improvements**
  * Skills are now installed globally for system-wide accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->