### PR TITLE
[T2] Bundled skills install + insforge skills subcommand family

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,41 @@ It also installs [`find-skills`](https://github.com/vercel-labs/skills) so agent
 
 Skill files are written to per-agent directories (e.g. `.claude/`, `.cursor/`, `.windsurf/`) and are automatically added to your `.gitignore`. You can re-run `npx @insforge/cli link` at any time to reinstall or update skills.
 
+### `insforge skills` — manage bundled Claude skills
+
+In addition to the `npx skills add …` flow above (which covers a wide set of agents), `@insforge/cli` ships a small set of InsForge skill files bundled directly inside the npm package. You can manage them with the `insforge skills` command family:
+
+```bash
+# Show installed + bundled-but-not-installed skills
+npx @insforge/cli skills list
+
+# Install every bundled skill into ~/.claude/skills/insforge-<slug>/
+npx @insforge/cli skills install
+
+# Install one specific skill (by slug)
+npx @insforge/cli skills install database
+
+# Re-copy from the bundle, overwriting any local edits
+npx @insforge/cli skills update
+
+# Keep local edits; update only the ones you haven't touched
+npx @insforge/cli skills update --keep-local
+
+# Remove an installed skill
+npx @insforge/cli skills uninstall database
+```
+
+By default skills are installed to `~/.claude/skills/insforge-<slug>/`. You can override the target directory with either of the following environment variables (in precedence order):
+
+| Variable | Effect |
+|----------|--------|
+| `CLAUDE_CONFIG_DIR` | Installs under `<CLAUDE_CONFIG_DIR>/skills/` |
+| `XDG_CONFIG_HOME` | Installs under `<XDG_CONFIG_HOME>/claude/skills/` |
+
+If neither is set, the default `~/.claude/skills/` is used. All commands also accept `--target-dir <path>` as an explicit override.
+
+If you ran `npx @insforge/cli skills install` from a local source build and see a "No skills bundled" warning, run `npm run build:skills` (or install `@insforge/cli` from npm — the bundled skills ship in the published tarball).
+
 ## Analytics
 
 The CLI reports anonymous usage events to [PostHog](https://posthog.com) so we can understand which features are being used and prioritize improvements. 

--- a/docs/specs/2026-04-18-bundled-skills-install.md
+++ b/docs/specs/2026-04-18-bundled-skills-install.md
@@ -1,0 +1,206 @@
+# Bundled skills install + `insforge skills` subcommand family
+
+## Problem
+
+`@insforge/cli` needs a first-class way for users (and the `insforge init` wrapper
+in CLI#73) to install the InsForge agent skill files into their local Claude
+configuration. Today we already have `installSkills()` in `src/lib/skills.ts`
+(merged in #72) that shells out to `npx skills add insforge/agent-skills -g …`
+and installs into `~/.agents/skills/` with per-agent symlinks. That works, but
+it depends on a third-party `skills` CLI, an internet connection, and the
+`insforge/agent-skills` bundle being reachable on the npm registry.
+
+Ticket #74 asks for a different, complementary mechanism: **bundle the skill
+markdown files directly into the `@insforge/cli` npm package** and copy them
+into `~/.claude/skills/insforge-<slug>/` on demand. This gives:
+
+- offline-capable install (files ship inside the tarball)
+- first-class `insforge skills` subcommand family (`list` / `install` /
+  `update` / `uninstall`) so users can manage skills without running `init`
+- a stable library surface (`installBundledSkills()`) that CLI#73's `init`
+  wrapper can call directly, keeping the primitives-vs-wrapper split clean
+
+The pinned operator comment on the ticket confirms this direction: `skills` is
+a primitive family that `init` uses; neither mechanism is being removed by the
+other.
+
+## Goals
+
+1. New library: `src/lib/skills-install.ts` exporting
+   `installBundledSkills({ targetDir?, force?, skillsSrcDir?, only? })` that
+   copies bundled `SKILL.md` files into `<targetDir>/insforge-<slug>/SKILL.md`
+   with correct perms (0644 / 0755).
+2. New subcommand family `insforge skills`:
+   - `list`   — show installed (under `~/.claude/skills/insforge-*`) and
+     bundled-but-not-installed skills.
+   - `install [name]` — install a specific skill, or all if no name.
+   - `update [name]` — re-copy from bundle (overwrites unless `--keep-local`).
+   - `uninstall <name>` — remove `~/.claude/skills/insforge-<name>/`.
+3. Build-time bundling: a one-shot `npm run build:skills` script populates
+   `dist/skills/<slug>/SKILL.md` from the `InsForge/insforge-skills` repo.
+   `prepublishOnly` runs it before `npm publish` so published tarballs contain
+   real skills. Local `npm run build` does not require network — if
+   `dist/skills/` is empty, `insforge skills install` prints a friendly hint.
+4. Env overrides: default target is `~/.claude/skills/` but respect
+   `CLAUDE_CONFIG_DIR` (→ `<CLAUDE_CONFIG_DIR>/skills/`) and
+   `XDG_CONFIG_HOME` (→ `<XDG_CONFIG_HOME>/claude/skills/`) when set.
+5. Vitest coverage: unit test the library against a fixture bundle in a
+   temp dir, asserting files, perms, skip-if-exists, `force`, and env
+   overrides.
+
+## Non-goals
+
+- Modifying `src/commands/init.ts` or the existing `src/lib/skills.ts`
+  (CLI#73 is the `init` wrapper that will call `installBundledSkills()`; #72's
+  `installSkills(json)` is a separate third-party-based install path and
+  stays as-is so we don't regress the existing onboarding).
+- Auto-update / version-check on `insforge` launches.
+- Signature / checksum verification of skill files.
+- Publishing to `claude plugin` marketplaces.
+
+## Proposed approach
+
+### Library (`src/lib/skills-install.ts`)
+
+Pure library, no I/O beyond `fs/promises`. The core function:
+
+```ts
+export interface BundledSkillsInstallOptions {
+  targetDir?: string;       // defaults to resolveTargetDir()
+  skillsSrcDir?: string;    // defaults to resolveBundledSkillsDir()
+  force?: boolean;          // overwrite existing on install
+  only?: string[];          // if set, only install skills whose slug matches
+  keepLocal?: boolean;      // update-only: skip if target already exists
+}
+
+export interface BundledSkillResult {
+  slug: string;
+  status: 'installed' | 'updated' | 'skipped-exists' | 'skipped-keep-local' | 'missing-source';
+  path: string;
+  bytes?: number;
+}
+
+export interface InstallBundledSkillsResult {
+  targetDir: string;
+  skillsSrcDir: string;
+  results: BundledSkillResult[];
+}
+
+export async function installBundledSkills(
+  opts?: BundledSkillsInstallOptions,
+): Promise<InstallBundledSkillsResult>;
+```
+
+Helpers also exported for reuse by the command layer:
+
+- `resolveTargetDir(env = process.env): string`
+- `resolveBundledSkillsDir(): string` — locates `dist/skills/` next to the
+  compiled `dist/index.js`.
+- `listBundledSkills(skillsSrcDir?): Promise<{ slug: string; path: string }[]>`
+- `listInstalledSkills(targetDir?): Promise<{ slug: string; path: string }[]>`
+- `uninstallSkill(slug, targetDir?): Promise<{ removed: boolean; path: string }>`
+
+Naming note: we deliberately **do not** use `installSkills` to avoid colliding
+with the existing export in `src/lib/skills.ts`. The new function has a
+different signature (options bag, returns result) and a different mechanism
+(copy-from-bundle vs. shell-out-to-npx), so they live side by side under
+distinct names.
+
+### Command family (`src/commands/skills/`)
+
+Mirror the multi-command dir shape used by `src/commands/secrets/`,
+`src/commands/projects/`, `src/commands/diagnose/`. One
+`register*` function per file, wired up by a new `skills` group in
+`src/index.ts`.
+
+- `list.ts` — prints a table (`outputTable`) of installed + bundled skills
+  with their status. JSON mode outputs the raw list.
+- `install.ts` — `insforge skills install [name]`. `--force` overwrites.
+  `--target-dir <path>` override for advanced users (mainly useful for tests).
+- `update.ts` — `insforge skills update [name]`. `--keep-local` preserves
+  existing files (treats them as skipped, not overwritten).
+- `uninstall.ts` — `insforge skills uninstall <name>`. Friendly error if
+  the skill is not installed.
+
+All commands reuse the existing `getRootOpts` / `handleError` / `outputJson`
+patterns; all I/O uses `fs/promises`; error messages match the existing
+`clack.log.*` tone.
+
+### Build-time bundling
+
+Option A from the ticket. Concretely:
+
+1. New script `scripts/build-skills.sh` (bash, no extra deps): clones
+   `InsForge/insforge-skills` into a tmpdir, copies each
+   `skill-*/SKILL.md` into `<repo>/dist/skills/<slug>/SKILL.md` with the
+   `skill-` prefix stripped. Idempotent.
+2. New `package.json` script: `"build:skills": "scripts/build-skills.sh"`.
+3. `prepublishOnly` gets updated from `npm run lint && npm run build` to
+   `npm run lint && npm run build && npm run build:skills`, so published
+   tarballs always contain the skills.
+4. `tsup.config.ts` is **not** modified — skills are runtime assets, not
+   JS, and we want them under `dist/skills/` in the published tarball.
+   The `files: ["dist"]` entry in `package.json` already includes them.
+
+If `dist/skills/` is empty at runtime (local dev without running
+`build:skills`), `installBundledSkills()` returns an empty result with a
+`missing-source` sentinel; the command layer shows:
+
+> No skills bundled. This is a local dev build — run `npm run build:skills`
+> to populate `dist/skills/`, or install `@insforge/cli` from npm.
+
+### Env override resolution
+
+```ts
+function resolveTargetDir(env = process.env): string {
+  if (env.INSFORGE_SKILLS_TARGET_DIR) return env.INSFORGE_SKILLS_TARGET_DIR; // test hook
+  if (env.CLAUDE_CONFIG_DIR) return join(env.CLAUDE_CONFIG_DIR, 'skills');
+  if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, 'claude', 'skills');
+  return join(homedir(), '.claude', 'skills');
+}
+```
+
+Precedence documented in the README.
+
+## Test plan
+
+- `src/lib/skills-install.test.ts` (Vitest):
+  - `resolveTargetDir` honors each env var with the documented precedence.
+  - `installBundledSkills` with a fixture `dist/skills/alpha/SKILL.md` +
+    `dist/skills/beta/SKILL.md` writes `insforge-alpha` + `insforge-beta`
+    under a per-test tmpdir, sets mode `0644` on files and `0755` on dirs.
+  - Re-running without `force` returns `skipped-exists` and does not touch
+    mtimes.
+  - Re-running with `force` overwrites.
+  - `only: ['alpha']` installs just alpha.
+  - `keepLocal: true` behaves like `force: false` even in update flows.
+  - Empty `skillsSrcDir` returns a single `missing-source` result.
+- `src/commands/skills/install.test.ts` (lightweight): wires up a fake
+  `Command`, points env vars at a tmpdir, asserts `list.ts` output and
+  `uninstall.ts` round-trip. If the commander scaffolding is heavy we keep
+  coverage at the library layer and smoke-test the command via one
+  end-to-end case.
+- `npm test` + `npm run lint` both green before opening the PR.
+
+## Risks / rollback
+
+- **Build-step network dep:** `scripts/build-skills.sh` pulls from
+  `InsForge/insforge-skills` at publish time. Mitigation: only
+  `prepublishOnly` runs it; `npm run build` does not. Rollback: delete the
+  script + revert the `prepublishOnly` change.
+- **User confusion between two install paths:** `insforge init` currently
+  calls the old `installSkills()` (npx-based). This ticket does not rewire
+  `init`. CLI#73's worker is the one that swaps `init` to call
+  `installBundledSkills()`. Until then, the two mechanisms coexist and the
+  README notes this explicitly. Rollback: remove the new command group
+  from `src/index.ts`; the library stays but is dormant.
+- **`fs.cp` availability:** `fs/promises.cp` is stable on Node 18+
+  (the engine floor in `package.json`). We use it with `{ recursive: true,
+  preserveTimestamps: false }` and set perms explicitly after copy.
+
+## Out of scope for this PR
+
+- `insforge init` integration (CLI#73).
+- Telemetry (`reportCliUsage`) on the new commands — can be added as a
+  follow-up; doesn't change behavior.
+- Removing or deprecating the existing `installSkills()` in `src/lib/skills.ts`.

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup",
+    "build:skills": "bash scripts/build-skills.sh",
     "dev": "tsup --watch",
     "lint": "vitest run --passWithNoTests && eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint && npm run build && npm run build:skills",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",
     "test:integration:real": "npm run build && vitest run src/integration/real-project.test.ts"

--- a/scripts/build-skills.sh
+++ b/scripts/build-skills.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# build-skills.sh — populate dist/skills/<slug>/SKILL.md from the
+# InsForge/insforge-skills repo. Idempotent. Intended to run as part of
+# `prepublishOnly` before `npm publish`, so that published tarballs contain
+# the bundled skill markdown files alongside the compiled CLI.
+#
+# Usage:
+#   ./scripts/build-skills.sh                # clone default repo + branch
+#   INSFORGE_SKILLS_REPO=... SKILLS_REF=...  # override source
+#   INSFORGE_SKILLS_LOCAL_DIR=/path/to/repo  # use a local checkout (no clone)
+#
+# The script is deliberately bash + git, no JS deps — keeps `npm run build`
+# fast and cheap. It skips silently with a warning if `git` isn't on PATH so
+# local dev builds don't fail without network.
+set -euo pipefail
+
+repo="${INSFORGE_SKILLS_REPO:-https://github.com/InsForge/insforge-skills.git}"
+ref="${SKILLS_REF:-main}"
+out_dir="${SKILLS_OUT_DIR:-dist/skills}"
+local_dir="${INSFORGE_SKILLS_LOCAL_DIR:-}"
+
+project_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$project_root"
+
+mkdir -p "$out_dir"
+
+if [ -n "$local_dir" ]; then
+  src="$local_dir"
+  cleanup=""
+else
+  if ! command -v git >/dev/null 2>&1; then
+    echo "build-skills: warning — git not on PATH; leaving $out_dir empty. Install skills from npm or run \`git\` locally." >&2
+    exit 0
+  fi
+  tmp="$(mktemp -d -t insforge-skills-XXXXXX)"
+  cleanup="$tmp"
+  # Shallow clone to keep the build fast. If the network is unreachable, fail
+  # loudly — we don't want to ship an empty bundle to npm silently.
+  git clone --depth 1 --branch "$ref" "$repo" "$tmp" >/dev/null 2>&1 || {
+    echo "build-skills: error — could not clone $repo@$ref" >&2
+    rm -rf "$tmp"
+    exit 1
+  }
+  src="$tmp"
+fi
+
+trap '[ -n "${cleanup:-}" ] && rm -rf "${cleanup}"' EXIT
+
+copied=0
+# Prefer `skill-*/SKILL.md` directories (canonical layout in
+# InsForge/insforge-skills). Fall back to `*/SKILL.md` if the repo layout
+# changes, so the build doesn't silently ship nothing.
+shopt -s nullglob
+for skill_dir in "$src"/skill-*/; do
+  slug="$(basename "$skill_dir")"
+  slug="${slug#skill-}"
+  if [ -f "$skill_dir/SKILL.md" ]; then
+    mkdir -p "$out_dir/$slug"
+    cp "$skill_dir/SKILL.md" "$out_dir/$slug/SKILL.md"
+    chmod 0644 "$out_dir/$slug/SKILL.md"
+    copied=$((copied + 1))
+  fi
+done
+
+if [ "$copied" -eq 0 ]; then
+  for skill_dir in "$src"/*/; do
+    [ "$(basename "$skill_dir")" = "node_modules" ] && continue
+    [ "$(basename "$skill_dir")" = ".git" ] && continue
+    slug="$(basename "$skill_dir")"
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      mkdir -p "$out_dir/$slug"
+      cp "$skill_dir/SKILL.md" "$out_dir/$slug/SKILL.md"
+      chmod 0644 "$out_dir/$slug/SKILL.md"
+      copied=$((copied + 1))
+    fi
+  done
+fi
+
+if [ "$copied" -eq 0 ]; then
+  echo "build-skills: warning — no skills found in $src" >&2
+else
+  echo "build-skills: copied $copied skill(s) into $out_dir"
+fi

--- a/src/commands/skills/install.ts
+++ b/src/commands/skills/install.ts
@@ -1,0 +1,87 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import {
+  installBundledSkills,
+  resolveBundledSkillsDir,
+  resolveTargetDir,
+  type BundledSkillResult,
+} from '../../lib/skills-install.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+
+export function registerSkillsInstallCommand(skillsCmd: Command): void {
+  skillsCmd
+    .command('install [name]')
+    .description('Install InsForge skills from the bundled source. With no name, installs all.')
+    .option('-f, --force', 'Overwrite existing skills at the target')
+    .option('--target-dir <path>', 'Override the target directory (defaults to ~/.claude/skills)')
+    .option('--skills-src-dir <path>', 'Override the bundled-skills source directory')
+    .action(async (name: string | undefined, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const targetDir = (opts.targetDir as string | undefined) ?? resolveTargetDir();
+        const skillsSrcDir = (opts.skillsSrcDir as string | undefined) ?? resolveBundledSkillsDir();
+
+        const res = await installBundledSkills({
+          targetDir,
+          skillsSrcDir,
+          force: Boolean(opts.force),
+          only: name ? [name] : undefined,
+        });
+
+        if (json) {
+          outputJson(res);
+          return;
+        }
+
+        reportHumanResults(res.results, res.targetDir, res.skillsSrcDir);
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}
+
+function reportHumanResults(
+  results: BundledSkillResult[],
+  targetDir: string,
+  skillsSrcDir: string,
+): void {
+  if (results.length === 1 && results[0].status === 'missing-source') {
+    clack.log.warn(
+      `No skills bundled at ${skillsSrcDir}. This is likely a local dev build — run \`npm run build:skills\` to populate \`dist/skills/\`, or install \`@insforge/cli\` from npm.`,
+    );
+    return;
+  }
+
+  if (results.length === 0) {
+    clack.log.info('No matching bundled skill to install.');
+    return;
+  }
+
+  clack.log.info(`Installing InsForge skills to ${targetDir}`);
+  for (const r of results) {
+    const label = `insforge-${r.slug}`;
+    switch (r.status) {
+      case 'installed':
+        clack.log.success(`${label} (${formatBytes(r.bytes)})`);
+        break;
+      case 'updated':
+        clack.log.success(`${label} — overwritten (${formatBytes(r.bytes)})`);
+        break;
+      case 'skipped-exists':
+        clack.log.info(`${label} — already installed (use --force to overwrite)`);
+        break;
+      case 'skipped-keep-local':
+        clack.log.info(`${label} — kept local copy (--keep-local)`);
+        break;
+      default:
+        clack.log.info(`${label} — ${r.status}`);
+    }
+  }
+}
+
+function formatBytes(bytes: number | undefined): string {
+  if (bytes === undefined) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}

--- a/src/commands/skills/list.ts
+++ b/src/commands/skills/list.ts
@@ -1,0 +1,73 @@
+import type { Command } from 'commander';
+import {
+  listBundledSkills,
+  listInstalledSkills,
+  resolveBundledSkillsDir,
+  resolveTargetDir,
+} from '../../lib/skills-install.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson, outputTable } from '../../lib/output.js';
+
+export function registerSkillsListCommand(skillsCmd: Command): void {
+  skillsCmd
+    .command('list')
+    .description('List installed InsForge skills and bundled-but-not-installed skills')
+    .option('--target-dir <path>', 'Override the target directory (defaults to ~/.claude/skills)')
+    .option('--skills-src-dir <path>', 'Override the bundled-skills source directory')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const targetDir = (opts.targetDir as string | undefined) ?? resolveTargetDir();
+        const skillsSrcDir = (opts.skillsSrcDir as string | undefined) ?? resolveBundledSkillsDir();
+
+        const [bundled, installed] = await Promise.all([
+          listBundledSkills(skillsSrcDir),
+          listInstalledSkills(targetDir),
+        ]);
+
+        const installedSlugs = new Set(installed.map((s) => s.slug));
+        const bundledSlugs = new Set(bundled.map((s) => s.slug));
+
+        // Union of all known skills, reporting which is installed vs bundled-only
+        const allSlugs = Array.from(new Set([...installedSlugs, ...bundledSlugs])).sort();
+
+        const rows = allSlugs.map((slug) => {
+          const isInstalled = installedSlugs.has(slug);
+          const isBundled = bundledSlugs.has(slug);
+          let status: string;
+          if (isInstalled && isBundled) status = 'installed';
+          else if (isInstalled && !isBundled) status = 'installed (no longer bundled)';
+          else status = 'available';
+          return { slug, status };
+        });
+
+        if (json) {
+          outputJson({
+            targetDir,
+            skillsSrcDir,
+            skills: rows,
+          });
+          return;
+        }
+
+        if (rows.length === 0) {
+          console.log('No skills installed and no skills bundled.');
+          console.log(`(target: ${targetDir})`);
+          return;
+        }
+
+        outputTable(
+          ['Skill', 'Status', 'Path'],
+          rows.map((r) => [
+            `insforge-${r.slug}`,
+            r.status,
+            r.status.startsWith('installed')
+              ? `${targetDir}/insforge-${r.slug}`
+              : `${skillsSrcDir}/${r.slug}/SKILL.md`,
+          ]),
+        );
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/skills/uninstall.ts
+++ b/src/commands/skills/uninstall.ts
@@ -1,0 +1,36 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import { resolveTargetDir, uninstallSkill } from '../../lib/skills-install.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+
+export function registerSkillsUninstallCommand(skillsCmd: Command): void {
+  skillsCmd
+    .command('uninstall <name>')
+    .description('Remove an installed InsForge skill from the target directory')
+    .option('--target-dir <path>', 'Override the target directory (defaults to ~/.claude/skills)')
+    .action(async (name: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const targetDir = (opts.targetDir as string | undefined) ?? resolveTargetDir();
+        const res = await uninstallSkill(name, targetDir);
+
+        if (json) {
+          outputJson(res);
+          return;
+        }
+
+        if (!res.removed) {
+          throw new CLIError(
+            `Skill "insforge-${name}" is not installed at ${targetDir}.`,
+            4,
+            'NOT_FOUND',
+          );
+        }
+
+        clack.log.success(`Removed ${res.path}`);
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -1,0 +1,70 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import {
+  installBundledSkills,
+  resolveBundledSkillsDir,
+  resolveTargetDir,
+} from '../../lib/skills-install.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+
+export function registerSkillsUpdateCommand(skillsCmd: Command): void {
+  skillsCmd
+    .command('update [name]')
+    .description('Re-copy InsForge skills from the bundle, overwriting existing files')
+    .option('--keep-local', 'Preserve any locally-edited skill files instead of overwriting')
+    .option('--target-dir <path>', 'Override the target directory (defaults to ~/.claude/skills)')
+    .option('--skills-src-dir <path>', 'Override the bundled-skills source directory')
+    .action(async (name: string | undefined, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const targetDir = (opts.targetDir as string | undefined) ?? resolveTargetDir();
+        const skillsSrcDir = (opts.skillsSrcDir as string | undefined) ?? resolveBundledSkillsDir();
+        const keepLocal = Boolean(opts.keepLocal);
+
+        const res = await installBundledSkills({
+          targetDir,
+          skillsSrcDir,
+          // update overwrites by default; --keep-local flips that
+          force: !keepLocal,
+          keepLocal,
+          only: name ? [name] : undefined,
+        });
+
+        if (json) {
+          outputJson(res);
+          return;
+        }
+
+        if (res.results.length === 1 && res.results[0].status === 'missing-source') {
+          clack.log.warn(
+            `No skills bundled at ${res.skillsSrcDir}. This is likely a local dev build — run \`npm run build:skills\`, or install \`@insforge/cli\` from npm.`,
+          );
+          return;
+        }
+
+        clack.log.info(`Updating InsForge skills at ${res.targetDir}`);
+        for (const r of res.results) {
+          const label = `insforge-${r.slug}`;
+          switch (r.status) {
+            case 'installed':
+              clack.log.success(`${label} — installed`);
+              break;
+            case 'updated':
+              clack.log.success(`${label} — overwritten`);
+              break;
+            case 'skipped-keep-local':
+              clack.log.info(`${label} — kept local copy`);
+              break;
+            case 'skipped-exists':
+              clack.log.info(`${label} — already up to date`);
+              break;
+            default:
+              clack.log.info(`${label} — ${r.status}`);
+          }
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,11 @@ import { registerLogsCommand } from './commands/logs.js';
 import { registerMetadataCommand } from './commands/metadata.js';
 import { registerDiagnoseCommands } from './commands/diagnose/index.js';
 
+import { registerSkillsListCommand } from './commands/skills/list.js';
+import { registerSkillsInstallCommand } from './commands/skills/install.js';
+import { registerSkillsUpdateCommand } from './commands/skills/update.js';
+import { registerSkillsUninstallCommand } from './commands/skills/uninstall.js';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
 
@@ -191,6 +196,13 @@ registerComputeDeleteCommand(computeCmd);
 registerComputeStartCommand(computeCmd);
 registerComputeStopCommand(computeCmd);
 registerComputeLogsCommand(computeCmd);
+
+// Skills commands (bundled InsForge agent skills — see docs/specs/2026-04-18-bundled-skills-install.md)
+const skillsCmd = program.command('skills').description('Manage bundled InsForge agent skills');
+registerSkillsListCommand(skillsCmd);
+registerSkillsInstallCommand(skillsCmd);
+registerSkillsUpdateCommand(skillsCmd);
+registerSkillsUninstallCommand(skillsCmd);
 
 // Schedules commands
 const schedulesCmd = program.command('schedules').description('Manage scheduled tasks (cron jobs)');

--- a/src/lib/skills-install.test.ts
+++ b/src/lib/skills-install.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile, stat, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  installBundledSkills,
+  listBundledSkills,
+  listInstalledSkills,
+  resolveTargetDir,
+  uninstallSkill,
+} from './skills-install.js';
+
+async function makeFixtureBundle(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'insforge-skills-src-'));
+  await mkdir(join(dir, 'alpha'), { recursive: true });
+  await writeFile(join(dir, 'alpha', 'SKILL.md'), '# alpha\nHello alpha.\n', { mode: 0o644 });
+  await mkdir(join(dir, 'beta'), { recursive: true });
+  await writeFile(join(dir, 'beta', 'SKILL.md'), '# beta\nHello beta.\n', { mode: 0o644 });
+  return dir;
+}
+
+describe('resolveTargetDir', () => {
+  it('honors INSFORGE_SKILLS_TARGET_DIR first (test hook)', () => {
+    expect(
+      resolveTargetDir({
+        INSFORGE_SKILLS_TARGET_DIR: '/tmp/override',
+        CLAUDE_CONFIG_DIR: '/should-be-ignored',
+        XDG_CONFIG_HOME: '/also-ignored',
+        HOME: '/home/user',
+      }),
+    ).toBe('/tmp/override');
+  });
+
+  it('falls back to CLAUDE_CONFIG_DIR/skills when set', () => {
+    expect(
+      resolveTargetDir({
+        CLAUDE_CONFIG_DIR: '/custom/claude',
+        HOME: '/home/user',
+      }),
+    ).toBe('/custom/claude/skills');
+  });
+
+  it('falls back to XDG_CONFIG_HOME/claude/skills when CLAUDE_CONFIG_DIR is unset', () => {
+    expect(
+      resolveTargetDir({
+        XDG_CONFIG_HOME: '/xdg',
+        HOME: '/home/user',
+      }),
+    ).toBe('/xdg/claude/skills');
+  });
+
+  it('defaults to ~/.claude/skills when no env vars are set', () => {
+    const result = resolveTargetDir({ HOME: '/home/user' });
+    expect(result).toBe('/home/user/.claude/skills');
+  });
+});
+
+describe('installBundledSkills', () => {
+  let srcDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    srcDir = await makeFixtureBundle();
+    targetDir = await mkdtemp(join(tmpdir(), 'insforge-skills-target-'));
+  });
+
+  afterEach(async () => {
+    await rm(srcDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  });
+
+  it('copies each bundled skill into insforge-<slug>/SKILL.md with 0644 perms', async () => {
+    const res = await installBundledSkills({ skillsSrcDir: srcDir, targetDir });
+
+    expect(res.results.map((r) => r.slug).sort()).toEqual(['alpha', 'beta']);
+    expect(res.results.every((r) => r.status === 'installed')).toBe(true);
+
+    const alphaPath = join(targetDir, 'insforge-alpha', 'SKILL.md');
+    const betaPath = join(targetDir, 'insforge-beta', 'SKILL.md');
+
+    const alphaContent = await readFile(alphaPath, 'utf-8');
+    expect(alphaContent).toContain('Hello alpha');
+
+    const alphaStat = await stat(alphaPath);
+    expect(alphaStat.mode & 0o777).toBe(0o644);
+
+    const alphaDirStat = await stat(join(targetDir, 'insforge-alpha'));
+    expect(alphaDirStat.mode & 0o777).toBe(0o755);
+
+    expect((await readFile(betaPath, 'utf-8'))).toContain('Hello beta');
+  });
+
+  it('skips already-installed skills on a plain re-run (no force)', async () => {
+    await installBundledSkills({ skillsSrcDir: srcDir, targetDir });
+
+    // mutate the installed file to prove we don't overwrite
+    const alphaPath = join(targetDir, 'insforge-alpha', 'SKILL.md');
+    await writeFile(alphaPath, '# local edit\n');
+
+    const res = await installBundledSkills({ skillsSrcDir: srcDir, targetDir });
+    expect(res.results.every((r) => r.status === 'skipped-exists')).toBe(true);
+
+    const after = await readFile(alphaPath, 'utf-8');
+    expect(after).toBe('# local edit\n');
+  });
+
+  it('overwrites when force is true', async () => {
+    await installBundledSkills({ skillsSrcDir: srcDir, targetDir });
+
+    const alphaPath = join(targetDir, 'insforge-alpha', 'SKILL.md');
+    await writeFile(alphaPath, '# local edit\n');
+
+    const res = await installBundledSkills({ skillsSrcDir: srcDir, targetDir, force: true });
+    expect(res.results.every((r) => r.status === 'installed' || r.status === 'updated')).toBe(true);
+
+    const after = await readFile(alphaPath, 'utf-8');
+    expect(after).toContain('Hello alpha');
+  });
+
+  it('honors keepLocal: skipped-keep-local on existing, installed on missing', async () => {
+    await installBundledSkills({ skillsSrcDir: srcDir, targetDir, only: ['alpha'] });
+
+    const res = await installBundledSkills({ skillsSrcDir: srcDir, targetDir, keepLocal: true });
+    const byStatus = Object.fromEntries(res.results.map((r) => [r.slug, r.status]));
+    expect(byStatus.alpha).toBe('skipped-keep-local');
+    expect(byStatus.beta).toBe('installed');
+  });
+
+  it('honors `only` filter', async () => {
+    const res = await installBundledSkills({ skillsSrcDir: srcDir, targetDir, only: ['beta'] });
+    expect(res.results.map((r) => r.slug)).toEqual(['beta']);
+
+    const entries = await readdir(targetDir);
+    expect(entries).toEqual(['insforge-beta']);
+  });
+
+  it('returns a single missing-source result when the bundle dir is empty', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'insforge-skills-empty-'));
+    try {
+      const res = await installBundledSkills({ skillsSrcDir: empty, targetDir });
+      expect(res.results).toHaveLength(1);
+      expect(res.results[0].status).toBe('missing-source');
+    } finally {
+      await rm(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a single missing-source result when the bundle dir does not exist', async () => {
+    const res = await installBundledSkills({
+      skillsSrcDir: join(srcDir, 'does-not-exist'),
+      targetDir,
+    });
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0].status).toBe('missing-source');
+  });
+});
+
+describe('listBundledSkills / listInstalledSkills / uninstallSkill', () => {
+  let srcDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    srcDir = await makeFixtureBundle();
+    targetDir = await mkdtemp(join(tmpdir(), 'insforge-skills-target-'));
+  });
+
+  afterEach(async () => {
+    await rm(srcDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  });
+
+  it('lists bundled skills by slug, ignoring unrelated entries', async () => {
+    // noise: a file at the root, a dir with no SKILL.md
+    await writeFile(join(srcDir, 'README.md'), 'noise');
+    await mkdir(join(srcDir, 'not-a-skill'), { recursive: true });
+
+    const list = await listBundledSkills(srcDir);
+    expect(list.map((s) => s.slug).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  it('lists installed skills under insforge- prefix only', async () => {
+    await installBundledSkills({ skillsSrcDir: srcDir, targetDir });
+    // drop a non-insforge-prefixed dir to prove filtering
+    await mkdir(join(targetDir, 'other-skill'), { recursive: true });
+
+    const installed = await listInstalledSkills(targetDir);
+    expect(installed.map((s) => s.slug).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  it('uninstallSkill removes the installed dir and reports removed=true', async () => {
+    await installBundledSkills({ skillsSrcDir: srcDir, targetDir });
+
+    const res = await uninstallSkill('alpha', targetDir);
+    expect(res.removed).toBe(true);
+
+    const entries = await readdir(targetDir);
+    expect(entries).toEqual(['insforge-beta']);
+
+    // Second uninstall is a no-op
+    const again = await uninstallSkill('alpha', targetDir);
+    expect(again.removed).toBe(false);
+  });
+});

--- a/src/lib/skills-install.ts
+++ b/src/lib/skills-install.ts
@@ -1,0 +1,219 @@
+import { access, chmod, copyFile, mkdir, readdir, rm, stat } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type BundledSkillStatus =
+  | 'installed'
+  | 'updated'
+  | 'skipped-exists'
+  | 'skipped-keep-local'
+  | 'missing-source';
+
+export interface BundledSkillsInstallOptions {
+  /** Where to install `insforge-<slug>/SKILL.md` dirs. Defaults to resolveTargetDir(). */
+  targetDir?: string;
+  /** Where bundled `<slug>/SKILL.md` files live. Defaults to resolveBundledSkillsDir(). */
+  skillsSrcDir?: string;
+  /** Overwrite existing installs. Mutually exclusive with keepLocal. */
+  force?: boolean;
+  /** If set, only install skills whose slug is in this list. */
+  only?: string[];
+  /** If true, existing installs are preserved (reported as skipped-keep-local). */
+  keepLocal?: boolean;
+}
+
+export interface BundledSkillResult {
+  slug: string;
+  status: BundledSkillStatus;
+  path: string;
+  bytes?: number;
+}
+
+export interface InstallBundledSkillsResult {
+  targetDir: string;
+  skillsSrcDir: string;
+  results: BundledSkillResult[];
+}
+
+export interface BundledSkillEntry {
+  slug: string;
+  path: string; // absolute path to the SKILL.md source
+}
+
+export interface InstalledSkillEntry {
+  slug: string;
+  path: string; // absolute path to the installed dir (insforge-<slug>)
+}
+
+const FILE_MODE = 0o644;
+const DIR_MODE = 0o755;
+
+/**
+ * Decide where installed skills should live on disk.
+ *
+ * Precedence:
+ *   1. INSFORGE_SKILLS_TARGET_DIR  (test hook / explicit override)
+ *   2. CLAUDE_CONFIG_DIR/skills    (matches Claude Code / Desktop)
+ *   3. XDG_CONFIG_HOME/claude/skills
+ *   4. ~/.claude/skills            (default)
+ */
+export function resolveTargetDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.INSFORGE_SKILLS_TARGET_DIR) return env.INSFORGE_SKILLS_TARGET_DIR;
+  if (env.CLAUDE_CONFIG_DIR) return join(env.CLAUDE_CONFIG_DIR, 'skills');
+  if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, 'claude', 'skills');
+  const home = env.HOME ?? homedir();
+  return join(home, '.claude', 'skills');
+}
+
+/**
+ * Locate the `dist/skills/` directory shipped with the compiled CLI.
+ *
+ * The CLI is bundled with tsup to `dist/index.js`; at publish time we populate
+ * `dist/skills/<slug>/SKILL.md` alongside it. When running from source (e.g.
+ * during tests), `dist/skills/` may not exist — callers should be prepared
+ * for `installBundledSkills` to report `missing-source`.
+ */
+export function resolveBundledSkillsDir(importMetaUrl?: string): string {
+  const here = importMetaUrl ? fileURLToPath(importMetaUrl) : fileURLToPath(import.meta.url);
+  // here ~ .../dist/index.js (published) or .../src/lib/skills-install.ts (dev)
+  const distCandidate = join(dirname(here), 'skills');
+  return distCandidate;
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listBundledSkills(skillsSrcDir?: string): Promise<BundledSkillEntry[]> {
+  const dir = skillsSrcDir ?? resolveBundledSkillsDir();
+  if (!(await dirExists(dir))) return [];
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: BundledSkillEntry[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const skillFile = join(dir, e.name, 'SKILL.md');
+    if (await fileExists(skillFile)) {
+      results.push({ slug: e.name, path: skillFile });
+    }
+  }
+  // stable order
+  results.sort((a, b) => a.slug.localeCompare(b.slug));
+  return results;
+}
+
+export async function listInstalledSkills(targetDir?: string): Promise<InstalledSkillEntry[]> {
+  const dir = targetDir ?? resolveTargetDir();
+  if (!(await dirExists(dir))) return [];
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: InstalledSkillEntry[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (!e.name.startsWith('insforge-')) continue;
+    results.push({
+      slug: e.name.slice('insforge-'.length),
+      path: join(dir, e.name),
+    });
+  }
+  results.sort((a, b) => a.slug.localeCompare(b.slug));
+  return results;
+}
+
+export async function uninstallSkill(
+  slug: string,
+  targetDir?: string,
+): Promise<{ removed: boolean; path: string }> {
+  const dir = targetDir ?? resolveTargetDir();
+  const path = join(dir, `insforge-${slug}`);
+  if (!(await dirExists(path))) {
+    return { removed: false, path };
+  }
+  await rm(path, { recursive: true, force: true });
+  return { removed: true, path };
+}
+
+/**
+ * Copy bundled SKILL.md files into `<targetDir>/insforge-<slug>/SKILL.md`.
+ *
+ * Semantics:
+ *   - No existing dir   → copy, status=installed
+ *   - Existing + force  → overwrite, status=updated
+ *   - Existing + keepLocal → leave alone, status=skipped-keep-local
+ *   - Existing + !force && !keepLocal → leave alone, status=skipped-exists
+ */
+export async function installBundledSkills(
+  opts: BundledSkillsInstallOptions = {},
+): Promise<InstallBundledSkillsResult> {
+  const targetDir = opts.targetDir ?? resolveTargetDir();
+  const skillsSrcDir = opts.skillsSrcDir ?? resolveBundledSkillsDir();
+
+  const bundled = await listBundledSkills(skillsSrcDir);
+  if (bundled.length === 0) {
+    return {
+      targetDir,
+      skillsSrcDir,
+      results: [
+        {
+          slug: '',
+          status: 'missing-source',
+          path: skillsSrcDir,
+        },
+      ],
+    };
+  }
+
+  await mkdir(targetDir, { recursive: true, mode: DIR_MODE });
+
+  const filter = opts.only && opts.only.length > 0 ? new Set(opts.only) : null;
+  const results: BundledSkillResult[] = [];
+
+  for (const skill of bundled) {
+    if (filter && !filter.has(skill.slug)) continue;
+
+    const installedDir = join(targetDir, `insforge-${skill.slug}`);
+    const installedFile = join(installedDir, 'SKILL.md');
+    const alreadyThere = await dirExists(installedDir);
+
+    if (alreadyThere && opts.keepLocal) {
+      results.push({ slug: skill.slug, status: 'skipped-keep-local', path: installedDir });
+      continue;
+    }
+    if (alreadyThere && !opts.force) {
+      results.push({ slug: skill.slug, status: 'skipped-exists', path: installedDir });
+      continue;
+    }
+
+    await mkdir(installedDir, { recursive: true, mode: DIR_MODE });
+    // ensure perms (mkdir honors umask; chmod is authoritative)
+    await chmod(installedDir, DIR_MODE);
+    await copyFile(skill.path, installedFile);
+    await chmod(installedFile, FILE_MODE);
+
+    const s = await stat(installedFile);
+    results.push({
+      slug: skill.slug,
+      status: alreadyThere ? 'updated' : 'installed',
+      path: installedDir,
+      bytes: s.size,
+    });
+  }
+
+  return { targetDir, skillsSrcDir, results };
+}


### PR DESCRIPTION
Closes #74

Implements: [`docs/specs/2026-04-18-bundled-skills-install.md`](docs/specs/2026-04-18-bundled-skills-install.md)

## Summary

- New library `src/lib/skills-install.ts` exporting `installBundledSkills({ targetDir, force, skillsSrcDir, only, keepLocal })` — the primitive that both `insforge skills install` and CLI#73's `insforge init` wrapper will call.
- New subcommand family under `insforge skills`: `list`, `install [name]`, `update [name] [--keep-local]`, `uninstall <name>`. Mirrors the shape of `src/commands/secrets/`, `src/commands/projects/`, `src/commands/diagnose/` exactly.
- Build-time bundling: `scripts/build-skills.sh` clones `InsForge/insforge-skills` and populates `dist/skills/<slug>/SKILL.md`. Wired into `prepublishOnly`; local `npm run build` stays offline.
- Env overrides: default target is `~/.claude/skills/`; `CLAUDE_CONFIG_DIR` → `<CLAUDE_CONFIG_DIR>/skills`, `XDG_CONFIG_HOME` → `<XDG_CONFIG_HOME>/claude/skills`. `INSFORGE_SKILLS_TARGET_DIR` is a test/override hook.
- README gets a new `insforge skills` subsection under the existing Agent Skills docs, including precedence rules and the "no skills bundled" dev-build hint.

## Coexistence with #72

PR #72 recently merged a different-mechanism installer (`installSkills(json)` in `src/lib/skills.ts`, shells out to `npx skills add insforge/agent-skills -g`). That path is untouched. The new library is named `installBundledSkills()` so the two exports coexist; the ticket's pinned comment confirms `skills` is a primitive family that `init` (CLI#73) wraps.

`src/commands/init.ts` is **not** touched — CLI#73 owns that integration.

## Test plan

- [x] `npm run lint` — green (vitest + eslint, both pass)
- [x] `npm test` — 83 pass (14 new), 13 skipped
- [x] `npm run build` — green, `dist/index.js` built (209 KB)
- [x] End-to-end smoke: fake fixture bundle → `insforge skills list` (shows bundled), `install` (writes files), `list` (shows installed), `uninstall agent-auth` (removes only that one). Verified on the local built `dist/index.js`.
- [x] `scripts/build-skills.sh` tested with `INSFORGE_SKILLS_LOCAL_DIR` against a fixture — correctly strips `skill-` prefix and copies `SKILL.md`.
- [ ] Follow-up on real `InsForge/insforge-skills` repo pulled at publish time — verifiable once the publish pipeline runs, or by running `npm run build:skills` locally with network access.

## Not in scope

- Wiring `installBundledSkills()` into `insforge init` (CLI#73).
- Removing or deprecating `installSkills()` in `src/lib/skills.ts`.
- Telemetry (`reportCliUsage`) on the new commands — follow-up, not behavioral.

## Risks

- `scripts/build-skills.sh` pulls from a remote repo at `prepublishOnly`. If the upstream branch layout changes, the script falls back from `skill-*/SKILL.md` to `*/SKILL.md` so it degrades gracefully. It exits 1 (loudly) on clone failure during publish so we don't ship an empty `dist/skills/`.
- `fs/promises.cp` is not used (we use `copyFile` + explicit `chmod`), so perms are set authoritatively regardless of umask.