### PR TITLE
 INS-73 fix(link): clearer error when user can't access project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -159,7 +159,7 @@ export function registerProjectLinkCommand(program: Command): void {
           if (err instanceof CLIError && (err.exitCode === 5 || err.exitCode === 4 || err.message.includes('not found'))) {
             const identity = creds.user?.email ?? creds.user?.name ?? 'unknown user';
             throw new CLIError(
-              `You're logged in as ${identity}, but can't access project ${projectId}. It's likely you're logged into the wrong account, or you don't own the project. Double-check the account and project ID, then run \`npx @insforge/cli logout\` and log in again to switch accounts.`,
+              `No access to project ${projectId} as ${identity}. Double-check the project ID, or run \`npx @insforge/cli logout\` to switch accounts.`,
               5,
               'PERMISSION_DENIED',
             );

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -13,7 +13,7 @@ import {
   getProjectApiKey,
   reportAgentConnected,
 } from '../../lib/api/platform.js';
-import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, FAKE_PROJECT_ID, FAKE_ORG_ID } from '../../lib/config.js';
+import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, getPlatformApiUrl, FAKE_PROJECT_ID, FAKE_ORG_ID } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
@@ -158,8 +158,9 @@ export function registerProjectLinkCommand(program: Command): void {
         } catch (err) {
           if (err instanceof CLIError && (err.exitCode === 5 || err.exitCode === 4 || err.message.includes('not found'))) {
             const identity = creds.user?.email ?? creds.user?.name ?? 'unknown user';
+            const currentApiUrl = getPlatformApiUrl(apiUrl);
             throw new CLIError(
-              `You're logged in as ${identity}, and you don't have access to project ${projectId}. Check that the project ID is correct and belongs to one of your organizations.`,
+              `You're logged in as ${identity} on ${currentApiUrl}, but can't access project ${projectId}. It's likely you're logged into the wrong account, or you don't own the project. Double-check the account and project ID, then run \`npx @insforge/cli logout\` and log in again to switch accounts.`,
               5,
               'PERMISSION_DENIED',
             );

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -13,7 +13,7 @@ import {
   getProjectApiKey,
   reportAgentConnected,
 } from '../../lib/api/platform.js';
-import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, getPlatformApiUrl, FAKE_PROJECT_ID, FAKE_ORG_ID } from '../../lib/config.js';
+import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, FAKE_PROJECT_ID, FAKE_ORG_ID } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
@@ -158,9 +158,8 @@ export function registerProjectLinkCommand(program: Command): void {
         } catch (err) {
           if (err instanceof CLIError && (err.exitCode === 5 || err.exitCode === 4 || err.message.includes('not found'))) {
             const identity = creds.user?.email ?? creds.user?.name ?? 'unknown user';
-            const currentApiUrl = getPlatformApiUrl(apiUrl);
             throw new CLIError(
-              `You're logged in as ${identity} on ${currentApiUrl}, but can't access project ${projectId}. It's likely you're logged into the wrong account, or you don't own the project. Double-check the account and project ID, then run \`npx @insforge/cli logout\` and log in again to switch accounts.`,
+              `You're logged in as ${identity}, but can't access project ${projectId}. It's likely you're logged into the wrong account, or you don't own the project. Double-check the account and project ID, then run \`npx @insforge/cli logout\` and log in again to switch accounts.`,
               5,
               'PERMISSION_DENIED',
             );


### PR DESCRIPTION
## Summary
- Rewrites the `insforge link` \"don't have access to project\" error to tell the user the two likely causes (wrong account, or not the owner) and give them the exact `npx @insforge/cli logout` + login command to switch accounts.
- Includes the current platform API URL in the error so users who are pointed at prod while looking for a staging project (or vice versa) can see the mismatch.
- Bumps version to 0.1.54.

## Before
> You're logged in as fermioniclyu@gmail.com, and you don't have access to project 652ed73c-8169-409c-b0f3-c0fdaeabf5da. Check that the project ID is correct and belongs to one of your organizations.

## After
> You're logged in as fermioniclyu@gmail.com on https://api.insforge.dev, but can't access project 652ed73c-8169-409c-b0f3-c0fdaeabf5da. It's likely you're logged into the wrong account, or you don't own the project. Double-check the account and project ID, then run \`npx @insforge/cli logout\` and log in again to switch accounts.

## Test plan
- [ ] Run \`insforge link --project-id <id-you-don't-own>\` and confirm the new message renders.
- [ ] Confirm \`--api-url\` override is reflected in the printed API URL.
- [ ] Confirm exit code is still 5 (\`PERMISSION_DENIED\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.1.54

* **Bug Fixes**
  * Improved project-linking error messages for permission/access issues: clearer explanation of likely causes and explicit re-authentication steps (logout and login) to restore access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->