### PR TITLE
feat(link): support --template in direct-link mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.53",
+  "version": "0.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.53",
+      "version": "0.1.55",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -39,6 +39,14 @@ export function registerProjectLinkCommand(program: Command): void {
     .option('--api-key <key>', 'API Key for direct linking (OSS/Self-hosted)')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
+
+      // Shared template validation — applies to both direct-link and OAuth paths.
+      const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce', 'todo'];
+      const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
+      if (opts.template && !validTemplates.includes(opts.template)) {
+        throw new CLIError(`Invalid template "${opts.template}". Valid options: ${validTemplates.join(', ')}`);
+      }
+
       try {
         if (opts.apiBaseUrl || opts.apiKey) {
           try {
@@ -63,6 +71,104 @@ export function registerProjectLinkCommand(program: Command): void {
               oss_host: opts.apiBaseUrl.replace(/\/$/, ''), // remove trailing slash if any
             };
 
+            const template = opts.template as string | undefined;
+
+            // Template path: create a subdirectory, link inside it, download template,
+            // install deps. Mirrors the OAuth template flow below.
+            if (template) {
+              const defaultDir = `insforge-${template}`;
+              let dirName = defaultDir;
+              if (!json) {
+                const inputDir = await prompts.text({
+                  message: 'Directory name:',
+                  initialValue: defaultDir,
+                  validate: (v) => {
+                    if (v.length < 1) return 'Directory name is required';
+                    const normalized = path.basename(v).replace(/[^a-zA-Z0-9._-]/g, '-');
+                    if (!normalized || normalized === '.' || normalized === '..') return 'Invalid directory name';
+                    return undefined;
+                  },
+                });
+                if (prompts.isCancel(inputDir)) process.exit(0);
+                dirName = path.basename(inputDir).replace(/[^a-zA-Z0-9._-]/g, '-');
+              }
+
+              if (!dirName || dirName === '.' || dirName === '..') {
+                throw new CLIError('Invalid directory name.');
+              }
+
+              const templateDir = path.resolve(process.cwd(), dirName);
+              const dirExists = await fs.stat(templateDir).catch(() => null);
+              if (dirExists) {
+                throw new CLIError(`Directory "${dirName}" already exists.`);
+              }
+              await fs.mkdir(templateDir);
+              process.chdir(templateDir);
+
+              saveProjectConfig(projectConfig);
+
+              if (json) {
+                outputJson({
+                  success: true,
+                  project: { id: projectConfig.project_id, name: projectConfig.project_name, region: projectConfig.region },
+                  directory: dirName,
+                  template,
+                });
+              } else {
+                outputSuccess(`Linked to direct project at ${projectConfig.oss_host}`);
+              }
+
+              captureEvent(FAKE_ORG_ID, 'template_selected', { template, source: 'link_direct' });
+
+              if (githubTemplates.includes(template)) {
+                await downloadGitHubTemplate(template, projectConfig, json);
+              } else {
+                await downloadTemplate(template as Framework, projectConfig, dirName, json, apiUrl);
+              }
+
+              const templateDownloaded = await fs.stat(path.join(process.cwd(), 'package.json')).catch(() => null);
+
+              if (templateDownloaded && !json) {
+                const installSpinner = clack.spinner();
+                installSpinner.start('Installing dependencies...');
+                try {
+                  await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
+                  installSpinner.stop('Dependencies installed');
+                } catch (err) {
+                  installSpinner.stop('Failed to install dependencies');
+                  clack.log.warn(`npm install failed: ${(err as Error).message}`);
+                  clack.log.info('Run `npm install` manually to install dependencies.');
+                }
+              }
+
+              await installSkills(json);
+              trackCommand('link', 'oss-org', { direct: true, template });
+              await reportCliUsage('cli.link_direct', true, 6, projectConfig);
+
+              // Report agent-connected event (best-effort)
+              try {
+                const urlMatch = opts.apiBaseUrl.match(/^https?:\/\/([^.]+)\.[^.]+\.insforge\.app/);
+                if (urlMatch) {
+                  await reportAgentConnected({ app_key: urlMatch[1] }, apiUrl);
+                }
+              } catch { /* ignore */ }
+
+              if (!json) {
+                if (templateDownloaded) {
+                  const runCommand = `${pc.cyan('cd')} ${pc.green(dirName)} ${pc.dim('&&')} ${pc.cyan('npm run dev')}`;
+                  const steps = [
+                    `${pc.bold('1.')} ${runCommand}`,
+                    `${pc.bold('2.')} Open ${pc.cyan('Claude Code')} or ${pc.cyan('Cursor')} and prompt your agent to add more features`,
+                  ];
+                  clack.note(steps.join('\n'), "What's next");
+                } else {
+                  clack.log.warn('Template download failed. You can retry or set up manually.');
+                }
+              }
+              return;
+            }
+
+            // Non-template direct-link: save config in cwd and return.
             saveProjectConfig(projectConfig);
 
             if (json) {
@@ -195,14 +301,10 @@ export function registerProjectLinkCommand(program: Command): void {
           await reportAgentConnected({ project_id: project.id }, apiUrl);
         } catch { /* ignore */ }
 
-        // Template download (only when --template flag is passed)
+        // Template download (only when --template flag is passed).
+        // Validation already ran at the top of the action.
         const template = opts.template as string | undefined;
         if (template) {
-          const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce', 'todo'];
-          if (!validTemplates.includes(template)) {
-            throw new CLIError(`Invalid template "${template}". Valid options: ${validTemplates.join(', ')}`);
-          }
-
           // Ask for directory name
           let dirName = project.name;
           if (!json) {
@@ -237,8 +339,7 @@ export function registerProjectLinkCommand(program: Command): void {
 
           captureEvent(orgId ?? project.organization_id, 'template_selected', { template, source: 'link' });
 
-          // Download template
-          const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
+          // Download template (githubTemplates defined at the top of the action)
           if (githubTemplates.includes(template)) {
             await downloadGitHubTemplate(template, projectConfig, json);
           } else {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -19,7 +19,7 @@ import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { installSkills, reportCliUsage } from '../../lib/skills.js';
 import { captureEvent, trackCommand, shutdownAnalytics } from '../../lib/analytics.js';
-import { downloadGitHubTemplate, downloadTemplate, type Framework } from '../create.js';
+import { downloadGitHubTemplate } from '../create.js';
 import type { ProjectConfig } from '../../types.js';
 
 const execAsync = promisify(exec);
@@ -40,14 +40,16 @@ export function registerProjectLinkCommand(program: Command): void {
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
 
-      // Shared template validation — applies to both direct-link and OAuth paths.
+      // Every template value accepted here is a directory in the InsForge
+      // templates repo, so validation and the download call reference the
+      // same single list.
       const validTemplates = ['react', 'nextjs', 'chatbot', 'crm', 'e-commerce', 'todo'];
-      const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
-      if (opts.template && !validTemplates.includes(opts.template)) {
-        throw new CLIError(`Invalid template "${opts.template}". Valid options: ${validTemplates.join(', ')}`);
-      }
 
       try {
+        if (opts.template && !validTemplates.includes(opts.template)) {
+          throw new CLIError(`Invalid template "${opts.template}". Valid options: ${validTemplates.join(', ')}`);
+        }
+
         if (opts.apiBaseUrl || opts.apiKey) {
           try {
             if (!opts.apiBaseUrl || !opts.apiKey) {
@@ -120,11 +122,7 @@ export function registerProjectLinkCommand(program: Command): void {
 
               captureEvent(FAKE_ORG_ID, 'template_selected', { template, source: 'link_direct' });
 
-              if (githubTemplates.includes(template)) {
-                await downloadGitHubTemplate(template, projectConfig, json);
-              } else {
-                await downloadTemplate(template as Framework, projectConfig, dirName, json, apiUrl);
-              }
+              await downloadGitHubTemplate(template, projectConfig, json);
 
               const templateDownloaded = await fs.stat(path.join(process.cwd(), 'package.json')).catch(() => null);
 
@@ -339,12 +337,7 @@ export function registerProjectLinkCommand(program: Command): void {
 
           captureEvent(orgId ?? project.organization_id, 'template_selected', { template, source: 'link' });
 
-          // Download template (githubTemplates defined at the top of the action)
-          if (githubTemplates.includes(template)) {
-            await downloadGitHubTemplate(template, projectConfig, json);
-          } else {
-            await downloadTemplate(template as Framework, projectConfig, project.name, json, apiUrl);
-          }
+          await downloadGitHubTemplate(template, projectConfig, json);
 
           // Only proceed with install/next steps if template actually downloaded
           const templateDownloaded = await fs.stat(path.join(process.cwd(), 'package.json')).catch(() => null);


### PR DESCRIPTION
## Summary

`link --template <name>` was advertised in `--help` but silently ignored when combined with `--api-base-url` + `--api-key`. The direct-link branch did `saveProjectConfig` → `installSkills` → `return` before ever touching the template handling code. This meant the agent-facing signup + link flow (used by the public skill.md on insforge.dev) had to fall back to a six-step manual recipe — clone template, `cd` in, link, fetch anon key via HTTP, write `.env.local`, run migration, npm install — to do what the OAuth path already does in one command.

This PR wires the direct-link branch into the same template flow used by the OAuth path.

## Changes in `src/commands/projects/link.ts`

- Pull template-name validation to the top of the action (shared between both paths). Invalid names fail before any I/O.
- Hoist `githubTemplates` to action scope so both paths reference the same list.
- When `--template` is set alongside `--api-base-url` + `--api-key`:
  - Prompt for a directory name (default `insforge-<template>` since direct-link has no `project.name` from the platform API).
  - `mkdir` / `chdir` into the new directory.
  - `saveProjectConfig` inside the template dir (so the CLI's CWD-only `.insforge/project.json` lookup finds it).
  - Call `downloadGitHubTemplate` (for `chatbot` / `crm` / `e-commerce` / `todo` / `react-github-copy` / `nextjs-github-copy`) or `downloadTemplate` (for the `react` / `nextjs` `create-insforge-app` scaffolds).
  - `npm install` in the new directory.
  - `installSkills`, record the existing `cli.link_direct` telemetry event (with `template` added to the payload), emit the same "What's next" note as the OAuth template flow.
- Non-template direct-link behavior is preserved exactly as-is.
- OAuth path is untouched except for two tiny refactors: it now uses the hoisted `validTemplates` and `githubTemplates` instead of re-declaring them.

## Why the default dir is `insforge-<template>`

OAuth defaults to `project.name` because `listProjects` returned it. Direct-link uses sentinel values (`FAKE_PROJECT_ID`, `project_name: 'oss-project'`, `appkey: 'ossfkey'`), so that's a poor default. `insforge-<template>` matches the convention `create-insforge-app` uses for its own default directory when `--projectName` is omitted.

## Verification

- [x] `npx tsc --noEmit` — clean on `link.ts` (pre-existing errors elsewhere in the repo are unrelated).
- [x] `npm run lint` — vitest 92/92 tests pass, eslint 0 errors.
- [x] `tsup` build succeeds.
- [x] Built `dist/index.js` contains the new branch at lines 2160–2241 with the correct control flow.
- [x] `link --help` output unchanged.
- [ ] **End-to-end smoke test against a real project** — not run from my sandbox. Please verify before publish:
  ```bash
  npx @insforge/cli link --api-base-url <url> --api-key <key> --template chatbot
  ```
  Expected: prompts for dir name (default `insforge-chatbot`), clones the chatbot template into that dir, writes `.env.local` with real `projectUrl` + anon key + `NEXT_PUBLIC_APP_URL`, applies `migrations/db_init.sql`, runs `npm install`, prints the "What's next" note.

## Follow-up

Once this is published, the public `skill.md` flow (insforge-cloud PR #376) can be simplified from the six-step manual recipe to a single `link --template` call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validates template selection during project linking to prevent invalid choices.
  * Direct API linking now supports creating a template-based project directory, downloading the template, saving configuration, and running initial setup (including dependency install when applicable).
  * OAuth linking retains guided template setup and post-configuration "What's next" guidance.

* **Chores**
  * Package version updated to 0.1.55.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->