### PR TITLE
feat(migrations): accept any numeric prefix for migration versions

### DIFF
--- a/src/commands/db/migrations.ts
+++ b/src/commands/db/migrations.ts
@@ -143,6 +143,15 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
 
         const migrations = await fetchRemoteMigrations();
         const migrationsDir = ensureMigrationsDir();
+        // Skip by canonical version, not just filepath: a local `0001_foo.sql`
+        // and a remote `1_foo.sql` refer to the same migration, and writing
+        // both would fail parseStrictLocalMigrations' duplicate-version check.
+        const existingLocalVersions = new Set(
+          listLocalMigrationFilenames()
+            .map((filename) => parseMigrationFilename(filename))
+            .filter((migration): migration is NonNullable<typeof migration> => migration !== null)
+            .map((migration) => migration.version),
+        );
         const createdFiles: string[] = [];
         const skippedFiles: string[] = [];
 
@@ -157,13 +166,14 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
           );
           const filePath = join(migrationsDir, filename);
 
-          if (existsSync(filePath)) {
+          if (existingLocalVersions.has(migration.version) || existsSync(filePath)) {
             skippedFiles.push(filename);
             continue;
           }
 
           writeFileSync(filePath, formatMigrationSql(migration.statements));
           createdFiles.push(filename);
+          existingLocalVersions.add(migration.version);
         }
 
         if (json) {

--- a/src/commands/db/migrations.ts
+++ b/src/commands/db/migrations.ts
@@ -5,7 +5,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
 import {
-  assertValidMigrationVersion,
+  canonicalMigrationVersion,
   compareMigrationVersions,
   ensureMigrationsDir,
   findOlderThanHeadLocalMigrations,
@@ -61,7 +61,7 @@ async function fetchRemoteMigrations(): Promise<Migration[]> {
   const migrations = Array.isArray(raw.migrations) ? raw.migrations : [];
 
   for (const migration of migrations) {
-    assertValidMigrationVersion(migration.version);
+    migration.version = canonicalMigrationVersion(migration.version);
   }
 
   return migrations;

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -228,6 +228,18 @@ describe('incrementMigrationVersion', () => {
   it('increments to the next second', () => {
     expect(incrementMigrationVersion('20260418235959')).toBe('20260419000000');
   });
+
+  it('increments a non-timestamp numeric version via BigInt', () => {
+    expect(incrementMigrationVersion('1')).toBe('2');
+    expect(incrementMigrationVersion('9')).toBe('10');
+  });
+
+  it('throws CLIError (not SyntaxError) on invalid input', () => {
+    expect(() => incrementMigrationVersion('abc')).toThrow(/invalid migration version/i);
+    expect(() => incrementMigrationVersion('9'.repeat(65))).toThrow(
+      /invalid migration version/i,
+    );
+  });
 });
 
 describe('resolveMigrationTarget', () => {

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   assertValidMigrationVersion,
+  canonicalMigrationVersion,
   compareMigrationVersions,
   findLocalMigrationByVersion,
   findOlderThanHeadLocalMigrations,
@@ -23,10 +24,10 @@ describe('parseMigrationFilename', () => {
     });
   });
 
-  it('accepts any numeric prefix (e.g. Drizzle-style)', () => {
+  it('accepts any numeric prefix (e.g. Drizzle-style) and canonicalizes the version', () => {
     expect(parseMigrationFilename('0001_add-post-index.sql')).toEqual({
       filename: '0001_add-post-index.sql',
-      version: '0001',
+      version: '1',
       name: 'add-post-index',
     });
     expect(parseMigrationFilename('42_add-post-index.sql')).toEqual({
@@ -42,6 +43,24 @@ describe('parseMigrationFilename', () => {
     expect(parseMigrationFilename('20260418091500 add-post-index.sql')).toBeNull();
     expect(parseMigrationFilename('abc_add-post-index.sql')).toBeNull();
     expect(parseMigrationFilename('_add-post-index.sql')).toBeNull();
+  });
+});
+
+describe('canonicalMigrationVersion', () => {
+  it('strips leading zeros so padded numeric prefixes match unpadded ones', () => {
+    expect(canonicalMigrationVersion('0001')).toBe('1');
+    expect(canonicalMigrationVersion('00042')).toBe('42');
+    expect(canonicalMigrationVersion('1')).toBe('1');
+    expect(canonicalMigrationVersion('0')).toBe('0');
+  });
+
+  it('leaves 14-digit timestamps unchanged', () => {
+    expect(canonicalMigrationVersion('20260418091500')).toBe('20260418091500');
+  });
+
+  it('throws on non-numeric input', () => {
+    expect(() => canonicalMigrationVersion('abc')).toThrow(/invalid migration version/i);
+    expect(() => canonicalMigrationVersion('../1')).toThrow(/invalid migration version/i);
   });
 });
 
@@ -156,6 +175,12 @@ describe('parseStrictLocalMigrations', () => {
       ])
     ).toThrow(/duplicate local migration version/i);
   });
+
+  it('treats padded and unpadded numeric prefixes of the same value as duplicates', () => {
+    expect(() =>
+      parseStrictLocalMigrations(['0001_create-users.sql', '1_create-accounts.sql'])
+    ).toThrow(/duplicate local migration version/i);
+  });
 });
 
 describe('formatMigrationSql', () => {
@@ -206,6 +231,19 @@ describe('resolveMigrationTarget', () => {
       filename: '20260418091600_add-user-index.sql',
       version: '20260418091600',
       name: 'add-user-index',
+    });
+  });
+
+  it('resolves a padded numeric target against an unpadded filename and vice versa', () => {
+    expect(resolveMigrationTarget('0001', ['1_create-users.sql'])).toEqual({
+      filename: '1_create-users.sql',
+      version: '1',
+      name: 'create-users',
+    });
+    expect(resolveMigrationTarget('1', ['0001_create-users.sql'])).toEqual({
+      filename: '0001_create-users.sql',
+      version: '1',
+      name: 'create-users',
     });
   });
 

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -23,30 +23,57 @@ describe('parseMigrationFilename', () => {
     });
   });
 
+  it('accepts any numeric prefix (e.g. Drizzle-style)', () => {
+    expect(parseMigrationFilename('0001_add-post-index.sql')).toEqual({
+      filename: '0001_add-post-index.sql',
+      version: '0001',
+      name: 'add-post-index',
+    });
+    expect(parseMigrationFilename('42_add-post-index.sql')).toEqual({
+      filename: '42_add-post-index.sql',
+      version: '42',
+      name: 'add-post-index',
+    });
+  });
+
   it('rejects invalid migration filenames', () => {
-    expect(parseMigrationFilename('20260418_add-post-index.sql')).toBeNull();
     expect(parseMigrationFilename('20260418091500_add_post_index.sql')).toBeNull();
     expect(parseMigrationFilename('20260418091500_AddPostIndex.sql')).toBeNull();
     expect(parseMigrationFilename('20260418091500 add-post-index.sql')).toBeNull();
+    expect(parseMigrationFilename('abc_add-post-index.sql')).toBeNull();
+    expect(parseMigrationFilename('_add-post-index.sql')).toBeNull();
   });
 });
 
 describe('assertValidMigrationVersion', () => {
-  it('accepts a timestamp-formatted migration version', () => {
+  it('accepts any pure-digit migration version', () => {
     expect(() => assertValidMigrationVersion('20260418091500')).not.toThrow();
+    expect(() => assertValidMigrationVersion('20260418')).not.toThrow();
+    expect(() => assertValidMigrationVersion('0001')).not.toThrow();
+    expect(() => assertValidMigrationVersion('42')).not.toThrow();
   });
 
-  it('rejects invalid migration versions', () => {
-    expect(() => assertValidMigrationVersion('20260418')).toThrow(/invalid migration version/i);
+  it('rejects non-numeric or unsafe migration versions', () => {
     expect(() => assertValidMigrationVersion('../20260418091500')).toThrow(
       /invalid migration version/i,
     );
+    expect(() => assertValidMigrationVersion('abc')).toThrow(/invalid migration version/i);
+    expect(() => assertValidMigrationVersion('')).toThrow(/invalid migration version/i);
   });
 });
 
 describe('compareMigrationVersions', () => {
-  it('orders versions lexicographically by time', () => {
+  it('orders timestamp versions by time', () => {
     expect(compareMigrationVersions('20260418091500', '20260418091501')).toBeLessThan(0);
+  });
+
+  it('orders numeric versions of different widths numerically, not lexicographically', () => {
+    expect(compareMigrationVersions('2', '10')).toBeLessThan(0);
+    expect(compareMigrationVersions('0002', '0010')).toBeLessThan(0);
+  });
+
+  it('orders a short numeric prefix before a timestamp', () => {
+    expect(compareMigrationVersions('0001', '20260418091500')).toBeLessThan(0);
   });
 });
 

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -79,6 +79,13 @@ describe('assertValidMigrationVersion', () => {
     expect(() => assertValidMigrationVersion('abc')).toThrow(/invalid migration version/i);
     expect(() => assertValidMigrationVersion('')).toThrow(/invalid migration version/i);
   });
+
+  it('rejects versions longer than 64 digits', () => {
+    expect(() => assertValidMigrationVersion('9'.repeat(65))).toThrow(
+      /invalid migration version/i,
+    );
+    expect(() => assertValidMigrationVersion('9'.repeat(64))).not.toThrow();
+  });
 });
 
 describe('compareMigrationVersions', () => {

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -10,12 +10,16 @@ export interface ParsedMigrationFile {
 
 export type RemoteMigrationVersionStatus = 'already-applied' | 'older-than-head' | 'pending';
 
-const MIGRATION_VERSION_REGEX = /^\d+$/u;
-const MIGRATION_FILENAME_REGEX = /^(\d+)_([a-z0-9-]+)\.sql$/u;
+// Cap at 64 digits so unbounded input can't DoS BigInt conversions or
+// the backend's `version::numeric` casts. 64 comfortably fits 4-digit
+// Drizzle sequences, 14-digit YYYYMMDDHHmmss timestamps, and anything
+// realistic in between.
+const MIGRATION_VERSION_REGEX = /^\d{1,64}$/u;
+const MIGRATION_FILENAME_REGEX = /^(\d{1,64})_([a-z0-9-]+)\.sql$/u;
 
 export function assertValidMigrationVersion(version: string): void {
   if (!MIGRATION_VERSION_REGEX.test(version)) {
-    throw new CLIError(`Invalid migration version: ${version}. Expected a numeric version (e.g. 0001 or 20260418091500).`);
+    throw new CLIError(`Invalid migration version: ${version}. Expected a numeric string of at most 64 digits (e.g. 0001 or 20260418091500).`);
   }
 }
 
@@ -41,7 +45,7 @@ export function parseMigrationFilename(filename: string): ParsedMigrationFile | 
 }
 
 export function compareMigrationVersions(left: string, right: string): number {
-  if (/^\d+$/u.test(left) && /^\d+$/u.test(right)) {
+  if (MIGRATION_VERSION_REGEX.test(left) && MIGRATION_VERSION_REGEX.test(right)) {
     const a = BigInt(left);
     const b = BigInt(right);
     return a < b ? -1 : a > b ? 1 : 0;
@@ -223,7 +227,7 @@ export function resolveMigrationTarget(
   target: string,
   filenames: string[],
 ): ParsedMigrationFile {
-  if (/^\d+$/u.test(target)) {
+  if (/^\d{1,64}$/u.test(target)) {
     return findLocalMigrationByVersion(target, filenames);
   }
 

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -19,6 +19,14 @@ export function assertValidMigrationVersion(version: string): void {
   }
 }
 
+// Numeric prefixes like "0001" and "1" refer to the same migration. Strip
+// leading zeros so Set lookups, equality checks, and duplicate detection all
+// agree with the numeric ordering in compareMigrationVersions.
+export function canonicalMigrationVersion(version: string): string {
+  assertValidMigrationVersion(version);
+  return BigInt(version).toString();
+}
+
 export function parseMigrationFilename(filename: string): ParsedMigrationFile | null {
   const match = MIGRATION_FILENAME_REGEX.exec(filename);
   if (!match) {
@@ -27,7 +35,7 @@ export function parseMigrationFilename(filename: string): ParsedMigrationFile | 
 
   return {
     filename,
-    version: match[1],
+    version: canonicalMigrationVersion(match[1]),
     name: match[2],
   };
 }
@@ -190,11 +198,12 @@ export function findLocalMigrationByVersion(
   version: string,
   filenames: string[],
 ): ParsedMigrationFile {
+  const canonicalVersion = canonicalMigrationVersion(version);
   const matches = filenames
     .map((filename) => parseMigrationFilename(filename))
     .filter(
       (migration): migration is ParsedMigrationFile =>
-        migration !== null && migration.version === version,
+        migration !== null && migration.version === canonicalVersion,
     );
 
   if (matches.length === 0) {

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -10,12 +10,12 @@ export interface ParsedMigrationFile {
 
 export type RemoteMigrationVersionStatus = 'already-applied' | 'older-than-head' | 'pending';
 
-const MIGRATION_VERSION_REGEX = /^\d{14}$/u;
-const MIGRATION_FILENAME_REGEX = /^(\d{14})_([a-z0-9-]+)\.sql$/u;
+const MIGRATION_VERSION_REGEX = /^\d+$/u;
+const MIGRATION_FILENAME_REGEX = /^(\d+)_([a-z0-9-]+)\.sql$/u;
 
 export function assertValidMigrationVersion(version: string): void {
   if (!MIGRATION_VERSION_REGEX.test(version)) {
-    throw new CLIError(`Invalid migration version: ${version}. Expected YYYYMMDDHHmmss.`);
+    throw new CLIError(`Invalid migration version: ${version}. Expected a numeric version (e.g. 0001 or 20260418091500).`);
   }
 }
 
@@ -33,6 +33,11 @@ export function parseMigrationFilename(filename: string): ParsedMigrationFile | 
 }
 
 export function compareMigrationVersions(left: string, right: string): number {
+  if (/^\d+$/u.test(left) && /^\d+$/u.test(right)) {
+    const a = BigInt(left);
+    const b = BigInt(right);
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
   return left.localeCompare(right);
 }
 
@@ -67,6 +72,9 @@ function formatMigrationVersion(date: Date): string {
 }
 
 export function incrementMigrationVersion(version: string): string {
+  if (!/^\d{14}$/u.test(version)) {
+    return String(BigInt(version) + 1n);
+  }
   const year = Number(version.slice(0, 4));
   const month = Number(version.slice(4, 6)) - 1;
   const day = Number(version.slice(6, 8));
@@ -206,7 +214,7 @@ export function resolveMigrationTarget(
   target: string,
   filenames: string[],
 ): ParsedMigrationFile {
-  if (/^\d{14}$/u.test(target)) {
+  if (/^\d+$/u.test(target)) {
     return findLocalMigrationByVersion(target, filenames);
   }
 

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -84,6 +84,7 @@ function formatMigrationVersion(date: Date): string {
 }
 
 export function incrementMigrationVersion(version: string): string {
+  assertValidMigrationVersion(version);
   if (!/^\d{14}$/u.test(version)) {
     return String(BigInt(version) + 1n);
   }


### PR DESCRIPTION
## Summary

Relax the migration version/filename format so that Drizzle-style sequential numbering (e.g. `0001_create-users.sql`) is accepted alongside the existing `YYYYMMDDHHmmss_create-users.sql` timestamps.

Motivation: users bringing existing Drizzle (or similar) migration files today hit `CLIError: Invalid migration filename` before anything ever reaches the backend. The 14-digit requirement is policy, not a physical constraint — numeric prefixes sort cleanly if we compare numerically.

## Changes

- `MIGRATION_VERSION_REGEX` / `MIGRATION_FILENAME_REGEX`: `\d{14}` → `\d+`. `assertValidMigrationVersion` still rejects non-digits (incl. path-traversal like `../…`).
- `compareMigrationVersions`: when both sides are pure digits, compare as `BigInt` so that `"2" < "10"` and a short numeric prefix sorts before a 14-digit timestamp. Falls back to `localeCompare` otherwise.
- `incrementMigrationVersion`: for non-14-digit numeric inputs, increment via `BigInt + 1n`. 14-digit timestamps keep the existing `Date`-based rollover logic (so `20260418235959` → `20260419000000` still works).
- `resolveMigrationTarget`: treat any pure-digit target as a version lookup, not just 14-digit.

CLI-generated filenames continue to use 14-digit timestamps by default — this PR only *accepts* more inputs, it doesn't change what `db migrations new` produces.

## Test plan

- [x] `npx vitest run src/lib/migrations.test.ts` — 26 tests pass (new cases added for `0001_foo.sql`, `42_foo.sql`, numeric-width ordering, short-vs-timestamp ordering)
- [x] `npx vitest run` — full suite 95 passed / 13 skipped
- [x] `npx eslint src/lib/migrations.ts src/lib/migrations.test.ts` — clean
- [ ] Smoke test with a Drizzle-style `0001_foo.sql` against a backend that also has the companion relaxation (InsForge/InsForge PR for `createMigrationRequestSchema`, `migrationSchema`, and the `custom_migrations_version_check` constraint)

## Related

Paired with a backend PR in InsForge/InsForge that relaxes `createMigrationRequestSchema` / `migrationSchema`, the `custom_migrations_version_check` DB constraint, and the service-layer ordering/comparison. **This CLI change will 400 against an unrelaxed backend** — land the backend first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migration version handling now accepts any digit-only version (1–64 digits), normalizes numeric versions by stripping leading zeros, orders and increments numeric versions by numeric value, and treats padded/unpadded equivalents as duplicates when resolving or fetching migrations.

* **Tests**
  * Expanded test coverage for parsing, validation, comparison, incrementation, duplicate detection, and target resolution; non-numeric, empty, overly long, and otherwise invalid inputs are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->