### PR TITLE
fix(cli): pass through resource 404s on /api/compute

### DIFF
--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -65,12 +65,16 @@ export async function ossFetch(
       message += `\n${err.nextActions}`;
     }
 
-    // Feature not available on this backend version
-    if (res.status === 404 && path.startsWith('/api/compute')) {
+    // Feature not available on this backend version — ONLY when the 404 is a
+    // route-level miss (no structured error code), not a resource-level miss
+    // like COMPUTE_SERVICE_NOT_FOUND. Otherwise we'd hide real "service doesn't
+    // exist" errors behind a misleading "feature not enabled" message.
+    const isRouteLevel404 = !err.error || err.error === 'NOT_FOUND';
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/compute')) {
       message = 'Compute services are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin to enable compute.';
     }
 
-    if (res.status === 404 && path === '/api/database/migrations') {
+    if (res.status === 404 && isRouteLevel404 && path === '/api/database/migrations') {
       message = 'Database migrations are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin about database migration support.';
     }
 


### PR DESCRIPTION
## Summary

A catch-all in `ossFetch` treated **any** 404 on `/api/compute/*` as "compute is not enabled on this backend." That's wrong for resource-level 404s like `COMPUTE_SERVICE_NOT_FOUND` — the feature works, the specific service just doesn't exist. Users deleting a service and then running `compute get <id>` got a misleading message telling them compute was disabled.

Narrowed the check: only swap in the "feature unavailable" copy when the response is a true route-level 404 (no `error` field or a bare `NOT_FOUND` code). When the backend returns a structured error like `COMPUTE_SERVICE_NOT_FOUND`, surface the real message + `nextActions`. Same narrowing applied to the `/api/database/migrations` fallback.

## How it was found

A live agent-prompt test (sub-agent given the dashboard's suggested prompt "Deploy nginx:alpine on port 80 as a compute service"):
1. Deployed nginx ✓
2. Verified the URL responded ✓
3. Deleted the service ✓
4. Ran `compute get <old-id>` → got "Compute services are not available on this backend" — felt like the feature broke when it was really just a stale id lookup.

## Before / After

**Before:**
```
$ npx @insforge/cli compute get 00000000-0000-0000-0000-000000000000
Error: Compute services are not available on this backend.
Self-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin to enable compute.
```

**After:**
```
$ npx @insforge/cli compute get 00000000-0000-0000-0000-000000000000
Error: Service not found
The compute service was not found. Run `compute list` to see available services.
```

## Test plan

- [x] `compute get <nonexistent-id>` → real 404 message
- [x] `compute list` → still works
- [x] `compute create` → happy path unaffected
- [x] `compute delete` → happy path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of error messages for API endpoints by refining detection logic, reducing incorrect "feature not available" notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->