### PR TITLE
feat(login): --user-api-key via exchange endpoint

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -183,7 +183,10 @@ async function exchangePatForJwt(
     throw new CLIError(`API key is invalid or revoked: ${msg}`);
   }
 
-  const data = (await res.json()) as { token: string };
+  const data = (await res.json().catch(() => ({}))) as { token?: unknown };
+  if (typeof data.token !== 'string' || data.token.length === 0) {
+    throw new CLIError('Exchange endpoint returned an invalid response (missing token).');
+  }
   const jwt = data.token;
 
   // The exchange endpoint returns only the JWT. Fetch the user via /auth/v1/profile
@@ -199,8 +202,14 @@ async function exchangePatForJwt(
   if (!profileRes.ok) {
     throw new CLIError(`Exchange succeeded but could not fetch profile: HTTP ${profileRes.status}`);
   }
-  const profile = (await profileRes.json()) as { user?: User } | User;
-  const user = ('user' in profile ? profile.user : (profile as User)) as User | undefined;
+  const profile = (await profileRes.json().catch(() => null)) as
+    | { user?: User }
+    | User
+    | null;
+  const user =
+    profile && typeof profile === 'object' && 'user' in profile
+      ? (profile as { user?: User }).user
+      : ((profile as User | null) ?? undefined);
   if (!user) {
     throw new CLIError('Exchange succeeded but profile response was empty');
   }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,11 +1,11 @@
 import type { Command } from 'commander';
 import * as clack from '@clack/prompts';
 import * as prompts from '../lib/prompts.js';
-import { saveCredentials } from '../lib/config.js';
+import { saveCredentials, getPlatformApiUrl } from '../lib/config.js';
 import { login as platformLogin } from '../lib/api/platform.js';
 import { performOAuthLogin } from '../lib/auth.js';
-import { handleError, getRootOpts } from '../lib/errors.js';
-import type { StoredCredentials } from '../types.js';
+import { handleError, getRootOpts, CLIError, formatFetchError } from '../lib/errors.js';
+import type { StoredCredentials, User } from '../types.js';
 
 export function registerLoginCommand(program: Command): void {
   program
@@ -13,11 +13,14 @@ export function registerLoginCommand(program: Command): void {
     .description('Authenticate with InsForge platform')
     .option('--email', 'Login with email and password instead of browser')
     .option('--client-id <id>', 'OAuth client ID (defaults to insforge-cli)')
+    .option('--user-api-key <key>', 'Authenticate with a uak_ personal access token')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
 
       try {
-        if (opts.email) {
+        if (opts.userApiKey) {
+          await loginWithUserApiKey(opts.userApiKey, json, apiUrl);
+        } else if (opts.email) {
           await loginWithEmail(json, apiUrl);
         } else {
           await loginWithOAuth(json, apiUrl);
@@ -101,4 +104,106 @@ async function loginWithOAuth(json: boolean, apiUrl?: string): Promise<void> {
   } else {
     console.log(JSON.stringify({ success: true, user: creds.user }));
   }
+}
+
+async function loginWithUserApiKey(
+  key: string,
+  json: boolean,
+  apiUrl?: string,
+): Promise<void> {
+  if (!json) {
+    clack.intro('InsForge CLI');
+  }
+
+  if (!key.startsWith('uak_')) {
+    throw new CLIError('Invalid API key — must start with "uak_".');
+  }
+
+  const s = !json ? clack.spinner() : null;
+  s?.start('Verifying API key...');
+
+  let jwt: string;
+  let user: User;
+  try {
+    const exchanged = await exchangePatForJwt(key, apiUrl);
+    jwt = exchanged.token;
+    user = exchanged.user;
+  } catch (err) {
+    s?.stop('API key verification failed');
+    throw err instanceof CLIError
+      ? err
+      : new CLIError(err instanceof Error ? err.message : String(err));
+  }
+
+  // Storage: access_token holds the JWT, refresh_token holds the PAT.
+  // Detect PAT login later by checking refresh_token.startsWith('uak_').
+  saveCredentials({
+    access_token: jwt,
+    refresh_token: key,
+    user,
+  });
+
+  if (!json) {
+    s?.stop(`Authenticated as ${user.email}`);
+    clack.outro('Done');
+  } else {
+    console.log(JSON.stringify({ success: true, user }));
+  }
+}
+
+/**
+ * Exchange a uak_ PAT for a short-lived JWT via the backend exchange endpoint.
+ * The PAT itself is never stored as an access token — we store the JWT and
+ * keep the PAT only for silent re-exchange when the JWT expires.
+ */
+async function exchangePatForJwt(
+  apiKey: string,
+  apiUrl?: string,
+): Promise<{ token: string; user: User }> {
+  const baseUrl = getPlatformApiUrl(apiUrl);
+  const fullUrl = `${baseUrl}/auth/v1/exchange-api-key`;
+
+  let res: Response;
+  try {
+    res = await fetch(fullUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ apiKey }),
+    });
+  } catch (err) {
+    throw new CLIError(formatFetchError(err, fullUrl));
+  }
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as {
+      error?: string;
+      message?: string;
+    };
+    const msg = body.message ?? body.error ?? `HTTP ${res.status}`;
+    throw new CLIError(`API key is invalid or revoked: ${msg}`);
+  }
+
+  const data = (await res.json()) as { token: string };
+  const jwt = data.token;
+
+  // The exchange endpoint returns only the JWT. Fetch the user via /auth/v1/profile
+  // using the fresh JWT so we can persist identity in credentials.json.
+  let profileRes: Response;
+  try {
+    profileRes = await fetch(`${baseUrl}/auth/v1/profile`, {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+  } catch (err) {
+    throw new CLIError(formatFetchError(err, `${baseUrl}/auth/v1/profile`));
+  }
+  if (!profileRes.ok) {
+    throw new CLIError(`Exchange succeeded but could not fetch profile: HTTP ${profileRes.status}`);
+  }
+  const profile = (await profileRes.json()) as { user?: User } | User;
+  const user = ('user' in profile ? profile.user : (profile as User)) as User | undefined;
+  if (!user) {
+    throw new CLIError('Exchange succeeded but profile response was empty');
+  }
+
+  return { token: jwt, user };
 }

--- a/src/lib/credentials.pat.test.ts
+++ b/src/lib/credentials.pat.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isPatLogin } from './credentials.js';
+import type { StoredCredentials } from '../types.js';
+
+describe('isPatLogin', () => {
+  const base = (refresh_token: string): StoredCredentials => ({
+    access_token: 'jwt',
+    refresh_token,
+    user: {} as unknown as StoredCredentials['user'],
+  });
+
+  it('returns true when refresh_token starts with uak_', () => {
+    expect(isPatLogin(base('uak_abc'))).toBe(true);
+  });
+
+  it('returns false for OAuth refresh tokens', () => {
+    expect(isPatLogin(base('some-oauth-refresh-token'))).toBe(false);
+  });
+
+  it('returns false for null / undefined', () => {
+    expect(isPatLogin(null)).toBe(false);
+    expect(isPatLogin(undefined)).toBe(false);
+  });
+
+  it('returns false when refresh_token is empty', () => {
+    expect(isPatLogin(base(''))).toBe(false);
+  });
+});

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -5,6 +5,11 @@ import * as clack from '@clack/prompts';
 import * as prompts from './prompts.js';
 import type { StoredCredentials } from '../types.js';
 
+/** True if stored credentials represent a PAT-based login (refresh_token is a uak_ token). */
+export function isPatLogin(creds: StoredCredentials | null | undefined): boolean {
+  return creds?.refresh_token?.startsWith('uak_') ?? false;
+}
+
 export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promise<StoredCredentials> {
   const projConfig = getProjectConfig();
   if (allowOssBypass && projConfig?.project_id === FAKE_PROJECT_ID) {
@@ -23,6 +28,13 @@ export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promi
 
   const creds = getCredentials();
   if (creds && creds.access_token) return creds;
+
+  // PAT session with an expired/empty access_token: silently re-exchange
+  // instead of prompting for browser OAuth.
+  if (isPatLogin(creds)) {
+    await refreshAccessToken(apiUrl);
+    return getCredentials()!;
+  }
 
   clack.log.info('You need to log in to continue.');
 
@@ -45,11 +57,41 @@ export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promi
 
 export async function refreshAccessToken(apiUrl?: string): Promise<string> {
   const creds = getCredentials();
-  if (!creds?.refresh_token) {
-    throw new AuthError('Refresh token not found. Run `npx @insforge/cli login` again.');
+  if (!creds) {
+    throw new AuthError('Not logged in. Run `npx @insforge/cli login` first.');
   }
 
   const platformUrl = getPlatformApiUrl(apiUrl);
+
+  // PAT branch: re-exchange the stored uak_ for a fresh JWT.
+  if (isPatLogin(creds)) {
+    let res: Response;
+    try {
+      res = await fetch(`${platformUrl}/auth/v1/exchange-api-key`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey: creds.refresh_token }),
+      });
+    } catch (err) {
+      // This is a background refresh path — surface a network error clearly.
+      throw new AuthError(
+        `Unable to reach auth server at ${platformUrl}. Check your network connection.`
+      );
+    }
+    if (!res.ok) {
+      throw new AuthError(
+        'API key is invalid or revoked. Run `npx @insforge/cli login --user-api-key <new-key>` again.'
+      );
+    }
+    const { token } = (await res.json()) as { token: string };
+    saveCredentials({ ...creds, access_token: token });
+    return token;
+  }
+
+  if (!creds.refresh_token) {
+    throw new AuthError('Refresh token not found. Run `npx @insforge/cli login` again.');
+  }
+
   const config = getGlobalConfig();
   const clientId = config.oauth_client_id ?? DEFAULT_CLIENT_ID;
 

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -72,20 +72,31 @@ export async function refreshAccessToken(apiUrl?: string): Promise<string> {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ apiKey: creds.refresh_token }),
       });
-    } catch (err) {
-      // This is a background refresh path — surface a network error clearly.
+    } catch {
+      // Background refresh path — surface a network error clearly.
       throw new AuthError(
         `Unable to reach auth server at ${platformUrl}. Check your network connection.`
       );
     }
     if (!res.ok) {
+      // Auth failures (401/403/404) mean the PAT is actually bad — ask the user
+      // to rotate. Everything else (5xx, 429, gateway errors) is transient and
+      // shouldn't instruct the user to rotate a healthy key.
+      if (res.status === 401 || res.status === 403 || res.status === 404) {
+        throw new AuthError(
+          'API key is invalid or revoked. Run `npx @insforge/cli login --user-api-key <new-key>` again.'
+        );
+      }
       throw new AuthError(
-        'API key is invalid or revoked. Run `npx @insforge/cli login --user-api-key <new-key>` again.'
+        `Auth server returned HTTP ${res.status} while refreshing session. Please retry shortly.`
       );
     }
-    const { token } = (await res.json()) as { token: string };
-    saveCredentials({ ...creds, access_token: token });
-    return token;
+    const data = (await res.json().catch(() => ({}))) as { token?: unknown };
+    if (typeof data.token !== 'string' || data.token.length === 0) {
+      throw new AuthError('Exchange endpoint returned an invalid response (missing token).');
+    }
+    saveCredentials({ ...creds, access_token: data.token });
+    return data.token;
   }
 
   if (!creds.refresh_token) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,11 @@ export interface ConnectionStringResponse {
 // Stored credentials
 export interface StoredCredentials {
   access_token: string;
+  /**
+   * Either an OAuth refresh token (opaque string) or a user API key
+   * prefixed `uak_` (for PAT-based CLI logins). The `uak_` prefix is the
+   * discriminator — see `isPatLogin()` in `lib/credentials.ts`.
+   */
   refresh_token: string;
   user: User;
 }


### PR DESCRIPTION
## Summary

`insforge login --user-api-key uak_...` now calls the backend's new `POST /auth/v1/exchange-api-key` endpoint to trade the PAT for a short-lived JWT, and stores:

- the returned JWT → `access_token`
- the PAT → `refresh_token` (reused for silent re-exchange on JWT expiry)

Subsequent CLI commands use `Authorization: Bearer <JWT>`, matching the existing OAuth login flow exactly. Request code is unchanged.

Supersedes #80 after team discussion on 2026-04-23. The earlier design had the backend auth middleware recognize `uak_` Bearer tokens directly, giving PATs the same endpoint surface as JWTs. Team concern: a leaked PAT retained indefinite full-account (including admin) access. The exchange model shrinks PAT's reachable surface to a single endpoint and makes every successful session establishment an observable event.

## Changes

- **`src/commands/login.ts`** — new `--user-api-key <key>` flag; calls `/auth/v1/exchange-api-key`; persists JWT + PAT via `saveCredentials`.
- **`src/lib/credentials.ts`** — `refreshAccessToken` branches on `refresh_token.startsWith('uak_')`: on JWT expiry, re-exchanges the stored PAT for a fresh JWT. OAuth refresh path preserved verbatim for non-PAT logins.
- **`src/lib/credentials.pat.test.ts`** — unit tests covering the `isPatLogin` helper.
- **`src/types.ts`** — comment noting `refresh_token` may hold an OAuth refresh token OR a PAT prefixed `uak_`.

## Test plan

- [x] `npx vitest run` — all tests pass
- [x] Smoke against staging backend:
  - `insforge login --user-api-key uak_...` → "Authenticated as <email>"
  - `~/.insforge/credentials.json`: `access_token` is JWT (starts `eyJ`), `refresh_token` is PAT (starts `uak_`)
  - Force JWT expiry (e.g. clear `access_token`) → `insforge projects list` triggers silent re-exchange and succeeds
  - Revoke PAT backend-side → subsequent refresh fails with PAT-specific error (not the default OAuth refresh error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login command now accepts `--user-api-key` flag for personal access token authentication.
  * Personal access token-based sessions support automatic token refresh without browser OAuth prompts.
  * Enhanced error handling for authentication and network failures.

* **Tests**
  * Added personal access token authentication detection tests.

* **Documentation**
  * Updated token refresh behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->