### PR TITLE
feat(tracking): tag agent-connected requests with client=cli

### DIFF
--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -143,7 +143,7 @@ export async function reportAgentConnected(
   await fetch(`${baseUrl}/tracking/v1/agent-connected`, {
     method: 'POST',
     headers,
-    body: JSON.stringify(payload),
+    body: JSON.stringify({ ...payload, client: 'cli' }),
   });
 }
 


### PR DESCRIPTION
## Summary

- `reportAgentConnected()` now sends `client: 'cli'` in the request body to `/tracking/v1/agent-connected`.

## Why

Pairs with [insforge-cloud-backend#472](https://github.com/InsForge/insforge-cloud-backend/pull/472), which adds an optional `client` field on the cloud endpoint so PostHog/Mixpanel can break down agent-connected events by source. Without this CLI-side change, every CLI link reports as `client: 'unknown'` and is indistinguishable from MCP traffic.

## Test plan

- [ ] Run `cli link` against a real project, watch the `/tracking/v1/agent-connected` request body — should include `"client":"cli"`
- [ ] Verify cloud-side event in PostHog shows `client=cli` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)