### PR TITLE
feat(schedules): document sub-minute cadence in --cron help text

### DIFF
--- a/src/commands/schedules/create.ts
+++ b/src/commands/schedules/create.ts
@@ -11,7 +11,10 @@ export function registerSchedulesCreateCommand(schedulesCmd: Command): void {
     .command('create')
     .description('Create a new schedule')
     .requiredOption('--name <name>', 'Schedule name')
-    .requiredOption('--cron <expression>', 'Cron expression (5-field format)')
+    .requiredOption(
+      '--cron <expression>',
+      'Cron expression. 5-field cron (e.g. "*/5 * * * *", "0 9 * * 1-5") or pg_cron interval syntax for sub-minute cadence (e.g. "30 seconds", "5 minutes").'
+    )
     .requiredOption('--url <url>', 'URL to invoke')
     .requiredOption('--method <method>', 'HTTP method (GET, POST, PUT, PATCH, DELETE)')
     .option('--headers <json>', 'HTTP headers as JSON')

--- a/src/commands/schedules/update.ts
+++ b/src/commands/schedules/update.ts
@@ -9,7 +9,10 @@ export function registerSchedulesUpdateCommand(schedulesCmd: Command): void {
     .command('update <id>')
     .description('Update a schedule')
     .option('--name <name>', 'New schedule name')
-    .option('--cron <expression>', 'New cron expression')
+    .option(
+      '--cron <expression>',
+      'New cron expression. 5-field cron or pg_cron interval syntax (e.g. "30 seconds").'
+    )
     .option('--url <url>', 'New URL to invoke')
     .option('--method <method>', 'New HTTP method')
     .option('--headers <json>', 'New HTTP headers as JSON')


### PR DESCRIPTION
## Summary

Once [InsForge/InsForge#1159](https://github.com/InsForge/InsForge/pull/1159) lands, the schedules backend accepts pg_cron interval syntax (\`\"30 seconds\"\`, \`\"5 minutes\"\`) for sub-minute cadence in addition to 5-field cron. The CLI passes \`--cron\` through unmodified, so this PR is **purely cosmetic** — it just updates the commander help text on \`schedules create --cron\` and \`schedules update --cron\` so users running \`--help\` see both formats.

## What changed

\`\`\`diff
// src/commands/schedules/create.ts
-    .requiredOption('--cron <expression>', 'Cron expression (5-field format)')
+    .requiredOption(
+      '--cron <expression>',
+      'Cron expression. 5-field cron (e.g. \"*/5 * * * *\", \"0 9 * * 1-5\") or pg_cron interval syntax for sub-minute cadence (e.g. \"30 seconds\", \"5 minutes\").'
+    )

// src/commands/schedules/update.ts — same idea, briefer
\`\`\`

## Why split this off

This is a 2-line copy fix and the CLI ships independently. Bundling it with the backend PR would force a double release. Keeping them separate so the CLI can ship the moment InsForge#1159 lands.

## Test plan

- [x] \`npm run build\` — passes (tsup ESM + DTS)
- [x] \`npm run lint\` — 121 passed | 13 skipped, no regressions
- [ ] After InsForge#1159 lands: \`npx @insforge/cli schedules create --cron \"30 seconds\" ...\` works against a dev project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `--cron` option descriptions in schedule commands to clarify accepted cron formats and interval syntax options for improved user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->