### PR TITLE
feat(cli/compute): source mode uses flyctl remote builder (no local Docker)

### DIFF
--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -198,7 +198,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
         //    attenuated FLY_API_TOKEN we just received.
         const imageLabel = `cli-${Date.now()}`;
         if (!json) outputInfo(`Building & pushing on Fly remote builder...`);
-        const { imageRef } = flyctlBuildAndPush({
+        const { imageRef } = await flyctlBuildAndPush({
           dir: absDir,
           appId: flyAppId,
           imageLabel,

--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -7,29 +7,31 @@ import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
 import {
-  ensureDockerAvailable,
-  dockerBuild,
-  dockerLogin,
-  dockerPush,
-} from '../../lib/docker.js';
+  ensureFlyctlAvailable,
+  flyctlBuildAndPush,
+} from '../../lib/flyctl.js';
 
 // `compute deploy` has two modes:
 //
 //   1. Image mode (--image <url>):
-//      Deploy a pre-built image from any registry. Same as v1.
+//      Deploy a pre-built image from any registry. No flyctl/Docker needed.
 //
-//   2. Source mode ([dir]) — Path A (compute v3.1):
-//      CLI runs docker build + push to registry.fly.io using a per-app
-//      deploy token minted by the cloud. Cloud then launches the machine
-//      pointing at the freshly-pushed image. Requires Docker locally.
-//      Image bytes never proxy through OSS or cloud.
+//   2. Source mode ([dir]) — Path A (compute v3.2):
+//      CLI runs `flyctl deploy --remote-only --build-only` against the user's
+//      source directory using a per-app, attenuated deploy token minted by
+//      the cloud. The remote builder runs on Fly's infrastructure and pushes
+//      the image straight to registry.fly.io/<app>:<tag>. The cloud then
+//      launches the machine pointing at the freshly-pushed image.
+//      Requires `flyctl` on PATH (no Docker daemon needed).
+//      The deploy token is scoped to one app + builder/wg, with `else: deny`
+//      — it cannot deploy or read anything else in the InsForge Fly org.
 export function registerComputeDeployCommand(computeCmd: Command): void {
   computeCmd
     .command('deploy [dir]')
     .description(
       'Deploy a compute service. Two modes:\n' +
-        '  compute deploy <dir> --name <name>             (source mode — local docker build + push, requires Docker)\n' +
-        '  compute deploy --image <url> --name <name>     (image mode — deploys pre-built image, no Docker required)'
+        '  compute deploy <dir> --name <name>             (source mode — flyctl remote build + push, requires flyctl on PATH; no Docker needed)\n' +
+        '  compute deploy --image <url> --name <name>     (image mode — deploys pre-built image, no flyctl/Docker required)'
     )
     .requiredOption('--name <name>', 'Service name (DNS-safe, e.g. my-api)')
     .option('--image <url>', 'Pre-built image URL (image mode)')
@@ -144,7 +146,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
               `   • Use --image <url> to deploy a pre-built image instead`
           );
         }
-        ensureDockerAvailable();
+        ensureFlyctlAvailable();
 
         if (!json) outputInfo(`Detected Dockerfile at ${dockerfilePath}`);
 
@@ -190,17 +192,18 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
         );
         const tokenJson = (await tokenRes.json()) as { token: string; expirySeconds: number };
 
-        // 3. Build + push
-        const tag = `cli-${Date.now()}`;
-        const imageRef = `registry.fly.io/${flyAppId}:${tag}`;
-        if (!json) outputInfo(`Building image ${imageRef}...`);
-        dockerBuild({ dir: absDir, imageRef });
-
-        if (!json) outputInfo('Logging in to registry.fly.io...');
-        dockerLogin('registry.fly.io', tokenJson.token);
-
-        if (!json) outputInfo(`Pushing ${imageRef}...`);
-        dockerPush(imageRef);
+        // 3. Remote build + push (no local Docker daemon needed).
+        //    flyctl ships the build context to Fly's remote builder, builds
+        //    there, and pushes to registry.fly.io/<app>:<tag> using the
+        //    attenuated FLY_API_TOKEN we just received.
+        const imageLabel = `cli-${Date.now()}`;
+        if (!json) outputInfo(`Building & pushing on Fly remote builder...`);
+        const { imageRef } = flyctlBuildAndPush({
+          dir: absDir,
+          appId: flyAppId,
+          imageLabel,
+          token: tokenJson.token,
+        });
 
         // 4. Tell cloud the image is ready — launches new machine or
         //    updates existing one. PATCH includes any deploy-affecting
@@ -227,7 +230,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
           const verb = existing ? 'updated' : 'deployed';
           outputSuccess(`Service "${service.name}" ${verb} [${service.status}]`);
           if (service.endpointUrl) console.log(`  Endpoint: ${service.endpointUrl}`);
-          console.log(`  Tip: \`docker rmi ${imageRef}\` to reclaim local disk space`);
+          console.log(`  Image: ${imageRef} (built remotely; no local image to clean up)`);
         }
 
         await reportCliUsage('cli.compute.deploy', true);

--- a/src/lib/flyctl.ts
+++ b/src/lib/flyctl.ts
@@ -1,0 +1,78 @@
+// flyctl helpers for compute v3.2 source-deploy. Path A — refined:
+// the CLI shells out to `flyctl deploy --remote-only --build-only` using a
+// per-app deploy token minted by the cloud. Build runs on Fly's remote
+// builder; the resulting image is pushed straight to registry.fly.io. No
+// local Docker daemon required — the user only needs the single flyctl
+// binary on their PATH.
+//
+// Token shape: short-lived (~20 min) macaroon attenuated to one app +
+// builder/wg features, with `else: deny`. It can deploy to that one app and
+// nothing else, even within the InsForge Fly org.
+
+import { spawnSync } from 'node:child_process';
+import { CLIError } from './errors.js';
+
+export function ensureFlyctlAvailable(): void {
+  const r = spawnSync('flyctl', ['version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (r.error || r.status !== 0) {
+    throw new CLIError(
+      'flyctl is required for source-mode deploy.\n' +
+        '  • Install: curl -L https://fly.io/install.sh | sh\n' +
+        '  • Or use --image <pre-built-image> instead.\n' +
+        (r.stderr ? `  Detail: ${r.stderr.trim().slice(0, 200)}` : '')
+    );
+  }
+}
+
+export interface FlyctlBuildPushOptions {
+  dir: string;
+  appId: string; // Fly app name, e.g. "my-svc-<projectId>"
+  imageLabel: string; // tag suffix; final ref will be registry.fly.io/<appId>:<imageLabel>
+  token: string; // attenuated FlyV1 deploy token from cloud /deploy-token
+}
+
+/**
+ * Run `flyctl deploy --remote-only --build-only` against the user's source
+ * directory. Builds on Fly's remote builder, pushes to registry.fly.io, and
+ * returns the resulting image ref. Does NOT launch a machine — the cloud
+ * backend handles that step (it owns DB state and quota enforcement).
+ *
+ * The user's directory only needs a Dockerfile. If a fly.toml exists we
+ * append `app = "<appId>"` via env var so it doesn't conflict with whatever
+ * the user wrote there. If no fly.toml exists, flyctl invents one.
+ */
+export function flyctlBuildAndPush(
+  opts: FlyctlBuildPushOptions
+): { imageRef: string } {
+  const imageRef = `registry.fly.io/${opts.appId}:${opts.imageLabel}`;
+  const r = spawnSync(
+    'flyctl',
+    [
+      'deploy',
+      '--remote-only',
+      '--build-only',
+      '--app',
+      opts.appId,
+      '--image-label',
+      opts.imageLabel,
+      '--no-cache',
+    ],
+    {
+      cwd: opts.dir,
+      env: { ...process.env, FLY_API_TOKEN: opts.token },
+      stdio: 'inherit',
+    }
+  );
+  if (r.error) {
+    throw new CLIError(`flyctl deploy could not start: ${r.error.message}`);
+  }
+  if (r.status !== 0) {
+    throw new CLIError(
+      `flyctl deploy --build-only failed (exit ${r.status}). See output above.`
+    );
+  }
+  return { imageRef };
+}

--- a/src/lib/flyctl.ts
+++ b/src/lib/flyctl.ts
@@ -1,15 +1,15 @@
 // flyctl helpers for compute v3.2 source-deploy. Path A — refined:
-// the CLI shells out to `flyctl deploy --remote-only --build-only` using a
-// per-app deploy token minted by the cloud. Build runs on Fly's remote
-// builder; the resulting image is pushed straight to registry.fly.io. No
-// local Docker daemon required — the user only needs the single flyctl
+// the CLI shells out to `flyctl deploy --remote-only --build-only --push`
+// using a per-app deploy token minted by the cloud. Build runs on Fly's
+// remote builder; the resulting image is pushed straight to registry.fly.io.
+// No local Docker daemon required — the user only needs the single flyctl
 // binary on their PATH.
 //
 // Token shape: short-lived (~20 min) macaroon attenuated to one app +
 // builder/wg features, with `else: deny`. It can deploy to that one app and
 // nothing else, even within the InsForge Fly org.
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { CLIError } from './errors.js';
 
 export function ensureFlyctlAvailable(): void {
@@ -30,49 +30,85 @@ export function ensureFlyctlAvailable(): void {
 export interface FlyctlBuildPushOptions {
   dir: string;
   appId: string; // Fly app name, e.g. "my-svc-<projectId>"
-  imageLabel: string; // tag suffix; final ref will be registry.fly.io/<appId>:<imageLabel>
+  imageLabel: string; // tag suffix; only used as buildkit's --image-label.
   token: string; // attenuated FlyV1 deploy token from cloud /deploy-token
 }
 
 /**
- * Run `flyctl deploy --remote-only --build-only` against the user's source
- * directory. Builds on Fly's remote builder, pushes to registry.fly.io, and
- * returns the resulting image ref. Does NOT launch a machine — the cloud
+ * Run `flyctl deploy --remote-only --build-only --push` against the user's
+ * source directory. Builds on Fly's remote builder, pushes to registry.fly.io,
+ * and returns the resulting image ref. Does NOT launch a machine — the cloud
  * backend handles that step (it owns DB state and quota enforcement).
  *
- * The user's directory only needs a Dockerfile. If a fly.toml exists we
- * append `app = "<appId>"` via env var so it doesn't conflict with whatever
- * the user wrote there. If no fly.toml exists, flyctl invents one.
+ * IMPORTANT: returns the **digest-pinned** ref `<app>@sha256:<digest>`, not
+ * the tag-based `<app>:<label>` ref. buildkit's `--build-only --push` lands
+ * the manifest in the remote builder's namespace, and Fly's registry then
+ * aliases the user-app namespace to it by content digest. The bare tag does
+ * not always resolve (and racily fails on Fly's side as MANIFEST_UNKNOWN),
+ * but the digest always does. The cloud's launchMachine accepts either form.
+ *
+ * The user's directory only needs a Dockerfile. flyctl will invent a fly.toml
+ * if none exists.
  */
 export function flyctlBuildAndPush(
   opts: FlyctlBuildPushOptions
-): { imageRef: string } {
-  const imageRef = `registry.fly.io/${opts.appId}:${opts.imageLabel}`;
-  const r = spawnSync(
-    'flyctl',
-    [
-      'deploy',
-      '--remote-only',
-      '--build-only',
-      '--app',
-      opts.appId,
-      '--image-label',
-      opts.imageLabel,
-      '--no-cache',
-    ],
-    {
-      cwd: opts.dir,
-      env: { ...process.env, FLY_API_TOKEN: opts.token },
-      stdio: 'inherit',
-    }
-  );
-  if (r.error) {
-    throw new CLIError(`flyctl deploy could not start: ${r.error.message}`);
-  }
-  if (r.status !== 0) {
-    throw new CLIError(
-      `flyctl deploy --build-only failed (exit ${r.status}). See output above.`
+): Promise<{ imageRef: string }> {
+  return new Promise<{ imageRef: string }>((resolve, reject) => {
+    const child = spawn(
+      'flyctl',
+      [
+        'deploy',
+        '--remote-only',
+        '--build-only',
+        '--push',
+        '--app',
+        opts.appId,
+        '--image-label',
+        opts.imageLabel,
+        '--no-cache',
+      ],
+      {
+        cwd: opts.dir,
+        env: { ...process.env, FLY_API_TOKEN: opts.token },
+        stdio: ['inherit', 'pipe', 'pipe'],
+      }
     );
-  }
-  return { imageRef };
+
+    // Tee child's stdout+stderr to our own (so the user sees buildkit
+    // progress in real time) AND capture them so we can parse the digest.
+    let captured = '';
+    child.stdout?.on('data', (b) => {
+      const s = b.toString();
+      captured += s;
+      process.stdout.write(s);
+    });
+    child.stderr?.on('data', (b) => {
+      const s = b.toString();
+      captured += s;
+      process.stderr.write(s);
+    });
+    child.on('error', (err) => {
+      reject(new CLIError(`flyctl deploy could not start: ${err.message}`));
+    });
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        return reject(
+          new CLIError(`flyctl deploy --build-only failed (exit ${code}). See output above.`)
+        );
+      }
+      // buildkit emits "pushing manifest for registry.fly.io/<app>:<label>@sha256:<digest>"
+      // when the upload lands. Pin to that digest so the cloud's machine API
+      // can resolve unambiguously regardless of registry tag-aliasing races.
+      const m = captured.match(/pushing manifest for registry\.fly\.io\/[^\s]+@(sha256:[0-9a-f]+)/);
+      if (!m) {
+        return reject(
+          new CLIError(
+            'flyctl deploy succeeded but the buildkit "pushing manifest" line was not found. ' +
+              'Cannot determine image digest — please re-run with FLY_LOG_LEVEL=debug and report.'
+          )
+        );
+      }
+      resolve({ imageRef: `registry.fly.io/${opts.appId}@${m[1]}` });
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Source-mode deploy (`compute deploy <dir>`) no longer needs Docker installed locally. The CLI now shells out to `flyctl deploy --remote-only --build-only` using the same per-app deploy token the cloud already mints. Build runs on Fly's remote builder; the resulting image is pushed straight to `registry.fly.io`. Cloud still owns machine launch.

User-facing requirement drops from **Docker Desktop (~1 GB) + the InsForge CLI** to **single `flyctl` binary on PATH (~30 MB) + the InsForge CLI**.

Image mode (`compute deploy --image <url>`) is unchanged.

## Companion PRs

- **Cloud** (no-Docker live e2e + Round-3 fixes): https://github.com/InsForge/insforge-cloud-backend/pull/456
- **OSS provider** (comment update): https://github.com/InsForge/InsForge/pull/1156
- **Skills doc** (flyctl pattern): https://github.com/InsForge/insforge-skills/pull/45

## Why this is safe

The cloud-side `createDeployToken` already attenuates the macaroon with `IfPresent { ifs: [Apps[<oneApp>], FeatureSet[builder, wg]], else: deny }` + 20-min ValidityWindow. The token can drive the Fly remote builder (`FeatureSet[builder]`) and push to `registry.fly.io/<app>` (`Apps[<oneApp>]`), but cannot reach any other app or any org-level read endpoint. Verified end-to-end by 14 assertions in the cloud PR's live e2e.

## Test plan

- [x] vitest passes for compute + lib suites
- [x] `tsc --noEmit -p .` — no new type errors from this PR
- [ ] Reviewer: smoke-test `compute deploy ./some-dir --name foo` against staging cloud once #456 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Deployment now uses Flyctl remote build-and-push instead of local Docker builds.
  * Flyctl CLI is required for source-mode deployments; Docker is no longer needed locally.
  * Progress and help messaging updated for the new workflow; no local image cleanup required after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->