### PR TITLE
chore(release): bump @insforge/cli to 0.1.60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Releases the source-mode + flyctl-no-docker work merged in #89 to npm.

`0.1.60` is the first published cut where:
- Source mode (`compute deploy <dir>`) uses Fly's Depot remote builder via `flyctl deploy --remote-only` — **no local Docker daemon required**.
- The CLI fetches a per-app deploy token from the InsForge cloud (`POST /api/compute/services/:id/deploy-token`) — **no `FLY_API_TOKEN` required** on the user side.
- Cloud-backend silently retries the Fly registry alias propagation race (`MANIFEST_UNKNOWN`) so the previously-visible 500 from `Launching machine...` is gone.

## Test plan

- [x] Live e2e on staging (`api-beta.insforge.dev` cloud `v1.2.11-compute2` + OSS `v2.1.3-compute`):
  ```
  $ npx @insforge/cli compute deploy . --name show-... --port 80 --region iad --memory 256
  Detected Dockerfile at /private/tmp/cli-e2e/app/Dockerfile
  Creating service...
  Created Fly app show-...-<projectId>
  Requesting deploy token...
  Building & pushing on Fly remote builder...   ← Depot, no local Docker
  Launching machine...
  ✓ Service "show-..." deployed [running]
  ```
- [x] Live `curl` of resulting `*.fly.dev` URL → 200, served the custom Dockerfile-baked HTML.
- [x] `compute delete` cleanup → service + Fly app destroyed cleanly.
- [x] `npm run build` clean on `0.1.60`.

## Companion PRs (already merged)

- CLI source-mode flyctl pivot: #89
- Cloud backend deploy-token + MANIFEST_UNKNOWN retry + 4xx pass-through: https://github.com/InsForge/insforge-cloud-backend/pull/456
- Skills doc updates: https://github.com/InsForge/insforge-skills/pull/45

## Release checklist

- [ ] Merge this PR
- [ ] `npm publish` (or however the CI release pipeline picks up the version bump)
- [ ] Sanity check: `npm view @insforge/cli version` → `0.1.60`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.1.60

<!-- end of auto-generated comment: release notes by coderabbit.ai -->