### PR TITLE
Add payments commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @insforge/cli
 
-Command line tool for the [InsForge](https://insforge.dev) platform. Manage your databases, edge functions, storage, deployments, secrets, and more — directly from the terminal.
+Command line tool for the [InsForge](https://insforge.dev) platform. Manage your databases, edge functions, storage, deployments, payments, secrets, and more — directly from the terminal.
 
 Designed to be both human-friendly (interactive prompts, formatted tables) and agent-friendly (structured JSON output, non-interactive mode, semantic exit codes).
 
@@ -407,6 +407,92 @@ Cancel a running deployment.
 
 ```bash
 npx @insforge/cli deployments cancel abc-123
+```
+
+---
+
+### Payments — `npx @insforge/cli payments`
+
+Manage the Stripe payments foundation for the linked InsForge project. These commands are intended for developers and agents configuring Stripe keys, syncing catalog state, and managing products/prices. Runtime checkout and customer portal calls should usually be made from the app via the SDK.
+
+#### `npx @insforge/cli payments status`
+
+Show Stripe key, account, sync, and webhook status for test/live environments.
+
+```bash
+npx @insforge/cli payments status
+npx @insforge/cli payments status --json
+```
+
+#### `npx @insforge/cli payments config`
+
+List, set, or remove Stripe secret keys.
+
+```bash
+npx @insforge/cli payments config
+npx @insforge/cli payments config set test sk_test_xxx
+npx @insforge/cli payments config set live        # prompts securely
+npx @insforge/cli payments config remove test -y
+```
+
+#### `npx @insforge/cli payments sync`
+
+Sync Stripe products, prices, and subscriptions from configured environments.
+
+```bash
+npx @insforge/cli payments sync
+npx @insforge/cli payments sync --environment test
+npx @insforge/cli payments sync --environment live --json
+```
+
+#### `npx @insforge/cli payments webhooks configure <environment>`
+
+Create or recreate the InsForge-managed Stripe webhook endpoint for an environment.
+
+```bash
+npx @insforge/cli payments webhooks configure test
+```
+
+#### `npx @insforge/cli payments products`
+
+List, inspect, create, update, or delete Stripe products.
+
+```bash
+npx @insforge/cli payments products list --environment test
+npx @insforge/cli payments products get prod_123 --environment test
+npx @insforge/cli payments products create --environment test --name "Pro Plan"
+npx @insforge/cli payments products update prod_123 --environment test --description "Updated"
+npx @insforge/cli payments products delete prod_123 --environment test -y
+```
+
+#### `npx @insforge/cli payments prices`
+
+List, inspect, create, update, or archive Stripe prices.
+
+```bash
+npx @insforge/cli payments prices list --environment test
+npx @insforge/cli payments prices create --environment test --product prod_123 --currency usd --unit-amount 2000
+npx @insforge/cli payments prices create --environment test --product prod_123 --currency usd --unit-amount 2000 --interval month
+npx @insforge/cli payments prices update price_123 --environment test --active false
+npx @insforge/cli payments prices archive price_123 --environment test
+```
+
+#### `npx @insforge/cli payments subscriptions`
+
+List mirrored Stripe subscriptions for admin/debugging workflows.
+
+```bash
+npx @insforge/cli payments subscriptions --environment test
+npx @insforge/cli payments subscriptions --environment test --subject-type team --subject-id team_123
+```
+
+#### `npx @insforge/cli payments history`
+
+List mirrored payment history for admin/debugging workflows.
+
+```bash
+npx @insforge/cli payments history --environment test
+npx @insforge/cli payments history --environment test --limit 20 --json
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
-        "@insforge/shared-schemas": "^1.1.50",
+        "@insforge/shared-schemas": "^1.1.51-payments.0",
         "archiver": "^7.0.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.50",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.50.tgz",
-      "integrity": "sha512-fAL359bIa64NonKWaQuLqKY8xYEh/UMJSPH91b9KxTx6cSIHRZccz/e0xuXYg/+SzqPOW0f61/Bq2zydWJe2/A==",
+      "version": "1.1.51-payments.0",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.51-payments.0.tgz",
+      "integrity": "sha512-28iYPyKTYS42QOUoALlHpOybdPi81Zx36VX9P1mRIgeLHtqK99Wx+LbUf03kk0FUtXhr/AmSMMnnke5STQbYcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@insforge/shared-schemas": "^1.1.50",
+    "@insforge/shared-schemas": "^1.1.51-payments.0",
     "archiver": "^7.0.1",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",

--- a/src/commands/payments/catalog.ts
+++ b/src/commands/payments/catalog.ts
@@ -1,0 +1,67 @@
+import type { Command } from 'commander';
+import { listPaymentCatalog } from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputTable } from '../../lib/output.js';
+import { formatAmount, formatRecurring, parseEnvironment, trackPaymentUsage } from './utils.js';
+
+export function registerPaymentsCatalogCommand(paymentsCmd: Command): void {
+  paymentsCmd
+    .command('catalog')
+    .description('List mirrored Stripe products and prices')
+    .option('--environment <environment>', 'Stripe environment: test or live')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = opts.environment ? parseEnvironment(opts.environment) : undefined;
+        await requireAuth();
+
+        const data = await listPaymentCatalog(environment);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          if (data.products.length === 0 && data.prices.length === 0) {
+            console.log('No Stripe catalog records found.');
+            await trackPaymentUsage('catalog', true, { environment });
+            return;
+          }
+
+          if (data.products.length > 0) {
+            console.log('Products');
+            outputTable(
+              ['Env', 'Product ID', 'Name', 'Active', 'Default Price'],
+              data.products.map((product) => [
+                product.environment,
+                product.stripeProductId,
+                product.name,
+                product.active ? 'Yes' : 'No',
+                product.defaultPriceId ?? '-',
+              ]),
+            );
+          }
+
+          if (data.prices.length > 0) {
+            console.log('Prices');
+            outputTable(
+              ['Env', 'Price ID', 'Product ID', 'Amount', 'Type', 'Active', 'Recurring'],
+              data.prices.map((price) => [
+                price.environment,
+                price.stripePriceId,
+                price.stripeProductId ?? '-',
+                formatAmount(price.unitAmount, price.currency),
+                price.type,
+                price.active ? 'Yes' : 'No',
+                formatRecurring(price.recurringInterval, price.recurringIntervalCount),
+              ]),
+            );
+          }
+        }
+
+        await trackPaymentUsage('catalog', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('catalog', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/config.ts
+++ b/src/commands/payments/config.ts
@@ -97,7 +97,11 @@ export function registerPaymentsConfigCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(environmentValue);
         await requireAuth();
 
-        if (!yes && !json) {
+        if (json && !yes) {
+          throw new CLIError('Use --yes with --json to remove a Stripe key non-interactively.');
+        }
+
+        if (!yes) {
           const confirm = await prompts.confirm({
             message: `Remove Stripe ${environment} key? Payment sync and mutations for this environment will stop.`,
           });

--- a/src/commands/payments/config.ts
+++ b/src/commands/payments/config.ts
@@ -1,0 +1,121 @@
+import type { Command } from 'commander';
+import * as prompts from '../../lib/prompts.js';
+import {
+  getPaymentsConfig,
+  removeStripeSecretKey,
+  setStripeSecretKey,
+} from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
+import { parseEnvironment, trackPaymentUsage } from './utils.js';
+
+function outputConfigTable(data: Awaited<ReturnType<typeof getPaymentsConfig>>): void {
+  if (data.keys.length === 0) {
+    console.log('No Stripe keys configured.');
+    return;
+  }
+
+  outputTable(
+    ['Env', 'Configured', 'Key'],
+    data.keys.map((key) => [
+      key.environment,
+      key.hasKey ? 'Yes' : 'No',
+      key.maskedKey ?? '-',
+    ]),
+  );
+}
+
+export function registerPaymentsConfigCommand(paymentsCmd: Command): void {
+  const configCmd = paymentsCmd
+    .command('config')
+    .description('Manage Stripe API keys for payments')
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const data = await getPaymentsConfig();
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputConfigTable(data);
+        }
+
+        await trackPaymentUsage('config', true);
+      } catch (err) {
+        await trackPaymentUsage('config', false);
+        handleError(err, json);
+      }
+    });
+
+  configCmd
+    .command('set <environment> [secretKey]')
+    .description('Configure a Stripe secret key for test or live payments')
+    .action(async (environmentValue: string, secretKeyValue: string | undefined, _opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(environmentValue);
+        await requireAuth();
+
+        let secretKey = secretKeyValue;
+        if (!secretKey) {
+          if (json) {
+            throw new CLIError('Provide secretKey when using --json.');
+          }
+
+          const input = await prompts.password({
+            message: `Stripe ${environment} secret key`,
+          });
+          if (prompts.isCancel(input)) process.exit(0);
+          secretKey = input;
+        }
+
+        const data = await setStripeSecretKey(environment, secretKey);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe ${environment} key configured.`);
+        }
+
+        await trackPaymentUsage('config.set', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('config.set', false, { environment: environmentValue });
+        handleError(err, json);
+      }
+    });
+
+  configCmd
+    .command('remove <environment>')
+    .alias('delete')
+    .description('Remove a configured Stripe secret key')
+    .action(async (environmentValue: string, _opts, cmd) => {
+      const { json, yes } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(environmentValue);
+        await requireAuth();
+
+        if (!yes && !json) {
+          const confirm = await prompts.confirm({
+            message: `Remove Stripe ${environment} key? Payment sync and mutations for this environment will stop.`,
+          });
+          if (prompts.isCancel(confirm) || !confirm) process.exit(0);
+        }
+
+        const data = await removeStripeSecretKey(environment);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe ${environment} key removed.`);
+        }
+
+        await trackPaymentUsage('config.remove', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('config.remove', false, { environment: environmentValue });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/history.ts
+++ b/src/commands/payments/history.ts
@@ -1,0 +1,65 @@
+import type { Command } from 'commander';
+import { listPaymentHistory } from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputTable } from '../../lib/output.js';
+import {
+  formatAmount,
+  formatDate,
+  parseEnvironment,
+  parseIntegerOption,
+  trackPaymentUsage,
+} from './utils.js';
+
+export function registerPaymentsHistoryCommand(paymentsCmd: Command): void {
+  paymentsCmd
+    .command('history')
+    .description('List mirrored Stripe payment history')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .option('--subject-type <type>', 'Filter by billing subject type')
+    .option('--subject-id <id>', 'Filter by billing subject id')
+    .option('--limit <limit>', 'Maximum rows to return (1-100)', '50')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        const limit = parseIntegerOption(opts.limit, '--limit', { min: 1, max: 100 }) ?? 50;
+        await requireAuth();
+
+        const data = await listPaymentHistory({
+          environment,
+          limit,
+          ...(opts.subjectType !== undefined ? { subjectType: opts.subjectType } : {}),
+          ...(opts.subjectId !== undefined ? { subjectId: opts.subjectId } : {}),
+        });
+
+        if (json) {
+          outputJson(data);
+        } else if (data.paymentHistory.length === 0) {
+          console.log('No Stripe payment history found.');
+        } else {
+          outputTable(
+            ['Type', 'Status', 'Subject', 'Amount', 'Customer', 'Stripe Object', 'When'],
+            data.paymentHistory.map((entry) => [
+              entry.type,
+              entry.status,
+              entry.subjectType && entry.subjectId ? `${entry.subjectType}:${entry.subjectId}` : '-',
+              formatAmount(entry.amount, entry.currency),
+              entry.stripeCustomerId ?? '-',
+              entry.stripeCheckoutSessionId
+                ?? entry.stripeInvoiceId
+                ?? entry.stripePaymentIntentId
+                ?? entry.stripeRefundId
+                ?? '-',
+              formatDate(entry.paidAt ?? entry.failedAt ?? entry.refundedAt ?? entry.stripeCreatedAt),
+            ]),
+          );
+        }
+
+        await trackPaymentUsage('history', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('history', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/index.ts
+++ b/src/commands/payments/index.ts
@@ -1,0 +1,24 @@
+import type { Command } from 'commander';
+import { registerPaymentsCatalogCommand } from './catalog.js';
+import { registerPaymentsConfigCommand } from './config.js';
+import { registerPaymentsHistoryCommand } from './history.js';
+import { registerPaymentsPricesCommand } from './prices.js';
+import { registerPaymentsProductsCommand } from './products.js';
+import { registerPaymentsStatusCommand } from './status.js';
+import { registerPaymentsSubscriptionsCommand } from './subscriptions.js';
+import { registerPaymentsSyncCommand } from './sync.js';
+import { registerPaymentsWebhooksCommand } from './webhooks.js';
+
+export function registerPaymentsCommands(paymentsCmd: Command): void {
+  paymentsCmd.description('Manage Stripe payments');
+
+  registerPaymentsStatusCommand(paymentsCmd);
+  registerPaymentsConfigCommand(paymentsCmd);
+  registerPaymentsSyncCommand(paymentsCmd);
+  registerPaymentsWebhooksCommand(paymentsCmd);
+  registerPaymentsCatalogCommand(paymentsCmd);
+  registerPaymentsProductsCommand(paymentsCmd);
+  registerPaymentsPricesCommand(paymentsCmd);
+  registerPaymentsSubscriptionsCommand(paymentsCmd);
+  registerPaymentsHistoryCommand(paymentsCmd);
+}

--- a/src/commands/payments/prices.ts
+++ b/src/commands/payments/prices.ts
@@ -1,0 +1,255 @@
+import type { Command } from 'commander';
+import {
+  archivePaymentPrice,
+  createPaymentPrice,
+  getPaymentPrice,
+  listPaymentPrices,
+  updatePaymentPrice,
+} from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
+import type {
+  CreatePaymentPriceRequest,
+  StripePriceMirror,
+  StripePriceRecurringInterval,
+  StripePriceTaxBehavior,
+  UpdatePaymentPriceRequest,
+} from '@insforge/shared-schemas';
+import {
+  formatAmount,
+  formatDate,
+  formatRecurring,
+  parseBooleanOption,
+  parseEnvironment,
+  parseIntegerOption,
+  parseMetadataOption,
+  trackPaymentUsage,
+} from './utils.js';
+
+function nullableString(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  return value === 'null' ? null : value;
+}
+
+function parseRecurringInterval(value: string | undefined): StripePriceRecurringInterval | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'day' || value === 'week' || value === 'month' || value === 'year') return value;
+  throw new CLIError('--interval must be one of: day, week, month, year.');
+}
+
+function parseTaxBehavior(value: string | undefined): StripePriceTaxBehavior | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'exclusive' || value === 'inclusive' || value === 'unspecified') return value;
+  throw new CLIError('--tax-behavior must be one of: exclusive, inclusive, unspecified.');
+}
+
+function outputPricesTable(prices: StripePriceMirror[]): void {
+  if (prices.length === 0) {
+    console.log('No Stripe prices found.');
+    return;
+  }
+
+  outputTable(
+    ['Env', 'Price ID', 'Product ID', 'Amount', 'Type', 'Active', 'Recurring', 'Synced At'],
+    prices.map((price) => [
+      price.environment,
+      price.stripePriceId,
+      price.stripeProductId ?? '-',
+      formatAmount(price.unitAmount, price.currency),
+      price.type,
+      price.active ? 'Yes' : 'No',
+      formatRecurring(price.recurringInterval, price.recurringIntervalCount),
+      formatDate(price.syncedAt),
+    ]),
+  );
+}
+
+export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
+  const pricesCmd = paymentsCmd
+    .command('prices')
+    .description('Manage Stripe prices');
+
+  pricesCmd
+    .command('list')
+    .description('List mirrored Stripe prices')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .option('--product <productId>', 'Filter by Stripe product id')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const data = await listPaymentPrices(environment, opts.product);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputPricesTable(data.prices);
+        }
+
+        await trackPaymentUsage('prices.list', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('prices.list', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  pricesCmd
+    .command('get <priceId>')
+    .description('Show one Stripe price')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .action(async (priceId: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const data = await getPaymentPrice(environment, priceId);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputPricesTable([data.price]);
+        }
+
+        await trackPaymentUsage('prices.get', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('prices.get', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  pricesCmd
+    .command('create')
+    .description('Create a Stripe one-time or recurring price')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .requiredOption('--product <productId>', 'Stripe product id')
+    .requiredOption('--currency <currency>', 'Three-letter currency code, e.g. usd')
+    .requiredOption('--unit-amount <amount>', 'Unit amount in the smallest currency unit, e.g. cents')
+    .option('--interval <interval>', 'Recurring interval: day, week, month, or year')
+    .option('--interval-count <count>', 'Recurring interval count')
+    .option('--lookup-key <key>', 'Stripe lookup key, or "null"')
+    .option('--active <bool>', 'Set active status (true/false)')
+    .option('--tax-behavior <behavior>', 'exclusive, inclusive, or unspecified')
+    .option('--metadata <json>', 'Metadata JSON object with string values')
+    .option('--idempotency-key <key>', 'Caller-stable idempotency key')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const interval = parseRecurringInterval(opts.interval);
+        const intervalCount = parseIntegerOption(opts.intervalCount, '--interval-count', { min: 1 });
+        if (!interval && intervalCount !== undefined) {
+          throw new CLIError('Provide --interval when using --interval-count.');
+        }
+
+        const request: CreatePaymentPriceRequest = {
+          environment,
+          stripeProductId: opts.product,
+          currency: opts.currency,
+          unitAmount: parseIntegerOption(opts.unitAmount, '--unit-amount', { min: 0 }) ?? 0,
+        };
+        const lookupKey = nullableString(opts.lookupKey);
+        const active = parseBooleanOption(opts.active, '--active');
+        const taxBehavior = parseTaxBehavior(opts.taxBehavior);
+        const metadata = parseMetadataOption(opts.metadata);
+        if (lookupKey !== undefined) request.lookupKey = lookupKey;
+        if (active !== undefined) request.active = active;
+        if (taxBehavior !== undefined) request.taxBehavior = taxBehavior;
+        if (metadata !== undefined) request.metadata = metadata;
+        if (opts.idempotencyKey !== undefined) request.idempotencyKey = opts.idempotencyKey;
+        if (interval) {
+          request.recurring = {
+            interval,
+            ...(intervalCount !== undefined ? { intervalCount } : {}),
+          };
+        }
+
+        const data = await createPaymentPrice(request);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe price created: ${data.price.stripePriceId}`);
+        }
+
+        await trackPaymentUsage('prices.create', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('prices.create', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  pricesCmd
+    .command('update <priceId>')
+    .description('Update a Stripe price')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .option('--active <bool>', 'Set active status (true/false)')
+    .option('--lookup-key <key>', 'Stripe lookup key, or "null"')
+    .option('--tax-behavior <behavior>', 'exclusive, inclusive, or unspecified')
+    .option('--metadata <json>', 'Metadata JSON object with string values')
+    .action(async (priceId: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const request: UpdatePaymentPriceRequest = { environment };
+        const active = parseBooleanOption(opts.active, '--active');
+        const lookupKey = nullableString(opts.lookupKey);
+        const taxBehavior = parseTaxBehavior(opts.taxBehavior);
+        const metadata = parseMetadataOption(opts.metadata);
+        if (active !== undefined) request.active = active;
+        if (lookupKey !== undefined) request.lookupKey = lookupKey;
+        if (taxBehavior !== undefined) request.taxBehavior = taxBehavior;
+        if (metadata !== undefined) request.metadata = metadata;
+
+        if (Object.keys(request).length === 1) {
+          throw new CLIError('Provide at least one option to update (--active, --lookup-key, --tax-behavior, --metadata).');
+        }
+
+        const data = await updatePaymentPrice(priceId, request);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe price updated: ${data.price.stripePriceId}`);
+        }
+
+        await trackPaymentUsage('prices.update', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('prices.update', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  pricesCmd
+    .command('archive <priceId>')
+    .alias('delete')
+    .description('Archive a Stripe price')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .action(async (priceId: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const data = await archivePaymentPrice(environment, priceId);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe price archived: ${data.price.stripePriceId}`);
+        }
+
+        await trackPaymentUsage('prices.archive', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('prices.archive', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/products.ts
+++ b/src/commands/payments/products.ts
@@ -16,6 +16,7 @@ import type {
   UpdatePaymentProductRequest,
 } from '@insforge/shared-schemas';
 import {
+  formatAmount,
   formatDate,
   parseBooleanOption,
   parseEnvironment,
@@ -99,7 +100,7 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
               ['Price ID', 'Amount', 'Type', 'Active', 'Lookup Key'],
               data.prices.map((price) => [
                 price.stripePriceId,
-                price.unitAmount === null ? '-' : `${price.unitAmount} ${price.currency.toUpperCase()}`,
+                formatAmount(price.unitAmount, price.currency),
                 price.type,
                 price.active ? 'Yes' : 'No',
                 price.lookupKey ?? '-',
@@ -209,7 +210,11 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        if (!yes && !json) {
+        if (json && !yes) {
+          throw new CLIError('Use --yes with --json to delete a Stripe product non-interactively.');
+        }
+
+        if (!yes) {
           const confirm = await prompts.confirm({
             message: `Delete Stripe ${environment} product "${productId}"?`,
           });

--- a/src/commands/payments/products.ts
+++ b/src/commands/payments/products.ts
@@ -1,0 +1,233 @@
+import type { Command } from 'commander';
+import * as prompts from '../../lib/prompts.js';
+import {
+  createPaymentProduct,
+  deletePaymentProduct,
+  getPaymentProduct,
+  listPaymentProducts,
+  updatePaymentProduct,
+} from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
+import type {
+  CreatePaymentProductRequest,
+  StripeProductMirror,
+  UpdatePaymentProductRequest,
+} from '@insforge/shared-schemas';
+import {
+  formatDate,
+  parseBooleanOption,
+  parseEnvironment,
+  parseMetadataOption,
+  trackPaymentUsage,
+} from './utils.js';
+
+function nullableString(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  return value === 'null' ? null : value;
+}
+
+function outputProductsTable(products: StripeProductMirror[]): void {
+  if (products.length === 0) {
+    console.log('No Stripe products found.');
+    return;
+  }
+
+  outputTable(
+    ['Env', 'Product ID', 'Name', 'Active', 'Default Price', 'Synced At'],
+    products.map((product) => [
+      product.environment,
+      product.stripeProductId,
+      product.name,
+      product.active ? 'Yes' : 'No',
+      product.defaultPriceId ?? '-',
+      formatDate(product.syncedAt),
+    ]),
+  );
+}
+
+export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
+  const productsCmd = paymentsCmd
+    .command('products')
+    .description('Manage Stripe products');
+
+  productsCmd
+    .command('list')
+    .description('List mirrored Stripe products')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const data = await listPaymentProducts(environment);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputProductsTable(data.products);
+        }
+
+        await trackPaymentUsage('products.list', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('products.list', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  productsCmd
+    .command('get <productId>')
+    .description('Show one Stripe product and its prices')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .action(async (productId: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const data = await getPaymentProduct(environment, productId);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputProductsTable([data.product]);
+          if (data.prices.length > 0) {
+            console.log('Prices');
+            outputTable(
+              ['Price ID', 'Amount', 'Type', 'Active', 'Lookup Key'],
+              data.prices.map((price) => [
+                price.stripePriceId,
+                price.unitAmount === null ? '-' : `${price.unitAmount} ${price.currency.toUpperCase()}`,
+                price.type,
+                price.active ? 'Yes' : 'No',
+                price.lookupKey ?? '-',
+              ]),
+            );
+          }
+        }
+
+        await trackPaymentUsage('products.get', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('products.get', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  productsCmd
+    .command('create')
+    .description('Create a Stripe product')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .requiredOption('--name <name>', 'Product name')
+    .option('--description <description>', 'Product description, or "null"')
+    .option('--active <bool>', 'Set active status (true/false)')
+    .option('--metadata <json>', 'Metadata JSON object with string values')
+    .option('--idempotency-key <key>', 'Caller-stable idempotency key')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const request: CreatePaymentProductRequest = {
+          environment,
+          name: opts.name,
+        };
+        const description = nullableString(opts.description);
+        const active = parseBooleanOption(opts.active, '--active');
+        const metadata = parseMetadataOption(opts.metadata);
+        if (description !== undefined) request.description = description;
+        if (active !== undefined) request.active = active;
+        if (metadata !== undefined) request.metadata = metadata;
+        if (opts.idempotencyKey !== undefined) request.idempotencyKey = opts.idempotencyKey;
+
+        const data = await createPaymentProduct(request);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe product created: ${data.product.stripeProductId}`);
+        }
+
+        await trackPaymentUsage('products.create', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('products.create', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  productsCmd
+    .command('update <productId>')
+    .description('Update a Stripe product')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .option('--name <name>', 'Product name')
+    .option('--description <description>', 'Product description, or "null"')
+    .option('--active <bool>', 'Set active status (true/false)')
+    .option('--metadata <json>', 'Metadata JSON object with string values')
+    .action(async (productId: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const request: UpdatePaymentProductRequest = { environment };
+        const description = nullableString(opts.description);
+        const active = parseBooleanOption(opts.active, '--active');
+        const metadata = parseMetadataOption(opts.metadata);
+        if (opts.name !== undefined) request.name = opts.name;
+        if (description !== undefined) request.description = description;
+        if (active !== undefined) request.active = active;
+        if (metadata !== undefined) request.metadata = metadata;
+
+        if (Object.keys(request).length === 1) {
+          throw new CLIError('Provide at least one option to update (--name, --description, --active, --metadata).');
+        }
+
+        const data = await updatePaymentProduct(productId, request);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe product updated: ${data.product.stripeProductId}`);
+        }
+
+        await trackPaymentUsage('products.update', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('products.update', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+
+  productsCmd
+    .command('delete <productId>')
+    .description('Delete a Stripe product that has no prices')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .action(async (productId: string, opts, cmd) => {
+      const { json, yes } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        if (!yes && !json) {
+          const confirm = await prompts.confirm({
+            message: `Delete Stripe ${environment} product "${productId}"?`,
+          });
+          if (prompts.isCancel(confirm) || !confirm) process.exit(0);
+        }
+
+        const data = await deletePaymentProduct(environment, productId);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Stripe product deleted: ${data.stripeProductId}`);
+        }
+
+        await trackPaymentUsage('products.delete', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('products.delete', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/status.ts
+++ b/src/commands/payments/status.ts
@@ -1,0 +1,44 @@
+import type { Command } from 'commander';
+import { getPaymentsStatus } from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputTable } from '../../lib/output.js';
+import { formatDate, trackPaymentUsage } from './utils.js';
+
+export function registerPaymentsStatusCommand(paymentsCmd: Command): void {
+  paymentsCmd
+    .command('status')
+    .description('Show Stripe payment connection, sync, and webhook status')
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const data = await getPaymentsStatus();
+
+        if (json) {
+          outputJson(data);
+        } else if (data.connections.length === 0) {
+          console.log('No Stripe payment environments found.');
+        } else {
+          outputTable(
+            ['Env', 'Status', 'Key', 'Account', 'Webhook', 'Last Sync', 'Synced At'],
+            data.connections.map((connection) => [
+              connection.environment,
+              connection.status,
+              connection.maskedKey ?? '-',
+              connection.stripeAccountId ?? '-',
+              connection.webhookEndpointId ? 'Configured' : '-',
+              connection.lastSyncStatus ?? '-',
+              formatDate(connection.lastSyncedAt),
+            ]),
+          );
+        }
+
+        await trackPaymentUsage('status', true);
+      } catch (err) {
+        await trackPaymentUsage('status', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/subscriptions.ts
+++ b/src/commands/payments/subscriptions.ts
@@ -1,0 +1,61 @@
+import type { Command } from 'commander';
+import { listSubscriptions } from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputTable } from '../../lib/output.js';
+import {
+  formatDate,
+  parseEnvironment,
+  parseIntegerOption,
+  trackPaymentUsage,
+} from './utils.js';
+
+export function registerPaymentsSubscriptionsCommand(paymentsCmd: Command): void {
+  paymentsCmd
+    .command('subscriptions')
+    .description('List mirrored Stripe subscriptions')
+    .requiredOption('--environment <environment>', 'Stripe environment: test or live')
+    .option('--subject-type <type>', 'Filter by billing subject type')
+    .option('--subject-id <id>', 'Filter by billing subject id')
+    .option('--limit <limit>', 'Maximum rows to return (1-100)', '50')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        const limit = parseIntegerOption(opts.limit, '--limit', { min: 1, max: 100 }) ?? 50;
+        await requireAuth();
+
+        const data = await listSubscriptions({
+          environment,
+          limit,
+          ...(opts.subjectType !== undefined ? { subjectType: opts.subjectType } : {}),
+          ...(opts.subjectId !== undefined ? { subjectId: opts.subjectId } : {}),
+        });
+
+        if (json) {
+          outputJson(data);
+        } else if (data.subscriptions.length === 0) {
+          console.log('No Stripe subscriptions found.');
+        } else {
+          outputTable(
+            ['Subscription ID', 'Customer', 'Subject', 'Status', 'Items', 'Period End'],
+            data.subscriptions.map((subscription) => [
+              subscription.stripeSubscriptionId,
+              subscription.stripeCustomerId,
+              subscription.subjectType && subscription.subjectId
+                ? `${subscription.subjectType}:${subscription.subjectId}`
+                : '-',
+              subscription.status,
+              String(subscription.items?.length ?? 0),
+              formatDate(subscription.currentPeriodEnd),
+            ]),
+          );
+        }
+
+        await trackPaymentUsage('subscriptions', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('subscriptions', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/sync.ts
+++ b/src/commands/payments/sync.ts
@@ -1,0 +1,47 @@
+import type { Command } from 'commander';
+import { syncPayments } from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
+import { formatDate, parseEnvironmentOrAll, trackPaymentUsage } from './utils.js';
+
+export function registerPaymentsSyncCommand(paymentsCmd: Command): void {
+  paymentsCmd
+    .command('sync')
+    .description('Sync configured Stripe products, prices, and subscriptions')
+    .option('--environment <environment>', 'Stripe environment: test, live, or all', 'all')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironmentOrAll(opts.environment);
+        await requireAuth();
+
+        const data = await syncPayments(environment);
+
+        if (json) {
+          outputJson(data);
+        } else if (data.results.length === 0) {
+          console.log('No configured Stripe environments to sync.');
+        } else {
+          outputTable(
+            ['Env', 'Status', 'Products', 'Prices', 'Subscriptions', 'Unmapped', 'Synced At'],
+            data.results.map((result) => [
+              result.environment,
+              result.connection.lastSyncStatus ?? result.connection.status,
+              String(result.connection.lastSyncCounts.products ?? 0),
+              String(result.connection.lastSyncCounts.prices ?? 0),
+              String(result.subscriptions?.synced ?? 0),
+              String(result.subscriptions?.unmapped ?? 0),
+              formatDate(result.connection.lastSyncedAt),
+            ]),
+          );
+          outputSuccess('Stripe payments synced.');
+        }
+
+        await trackPaymentUsage('sync', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('sync', false, { environment: opts.environment });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/utils.ts
+++ b/src/commands/payments/utils.ts
@@ -81,8 +81,22 @@ export function formatAmount(
   currency: string | null | undefined,
 ): string {
   if (amount === null || amount === undefined) return '-';
-  const code = currency?.toUpperCase() ?? '';
-  return `${(amount / 100).toFixed(2)} ${code}`.trim();
+  const code = currency?.toUpperCase();
+  let fractionDigits = 2;
+
+  if (code) {
+    try {
+      fractionDigits = new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: code,
+      }).resolvedOptions().maximumFractionDigits;
+    } catch {
+      fractionDigits = 2;
+    }
+  }
+
+  const divisor = 10 ** fractionDigits;
+  return `${(amount / divisor).toFixed(fractionDigits)} ${code ?? ''}`.trim();
 }
 
 export function formatRecurring(

--- a/src/commands/payments/utils.ts
+++ b/src/commands/payments/utils.ts
@@ -1,0 +1,116 @@
+import type { StripeEnvironment } from '@insforge/shared-schemas';
+import { getProjectConfig } from '../../lib/config.js';
+import { CLIError } from '../../lib/errors.js';
+import { shutdownAnalytics, trackPayments } from '../../lib/analytics.js';
+
+export type PaymentCommandTelemetry = Record<string, string | number | boolean | undefined>;
+
+export function parseEnvironment(value: string): StripeEnvironment {
+  if (value === 'test' || value === 'live') return value;
+  throw new CLIError('Environment must be "test" or "live".');
+}
+
+export function parseEnvironmentOrAll(value: string): StripeEnvironment | 'all' {
+  if (value === 'all') return value;
+  return parseEnvironment(value);
+}
+
+export function parseBooleanOption(value: string | undefined, flagName: string): boolean | undefined {
+  if (value === undefined) return undefined;
+
+  const normalized = value.toLowerCase();
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+
+  throw new CLIError(`${flagName} must be "true" or "false".`);
+}
+
+export function parseIntegerOption(
+  value: string | undefined,
+  flagName: string,
+  options: { min?: number; max?: number } = {},
+): number | undefined {
+  if (value === undefined) return undefined;
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || String(parsed) !== value.trim()) {
+    throw new CLIError(`${flagName} must be an integer.`);
+  }
+  if (options.min !== undefined && parsed < options.min) {
+    throw new CLIError(`${flagName} must be at least ${options.min}.`);
+  }
+  if (options.max !== undefined && parsed > options.max) {
+    throw new CLIError(`${flagName} must be at most ${options.max}.`);
+  }
+  return parsed;
+}
+
+export function parseMetadataOption(value: string | undefined): Record<string, string> | undefined {
+  if (value === undefined) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new CLIError('Invalid JSON for --metadata.');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new CLIError('--metadata must be a JSON object.');
+  }
+
+  const metadata: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(parsed)) {
+    if (typeof raw !== 'string') {
+      throw new CLIError(`Metadata value for "${key}" must be a string.`);
+    }
+    metadata[key] = raw;
+  }
+
+  return metadata;
+}
+
+export function formatDate(value: string | null | undefined): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+export function formatAmount(
+  amount: number | null | undefined,
+  currency: string | null | undefined,
+): string {
+  if (amount === null || amount === undefined) return '-';
+  const code = currency?.toUpperCase() ?? '';
+  return `${(amount / 100).toFixed(2)} ${code}`.trim();
+}
+
+export function formatRecurring(
+  interval: string | null | undefined,
+  intervalCount: number | null | undefined,
+): string {
+  if (!interval) return 'one-time';
+  return `${intervalCount && intervalCount > 1 ? `${intervalCount} ` : ''}${interval}`;
+}
+
+export async function trackPaymentUsage(
+  subcommand: string,
+  success: boolean,
+  properties: PaymentCommandTelemetry = {},
+): Promise<void> {
+  try {
+    try {
+      const config = getProjectConfig();
+      if (config) {
+        trackPayments(subcommand, config, {
+          success,
+          ...properties,
+        });
+      }
+    } catch {
+      // Telemetry should never affect command behavior.
+    }
+  } finally {
+    await shutdownAnalytics();
+  }
+}

--- a/src/commands/payments/webhooks.ts
+++ b/src/commands/payments/webhooks.ts
@@ -1,0 +1,45 @@
+import type { Command } from 'commander';
+import { configurePaymentWebhook } from '../../lib/api/payments.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
+import { formatDate, parseEnvironment, trackPaymentUsage } from './utils.js';
+
+export function registerPaymentsWebhooksCommand(paymentsCmd: Command): void {
+  const webhooksCmd = paymentsCmd
+    .command('webhooks')
+    .description('Manage InsForge-managed Stripe webhooks');
+
+  webhooksCmd
+    .command('configure <environment>')
+    .description('Create or recreate the managed Stripe webhook endpoint')
+    .action(async (environmentValue: string, _opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(environmentValue);
+        await requireAuth();
+
+        const data = await configurePaymentWebhook(environment);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputTable(
+            ['Env', 'Webhook ID', 'URL', 'Configured At'],
+            [[
+              data.connection.environment,
+              data.connection.webhookEndpointId ?? '-',
+              data.connection.webhookEndpointUrl ?? '-',
+              formatDate(data.connection.webhookConfiguredAt),
+            ]],
+          );
+          outputSuccess(`Stripe ${environment} webhook configured.`);
+        }
+
+        await trackPaymentUsage('webhooks.configure', true, { environment });
+      } catch (err) {
+        await trackPaymentUsage('webhooks.configure', false, { environment: environmentValue });
+        handleError(err, json);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import { registerComputeDeployCommand } from './commands/compute/deploy.js';
 import { registerLogsCommand } from './commands/logs.js';
 import { registerMetadataCommand } from './commands/metadata.js';
 import { registerDiagnoseCommands } from './commands/diagnose/index.js';
+import { registerPaymentsCommands } from './commands/payments/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
@@ -180,6 +181,10 @@ registerMetadataCommand(program);
 // Diagnose commands
 const diagnoseCmd = program.command('diagnose');
 registerDiagnoseCommands(diagnoseCmd);
+
+// Payments commands
+const paymentsCmd = program.command('payments').description('Manage Stripe payments');
+registerPaymentsCommands(paymentsCmd);
 
 // Compute commands
 const computeCmd = program.command('compute').description('Manage compute services (Docker containers on Fly.io)');

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -45,6 +45,22 @@ export function trackDiagnose(subcommand: string, config: ProjectConfig): void {
   });
 }
 
+export function trackPayments(
+  subcommand: string,
+  config: ProjectConfig,
+  properties?: Record<string, unknown>,
+): void {
+  captureEvent(config.project_id, 'cli_payments_invoked', {
+    subcommand,
+    project_id: config.project_id,
+    project_name: config.project_name,
+    org_id: config.org_id,
+    region: config.region,
+    oss_mode: config.project_id === FAKE_PROJECT_ID,
+    ...properties,
+  });
+}
+
 export async function shutdownAnalytics(): Promise<void> {
   try {
     if (client) await client.shutdown();

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -74,6 +74,10 @@ export async function ossFetch(
       message = 'Compute services are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin to enable compute.';
     }
 
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/payments')) {
+      message = 'Payments are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud/private preview: contact your InsForge admin to enable payments.';
+    }
+
     if (res.status === 404 && isRouteLevel404 && path === '/api/database/migrations') {
       message = 'Database migrations are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin about database migration support.';
     }

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -1,0 +1,193 @@
+import { ossFetch } from './oss.js';
+import type {
+  ArchivePaymentPriceResponse,
+  ConfigurePaymentWebhookResponse,
+  CreatePaymentPriceRequest,
+  CreatePaymentProductRequest,
+  DeletePaymentProductResponse,
+  GetPaymentPriceResponse,
+  GetPaymentProductResponse,
+  GetPaymentsConfigResponse,
+  GetPaymentsStatusResponse,
+  ListPaymentCatalogResponse,
+  ListPaymentHistoryRequest,
+  ListPaymentHistoryResponse,
+  ListPaymentPricesResponse,
+  ListPaymentProductsResponse,
+  ListSubscriptionsRequest,
+  ListSubscriptionsResponse,
+  MutatePaymentPriceResponse,
+  MutatePaymentProductResponse,
+  StripeEnvironment,
+  SyncPaymentsRequest,
+  SyncPaymentsResponse,
+  UpdatePaymentPriceRequest,
+  UpdatePaymentProductRequest,
+} from '@insforge/shared-schemas';
+
+function withQuery(path: string, params: Record<string, string | number | undefined>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) query.set(key, String(value));
+  }
+  const suffix = query.toString();
+  return suffix ? `${path}?${suffix}` : path;
+}
+
+async function readJson<T>(res: Response): Promise<T> {
+  return await res.json() as T;
+}
+
+export async function getPaymentsStatus(): Promise<GetPaymentsStatusResponse> {
+  return readJson(await ossFetch('/api/payments/status'));
+}
+
+export async function getPaymentsConfig(): Promise<GetPaymentsConfigResponse> {
+  return readJson(await ossFetch('/api/payments/config'));
+}
+
+export async function setStripeSecretKey(
+  environment: StripeEnvironment,
+  secretKey: string,
+): Promise<GetPaymentsConfigResponse> {
+  return readJson(await ossFetch('/api/payments/config', {
+    method: 'POST',
+    body: JSON.stringify({ environment, secretKey }),
+  }));
+}
+
+export async function removeStripeSecretKey(
+  environment: StripeEnvironment,
+): Promise<GetPaymentsConfigResponse> {
+  return readJson(await ossFetch(`/api/payments/config/${encodeURIComponent(environment)}`, {
+    method: 'DELETE',
+  }));
+}
+
+export async function syncPayments(environment: SyncPaymentsRequest['environment'] = 'all'): Promise<SyncPaymentsResponse> {
+  return readJson(await ossFetch('/api/payments/sync', {
+    method: 'POST',
+    body: JSON.stringify({ environment }),
+  }));
+}
+
+export async function configurePaymentWebhook(
+  environment: StripeEnvironment,
+): Promise<ConfigurePaymentWebhookResponse> {
+  return readJson(await ossFetch(
+    `/api/payments/webhooks/${encodeURIComponent(environment)}/configure`,
+    { method: 'POST' },
+  ));
+}
+
+export async function listPaymentCatalog(
+  environment?: StripeEnvironment,
+): Promise<ListPaymentCatalogResponse> {
+  return readJson(await ossFetch(withQuery('/api/payments/catalog', { environment })));
+}
+
+export async function listPaymentProducts(
+  environment: StripeEnvironment,
+): Promise<ListPaymentProductsResponse> {
+  return readJson(await ossFetch(withQuery('/api/payments/products', { environment })));
+}
+
+export async function getPaymentProduct(
+  environment: StripeEnvironment,
+  productId: string,
+): Promise<GetPaymentProductResponse> {
+  return readJson(await ossFetch(withQuery(
+    `/api/payments/products/${encodeURIComponent(productId)}`,
+    { environment },
+  )));
+}
+
+export async function createPaymentProduct(
+  request: CreatePaymentProductRequest,
+): Promise<MutatePaymentProductResponse> {
+  return readJson(await ossFetch('/api/payments/products', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  }));
+}
+
+export async function updatePaymentProduct(
+  productId: string,
+  request: UpdatePaymentProductRequest,
+): Promise<MutatePaymentProductResponse> {
+  return readJson(await ossFetch(`/api/payments/products/${encodeURIComponent(productId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(request),
+  }));
+}
+
+export async function deletePaymentProduct(
+  environment: StripeEnvironment,
+  productId: string,
+): Promise<DeletePaymentProductResponse> {
+  return readJson(await ossFetch(withQuery(
+    `/api/payments/products/${encodeURIComponent(productId)}`,
+    { environment },
+  ), { method: 'DELETE' }));
+}
+
+export async function listPaymentPrices(
+  environment: StripeEnvironment,
+  stripeProductId?: string,
+): Promise<ListPaymentPricesResponse> {
+  return readJson(await ossFetch(withQuery('/api/payments/prices', {
+    environment,
+    stripeProductId,
+  })));
+}
+
+export async function getPaymentPrice(
+  environment: StripeEnvironment,
+  priceId: string,
+): Promise<GetPaymentPriceResponse> {
+  return readJson(await ossFetch(withQuery(
+    `/api/payments/prices/${encodeURIComponent(priceId)}`,
+    { environment },
+  )));
+}
+
+export async function createPaymentPrice(
+  request: CreatePaymentPriceRequest,
+): Promise<MutatePaymentPriceResponse> {
+  return readJson(await ossFetch('/api/payments/prices', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  }));
+}
+
+export async function updatePaymentPrice(
+  priceId: string,
+  request: UpdatePaymentPriceRequest,
+): Promise<MutatePaymentPriceResponse> {
+  return readJson(await ossFetch(`/api/payments/prices/${encodeURIComponent(priceId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(request),
+  }));
+}
+
+export async function archivePaymentPrice(
+  environment: StripeEnvironment,
+  priceId: string,
+): Promise<ArchivePaymentPriceResponse> {
+  return readJson(await ossFetch(withQuery(
+    `/api/payments/prices/${encodeURIComponent(priceId)}`,
+    { environment },
+  ), { method: 'DELETE' }));
+}
+
+export async function listSubscriptions(
+  request: ListSubscriptionsRequest,
+): Promise<ListSubscriptionsResponse> {
+  return readJson(await ossFetch(withQuery('/api/payments/subscriptions', request)));
+}
+
+export async function listPaymentHistory(
+  request: ListPaymentHistoryRequest,
+): Promise<ListPaymentHistoryResponse> {
+  return readJson(await ossFetch(withQuery('/api/payments/payment-history', request)));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Stripe payments CLI: status, config (key management), sync, webhooks, catalog, products, prices, subscriptions, and history with JSON/table output and filtering.

* **Documentation**
  * Expanded README with detailed payments CLI usage, examples, and command references.

* **Chores**
  * Updated dependency version to enable payments-related schemas and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->