### PR TITLE
feat(cli): add `insforge.toml` config-as-code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "commander": "^13.1.0",
         "open": "^10.1.0",
         "picocolors": "^1.1.1",
-        "posthog-node": "^5.28.9"
+        "posthog-node": "^5.28.9",
+        "smol-toml": "^1.6.1"
       },
       "bin": {
         "insforge": "dist/index.js"
@@ -4194,6 +4195,18 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "commander": "^13.1.0",
     "open": "^10.1.0",
     "picocolors": "^1.1.1",
-    "posthog-node": "^5.28.9"
+    "posthog-node": "^5.28.9",
+    "smol-toml": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/commands/config/apply.ts
+++ b/src/commands/config/apply.ts
@@ -1,0 +1,79 @@
+// CLI/src/commands/config/apply.ts
+import type { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { parseConfigToml } from '../../lib/config-toml.js';
+import { formatPlan } from '../../lib/config-format.js';
+import type { DiffResult } from '../../lib/config-diff.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+export function registerConfigApplyCommand(cfg: Command): void {
+  cfg
+    .command('apply')
+    .description('Apply insforge.toml to the live project')
+    .option('--file <path>', 'path to insforge.toml', 'insforge.toml')
+    .option('--dry-run', 'show plan, do not apply')
+    .option('--auto-approve', 'skip confirmation prompt')
+    .option('--prune', 'delete items in live state that are missing from the file')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const tomlPath = resolve(process.cwd(), opts.file);
+        const tomlSource = readFileSync(tomlPath, 'utf8');
+        const file = parseConfigToml(tomlSource);
+
+        // Phase 1: always POST with dry_run=true to get the plan.
+        const planRes = await ossFetch('/api/config/apply', {
+          method: 'POST',
+          body: JSON.stringify({ config: file, dry_run: true, prune: !!opts.prune }),
+        });
+        const planResult = (await planRes.json()) as { plan: DiffResult; applied: boolean };
+
+        if (json) {
+          console.log(JSON.stringify(planResult, null, 2));
+        } else {
+          console.log(formatPlan(planResult.plan));
+        }
+
+        if (planResult.plan.changes.length === 0 || opts.dryRun) {
+          await reportCliUsage('cli.config.apply', true);
+          return;
+        }
+
+        // Phase 2: confirm (unless --auto-approve).
+        if (!opts.autoApprove) {
+          const ok = await p.confirm({ message: 'Apply these changes?', initialValue: false });
+          if (!ok || p.isCancel(ok)) {
+            console.log('Aborted.');
+            await reportCliUsage('cli.config.apply', true);
+            return;
+          }
+        }
+
+        // Phase 3: POST with dry_run=false to actually apply.
+        const applyRes = await ossFetch('/api/config/apply', {
+          method: 'POST',
+          body: JSON.stringify({ config: file, dry_run: false, prune: !!opts.prune }),
+        });
+        const applyResult = (await applyRes.json()) as { plan: DiffResult; applied: boolean };
+
+        if (json) {
+          console.log(JSON.stringify(applyResult, null, 2));
+        } else {
+          const s = applyResult.plan.summary;
+          console.log(`${pc.green('✓')} Applied (${s.add} added, ${s.modify} modified, ${s.remove} removed)`);
+        }
+        await reportCliUsage('cli.config.apply', true);
+      } catch (err) {
+        await reportCliUsage('cli.config.apply', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/config/export.ts
+++ b/src/commands/config/export.ts
@@ -1,0 +1,51 @@
+// CLI/src/commands/config/export.ts
+import type { Command } from 'commander';
+import { writeFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { stringifyConfigToml } from '../../lib/config-toml.js';
+import { validateConfig, type InsforgeConfig } from '../../lib/config-schema.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+export function registerConfigExportCommand(cfg: Command): void {
+  cfg
+    .command('export')
+    .description('Pull live project config and write insforge.toml')
+    .option('--out <path>', 'output path', 'insforge.toml')
+    .option('--force', 'overwrite without confirmation')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const target = resolve(process.cwd(), opts.out);
+        if (existsSync(target) && !opts.force) {
+          const ok = await p.confirm({ message: `${opts.out} exists. Overwrite?`, initialValue: false });
+          if (!ok || p.isCancel(ok)) {
+            console.log('Aborted.');
+            return;
+          }
+        }
+
+        const res = await ossFetch('/api/config');
+        const raw = (await res.json()) as { config: unknown };
+        const config: InsforgeConfig = validateConfig(raw.config);
+        const toml = stringifyConfigToml(config);
+        writeFileSync(target, toml, 'utf8');
+
+        if (json) {
+          console.log(JSON.stringify({ written: target, config }));
+        } else {
+          console.log(`${pc.green('✓')} Wrote ${target}`);
+        }
+        await reportCliUsage('cli.config.export', true);
+      } catch (err) {
+        await reportCliUsage('cli.config.export', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,0 +1,14 @@
+// CLI/src/commands/config/index.ts
+import type { Command } from 'commander';
+import { registerConfigExportCommand } from './export.js';
+import { registerConfigPlanCommand } from './plan.js';
+import { registerConfigApplyCommand } from './apply.js';
+
+export function registerConfigCommand(program: Command): void {
+  const cfg = program
+    .command('config')
+    .description('Manage insforge.toml (declarative project configuration)');
+  registerConfigExportCommand(cfg);
+  registerConfigPlanCommand(cfg);
+  registerConfigApplyCommand(cfg);
+}

--- a/src/commands/config/plan.ts
+++ b/src/commands/config/plan.ts
@@ -1,0 +1,47 @@
+// CLI/src/commands/config/plan.ts
+import type { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { parseConfigToml } from '../../lib/config-toml.js';
+import { diffConfig } from '../../lib/config-diff.js';
+import { formatPlan } from '../../lib/config-format.js';
+import { validateConfig } from '../../lib/config-schema.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+export function registerConfigPlanCommand(cfg: Command): void {
+  cfg
+    .command('plan')
+    .description('Show diff between insforge.toml and live project state')
+    .option('--file <path>', 'path to insforge.toml', 'insforge.toml')
+    .option('--prune', 'mark DB-only items as removals (default: keep)')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const tomlPath = resolve(process.cwd(), opts.file);
+        const tomlSource = readFileSync(tomlPath, 'utf8');
+        const file = parseConfigToml(tomlSource);
+
+        const res = await ossFetch('/api/config');
+        const raw = (await res.json()) as { config: unknown };
+        const live = validateConfig(raw.config);
+
+        const result = diffConfig({ live, file, prune: !!opts.prune });
+
+        if (json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Plan for insforge.toml (file: ${opts.file}):\n`);
+          console.log(formatPlan(result));
+        }
+        await reportCliUsage('cli.config.plan', true);
+      } catch (err) {
+        await reportCliUsage('cli.config.plan', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import { registerLogsCommand } from './commands/logs.js';
 import { registerMetadataCommand } from './commands/metadata.js';
 import { registerDiagnoseCommands } from './commands/diagnose/index.js';
 import { registerPaymentsCommands } from './commands/payments/index.js';
+import { registerConfigCommand } from './commands/config/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
@@ -175,6 +176,9 @@ registerSecretsGetCommand(secretsCmd);
 registerSecretsAddCommand(secretsCmd);
 registerSecretsUpdateCommand(secretsCmd);
 registerSecretsDeleteCommand(secretsCmd);
+
+// Config commands (insforge.toml)
+registerConfigCommand(program);
 
 // Logs command
 registerLogsCommand(program);

--- a/src/lib/config-diff.test.ts
+++ b/src/lib/config-diff.test.ts
@@ -4,10 +4,18 @@ import { diffConfig } from './config-diff.js';
 
 describe('diffConfig', () => {
   it('detects auth modifications', () => {
-    const live = { auth: { jwt_expiry: 3600, enable_signup: true } };
-    const file = { auth: { jwt_expiry: 7200, enable_signup: true } };
+    const live = { auth: { additional_redirect_urls: ['http://a'] } };
+    const file = { auth: { additional_redirect_urls: ['http://a', 'http://b'] } };
     expect(diffConfig({ live, file })).toEqual({
-      changes: [{ section: 'auth', op: 'modify', key: 'jwt_expiry', from: 3600, to: 7200 }],
+      changes: [
+        {
+          section: 'auth',
+          op: 'modify',
+          key: 'additional_redirect_urls',
+          from: ['http://a'],
+          to: ['http://a', 'http://b'],
+        },
+      ],
       summary: { add: 0, modify: 1, remove: 0, kept: 0 },
     });
   });
@@ -54,7 +62,7 @@ describe('diffConfig', () => {
 
   it('returns no changes for converged state (idempotence sanity)', () => {
     const same = {
-      auth: { jwt_expiry: 3600, enable_signup: true },
+      auth: { additional_redirect_urls: ['http://a'] },
       storage: { buckets: { a: { public: true } } },
     };
     expect(diffConfig({ live: same, file: same })).toEqual({

--- a/src/lib/config-diff.test.ts
+++ b/src/lib/config-diff.test.ts
@@ -1,0 +1,65 @@
+// CLI/src/lib/config-diff.test.ts
+import { describe, expect, it } from 'vitest';
+import { diffConfig } from './config-diff.js';
+
+describe('diffConfig', () => {
+  it('detects auth modifications', () => {
+    const live = { auth: { jwt_expiry: 3600, enable_signup: true } };
+    const file = { auth: { jwt_expiry: 7200, enable_signup: true } };
+    expect(diffConfig({ live, file })).toEqual({
+      changes: [{ section: 'auth', op: 'modify', key: 'jwt_expiry', from: 3600, to: 7200 }],
+      summary: { add: 0, modify: 1, remove: 0, kept: 0 },
+    });
+  });
+
+  it('detects bucket add and modify', () => {
+    const live = { storage: { buckets: { existing: { public: false } } } };
+    const file = {
+      storage: {
+        buckets: {
+          existing: { public: true },
+          newone: { public: true },
+        },
+      },
+    };
+    const d = diffConfig({ live, file });
+    expect(d.changes).toEqual(
+      expect.arrayContaining([
+        { section: 'storage.buckets', op: 'modify', key: 'existing', field: 'public', from: false, to: true },
+        { section: 'storage.buckets', op: 'add', key: 'newone', value: { public: true } },
+      ]),
+    );
+    expect(d.summary).toEqual({ add: 1, modify: 1, remove: 0, kept: 0 });
+  });
+
+  it('marks DB-only buckets as kept (not removed) by default', () => {
+    const live = { storage: { buckets: { orphan: { public: true } } } };
+    const file = { storage: { buckets: {} } };
+    const d = diffConfig({ live, file });
+    expect(d.changes).toEqual([
+      { section: 'storage.buckets', op: 'remove', key: 'orphan', kept: true },
+    ]);
+    expect(d.summary).toEqual({ add: 0, modify: 0, remove: 0, kept: 1 });
+  });
+
+  it('marks DB-only buckets as removed when prune=true', () => {
+    const live = { storage: { buckets: { orphan: { public: true } } } };
+    const file = { storage: { buckets: {} } };
+    const d = diffConfig({ live, file, prune: true });
+    expect(d.changes).toEqual([
+      { section: 'storage.buckets', op: 'remove', key: 'orphan', kept: false },
+    ]);
+    expect(d.summary).toEqual({ add: 0, modify: 0, remove: 1, kept: 0 });
+  });
+
+  it('returns no changes for converged state (idempotence sanity)', () => {
+    const same = {
+      auth: { jwt_expiry: 3600, enable_signup: true },
+      storage: { buckets: { a: { public: true } } },
+    };
+    expect(diffConfig({ live: same, file: same })).toEqual({
+      changes: [],
+      summary: { add: 0, modify: 0, remove: 0, kept: 0 },
+    });
+  });
+});

--- a/src/lib/config-diff.ts
+++ b/src/lib/config-diff.ts
@@ -31,7 +31,7 @@ export function diffConfig({ live, file, prune = false }: DiffInput): DiffResult
   // --- auth ---
   const liveAuth = live.auth ?? {};
   const fileAuth = file.auth ?? {};
-  for (const key of ['jwt_expiry', 'enable_signup', 'site_url', 'additional_redirect_urls'] as const) {
+  for (const key of ['additional_redirect_urls'] as const) {
     if (!(key in fileAuth)) continue;
     const fromV = (liveAuth as Record<string, unknown>)[key];
     const toV = (fileAuth as Record<string, unknown>)[key];

--- a/src/lib/config-diff.ts
+++ b/src/lib/config-diff.ts
@@ -1,0 +1,91 @@
+// CLI/src/lib/config-diff.ts
+import type { InsforgeConfig } from './config-schema.js';
+
+export type DiffChange =
+  | { section: 'auth'; op: 'modify'; key: keyof NonNullable<InsforgeConfig['auth']>; from: unknown; to: unknown }
+  | { section: 'storage.buckets'; op: 'add'; key: string; value: { public?: boolean } }
+  | { section: 'storage.buckets'; op: 'modify'; key: string; field: 'public'; from: boolean; to: boolean }
+  | { section: 'storage.buckets'; op: 'remove'; key: string; kept: boolean };
+
+export interface DiffSummary {
+  add: number;
+  modify: number;
+  remove: number;
+  kept: number;
+}
+
+export interface DiffResult {
+  changes: DiffChange[];
+  summary: DiffSummary;
+}
+
+export interface DiffInput {
+  live: InsforgeConfig;
+  file: InsforgeConfig;
+  prune?: boolean;
+}
+
+export function diffConfig({ live, file, prune = false }: DiffInput): DiffResult {
+  const changes: DiffChange[] = [];
+
+  // --- auth ---
+  const liveAuth = live.auth ?? {};
+  const fileAuth = file.auth ?? {};
+  for (const key of ['jwt_expiry', 'enable_signup', 'site_url', 'additional_redirect_urls'] as const) {
+    if (!(key in fileAuth)) continue;
+    const fromV = (liveAuth as Record<string, unknown>)[key];
+    const toV = (fileAuth as Record<string, unknown>)[key];
+    if (!deepEqual(fromV, toV)) {
+      changes.push({ section: 'auth', op: 'modify', key, from: fromV, to: toV });
+    }
+  }
+
+  // --- storage.buckets ---
+  const liveBuckets = live.storage?.buckets ?? {};
+  const fileBuckets = file.storage?.buckets ?? {};
+
+  for (const [name, fileB] of Object.entries(fileBuckets)) {
+    const liveB = liveBuckets[name];
+    if (!liveB) {
+      changes.push({ section: 'storage.buckets', op: 'add', key: name, value: fileB });
+      continue;
+    }
+    if (fileB.public !== undefined && fileB.public !== liveB.public) {
+      changes.push({
+        section: 'storage.buckets',
+        op: 'modify',
+        key: name,
+        field: 'public',
+        from: liveB.public ?? false,
+        to: fileB.public,
+      });
+    }
+  }
+
+  for (const name of Object.keys(liveBuckets)) {
+    if (!(name in fileBuckets)) {
+      changes.push({ section: 'storage.buckets', op: 'remove', key: name, kept: !prune });
+    }
+  }
+
+  return { changes, summary: summarize(changes) };
+}
+
+function summarize(changes: DiffChange[]): DiffSummary {
+  const s: DiffSummary = { add: 0, modify: 0, remove: 0, kept: 0 };
+  for (const c of changes) {
+    if (c.op === 'add') s.add++;
+    else if (c.op === 'modify') s.modify++;
+    else if (c.op === 'remove') c.kept ? s.kept++ : s.remove++;
+  }
+  return s;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  return false;
+}

--- a/src/lib/config-format.test.ts
+++ b/src/lib/config-format.test.ts
@@ -1,0 +1,29 @@
+// CLI/src/lib/config-format.test.ts
+import { describe, expect, it } from 'vitest';
+import { formatPlan } from './config-format.js';
+
+describe('formatPlan', () => {
+  it('renders a multi-section plan with kept warnings', () => {
+    const out = formatPlan({
+      changes: [
+        { section: 'auth', op: 'modify', key: 'jwt_expiry', from: 3600, to: 7200 },
+        { section: 'storage.buckets', op: 'add', key: 'avatars', value: { public: true } },
+        { section: 'storage.buckets', op: 'modify', key: 'user-files', field: 'public', from: false, to: true },
+        { section: 'storage.buckets', op: 'remove', key: 'old-bucket', kept: true },
+      ],
+      summary: { add: 1, modify: 2, remove: 0, kept: 1 },
+    });
+    expect(out).toContain('auth:');
+    expect(out).toContain('~ jwt_expiry: 3600 → 7200');
+    expect(out).toContain('storage.buckets:');
+    expect(out).toContain('+ avatars');
+    expect(out).toContain('~ user-files: public false → true');
+    expect(out).toContain('- old-bucket (in DB, not in file — KEPT; use --prune to delete)');
+    expect(out).toContain('1 add, 2 modify, 0 remove, 1 untracked kept');
+  });
+
+  it('renders no-change plans cleanly', () => {
+    const out = formatPlan({ changes: [], summary: { add: 0, modify: 0, remove: 0, kept: 0 } });
+    expect(out).toContain('No changes. Live state matches insforge.toml.');
+  });
+});

--- a/src/lib/config-format.test.ts
+++ b/src/lib/config-format.test.ts
@@ -6,7 +6,13 @@ describe('formatPlan', () => {
   it('renders a multi-section plan with kept warnings', () => {
     const out = formatPlan({
       changes: [
-        { section: 'auth', op: 'modify', key: 'jwt_expiry', from: 3600, to: 7200 },
+        {
+          section: 'auth',
+          op: 'modify',
+          key: 'additional_redirect_urls',
+          from: ['http://a'],
+          to: ['http://a', 'http://b'],
+        },
         { section: 'storage.buckets', op: 'add', key: 'avatars', value: { public: true } },
         { section: 'storage.buckets', op: 'modify', key: 'user-files', field: 'public', from: false, to: true },
         { section: 'storage.buckets', op: 'remove', key: 'old-bucket', kept: true },
@@ -14,7 +20,7 @@ describe('formatPlan', () => {
       summary: { add: 1, modify: 2, remove: 0, kept: 1 },
     });
     expect(out).toContain('auth:');
-    expect(out).toContain('~ jwt_expiry: 3600 → 7200');
+    expect(out).toContain('~ additional_redirect_urls: ["http://a"] → ["http://a","http://b"]');
     expect(out).toContain('storage.buckets:');
     expect(out).toContain('+ avatars');
     expect(out).toContain('~ user-files: public false → true');

--- a/src/lib/config-format.ts
+++ b/src/lib/config-format.ts
@@ -1,0 +1,54 @@
+// CLI/src/lib/config-format.ts
+import type { DiffChange, DiffResult } from './config-diff.js';
+
+export function formatPlan(result: DiffResult): string {
+  if (result.changes.length === 0) {
+    return 'No changes. Live state matches insforge.toml.';
+  }
+
+  const bySection = new Map<string, DiffChange[]>();
+  for (const c of result.changes) {
+    const arr = bySection.get(c.section) ?? [];
+    arr.push(c);
+    bySection.set(c.section, arr);
+  }
+
+  const lines: string[] = [];
+  for (const [section, changes] of bySection) {
+    lines.push(`  ${section}:`);
+    for (const c of changes) {
+      lines.push(`    ${formatChange(c)}`);
+    }
+    lines.push('');
+  }
+
+  const s = result.summary;
+  lines.push(`${s.add} add, ${s.modify} modify, ${s.remove} remove, ${s.kept} untracked kept.`);
+
+  return lines.join('\n');
+}
+
+function formatChange(c: DiffChange): string {
+  if (c.section === 'auth' && c.op === 'modify') {
+    return `~ ${String(c.key)}: ${formatValue(c.from)} → ${formatValue(c.to)}`;
+  }
+  if (c.section === 'storage.buckets') {
+    if (c.op === 'add') return `+ ${c.key} (${formatBucket(c.value)})`;
+    if (c.op === 'modify') return `~ ${c.key}: ${c.field} ${c.from} → ${c.to}`;
+    if (c.op === 'remove') {
+      return c.kept
+        ? `- ${c.key} (in DB, not in file — KEPT; use --prune to delete)`
+        : `- ${c.key} (will be deleted)`;
+    }
+  }
+  return `? ${JSON.stringify(c)}`;
+}
+
+function formatBucket(b: { public?: boolean }): string {
+  return b.public ? 'public' : 'private';
+}
+
+function formatValue(v: unknown): string {
+  if (Array.isArray(v)) return JSON.stringify(v);
+  return String(v);
+}

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -1,0 +1,119 @@
+// CLI/src/lib/config-schema.ts
+
+export interface InsforgeConfig {
+  project_id?: string;
+  auth?: AuthConfig;
+  storage?: StorageConfig;
+}
+
+export interface AuthConfig {
+  jwt_expiry?: number;
+  enable_signup?: boolean;
+  site_url?: string;
+  additional_redirect_urls?: string[];
+}
+
+export interface StorageConfig {
+  buckets?: Record<string, BucketConfig>;
+}
+
+export interface BucketConfig {
+  public?: boolean;
+}
+
+export class ConfigValidationError extends Error {
+  constructor(public readonly path: string, message: string) {
+    super(`config.${path}: ${message}`);
+    this.name = 'ConfigValidationError';
+  }
+}
+
+export function validateConfig(input: unknown): InsforgeConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ConfigValidationError('', 'must be an object');
+  }
+  const obj = input as Record<string, unknown>;
+  const out: InsforgeConfig = {};
+
+  if ('project_id' in obj) {
+    if (typeof obj.project_id !== 'string') {
+      throw new ConfigValidationError('project_id', 'must be a string');
+    }
+    out.project_id = obj.project_id;
+  }
+
+  if ('auth' in obj) out.auth = validateAuth(obj.auth);
+  if ('storage' in obj) out.storage = validateStorage(obj.storage);
+
+  return out;
+}
+
+function validateAuth(input: unknown): AuthConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ConfigValidationError('auth', 'must be an object');
+  }
+  const obj = input as Record<string, unknown>;
+  const out: AuthConfig = {};
+
+  if ('jwt_expiry' in obj) {
+    if (typeof obj.jwt_expiry !== 'number' || !Number.isInteger(obj.jwt_expiry) || obj.jwt_expiry <= 0) {
+      throw new ConfigValidationError('auth.jwt_expiry', 'must be a positive integer');
+    }
+    out.jwt_expiry = obj.jwt_expiry;
+  }
+  if ('enable_signup' in obj) {
+    if (typeof obj.enable_signup !== 'boolean') {
+      throw new ConfigValidationError('auth.enable_signup', 'must be a boolean');
+    }
+    out.enable_signup = obj.enable_signup;
+  }
+  if ('site_url' in obj) {
+    if (typeof obj.site_url !== 'string') {
+      throw new ConfigValidationError('auth.site_url', 'must be a string');
+    }
+    out.site_url = obj.site_url;
+  }
+  if ('additional_redirect_urls' in obj) {
+    if (!Array.isArray(obj.additional_redirect_urls) || !obj.additional_redirect_urls.every((u) => typeof u === 'string')) {
+      throw new ConfigValidationError('auth.additional_redirect_urls', 'must be an array of strings');
+    }
+    out.additional_redirect_urls = obj.additional_redirect_urls;
+  }
+
+  return out;
+}
+
+function validateStorage(input: unknown): StorageConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ConfigValidationError('storage', 'must be an object');
+  }
+  const obj = input as Record<string, unknown>;
+  const out: StorageConfig = {};
+
+  if ('buckets' in obj) {
+    if (obj.buckets === null || typeof obj.buckets !== 'object' || Array.isArray(obj.buckets)) {
+      throw new ConfigValidationError('storage.buckets', 'must be an object map');
+    }
+    out.buckets = {};
+    for (const [name, raw] of Object.entries(obj.buckets as Record<string, unknown>)) {
+      out.buckets[name] = validateBucket(`storage.buckets.${name}`, raw);
+    }
+  }
+
+  return out;
+}
+
+function validateBucket(path: string, input: unknown): BucketConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ConfigValidationError(path, 'must be an object');
+  }
+  const obj = input as Record<string, unknown>;
+  const out: BucketConfig = {};
+  if ('public' in obj) {
+    if (typeof obj.public !== 'boolean') {
+      throw new ConfigValidationError(`${path}.public`, 'must be a boolean');
+    }
+    out.public = obj.public;
+  }
+  return out;
+}

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -7,9 +7,6 @@ export interface InsforgeConfig {
 }
 
 export interface AuthConfig {
-  jwt_expiry?: number;
-  enable_signup?: boolean;
-  site_url?: string;
   additional_redirect_urls?: string[];
 }
 
@@ -55,24 +52,6 @@ function validateAuth(input: unknown): AuthConfig {
   const obj = input as Record<string, unknown>;
   const out: AuthConfig = {};
 
-  if ('jwt_expiry' in obj) {
-    if (typeof obj.jwt_expiry !== 'number' || !Number.isInteger(obj.jwt_expiry) || obj.jwt_expiry <= 0) {
-      throw new ConfigValidationError('auth.jwt_expiry', 'must be a positive integer');
-    }
-    out.jwt_expiry = obj.jwt_expiry;
-  }
-  if ('enable_signup' in obj) {
-    if (typeof obj.enable_signup !== 'boolean') {
-      throw new ConfigValidationError('auth.enable_signup', 'must be a boolean');
-    }
-    out.enable_signup = obj.enable_signup;
-  }
-  if ('site_url' in obj) {
-    if (typeof obj.site_url !== 'string') {
-      throw new ConfigValidationError('auth.site_url', 'must be a string');
-    }
-    out.site_url = obj.site_url;
-  }
   if ('additional_redirect_urls' in obj) {
     if (!Array.isArray(obj.additional_redirect_urls) || !obj.additional_redirect_urls.every((u) => typeof u === 'string')) {
       throw new ConfigValidationError('auth.additional_redirect_urls', 'must be an array of strings');

--- a/src/lib/config-toml.test.ts
+++ b/src/lib/config-toml.test.ts
@@ -8,9 +8,6 @@ describe('parseConfigToml', () => {
 project_id = "proj-abc"
 
 [auth]
-jwt_expiry = 3600
-enable_signup = true
-site_url = "https://app.example.com"
 additional_redirect_urls = ["http://localhost:3000"]
 
 [storage.buckets.avatars]
@@ -22,9 +19,6 @@ public = false
     expect(parseConfigToml(toml)).toEqual({
       project_id: 'proj-abc',
       auth: {
-        jwt_expiry: 3600,
-        enable_signup: true,
-        site_url: 'https://app.example.com',
         additional_redirect_urls: ['http://localhost:3000'],
       },
       storage: {
@@ -37,7 +31,9 @@ public = false
   });
 
   it('throws ConfigValidationError on bad type', () => {
-    expect(() => parseConfigToml('[auth]\njwt_expiry = "60m"')).toThrow(/jwt_expiry.*positive integer/);
+    expect(() => parseConfigToml('[auth]\nadditional_redirect_urls = "not-an-array"')).toThrow(
+      /additional_redirect_urls.*array of strings/,
+    );
   });
 
   it('throws on malformed TOML with a clear message', () => {
@@ -49,7 +45,7 @@ describe('stringifyConfigToml', () => {
   it('round-trips a config through stringify → parse', () => {
     const original = {
       project_id: 'proj-abc',
-      auth: { jwt_expiry: 3600, enable_signup: false },
+      auth: { additional_redirect_urls: ['http://localhost:3000'] },
       storage: { buckets: { avatars: { public: true } } },
     };
     expect(parseConfigToml(stringifyConfigToml(original))).toEqual(original);
@@ -58,7 +54,7 @@ describe('stringifyConfigToml', () => {
   it('emits stable, predictable section ordering', () => {
     const out = stringifyConfigToml({
       storage: { buckets: { z: { public: true }, a: { public: false } } },
-      auth: { enable_signup: true },
+      auth: { additional_redirect_urls: ['http://localhost:3000'] },
       project_id: 'proj-x',
     });
     // project_id first, then auth, then storage; bucket keys sorted

--- a/src/lib/config-toml.test.ts
+++ b/src/lib/config-toml.test.ts
@@ -1,0 +1,69 @@
+// CLI/src/lib/config-toml.test.ts
+import { describe, expect, it } from 'vitest';
+import { parseConfigToml, stringifyConfigToml } from './config-toml.js';
+
+describe('parseConfigToml', () => {
+  it('parses MVP fields end-to-end', () => {
+    const toml = `
+project_id = "proj-abc"
+
+[auth]
+jwt_expiry = 3600
+enable_signup = true
+site_url = "https://app.example.com"
+additional_redirect_urls = ["http://localhost:3000"]
+
+[storage.buckets.avatars]
+public = true
+
+[storage.buckets.user-files]
+public = false
+`;
+    expect(parseConfigToml(toml)).toEqual({
+      project_id: 'proj-abc',
+      auth: {
+        jwt_expiry: 3600,
+        enable_signup: true,
+        site_url: 'https://app.example.com',
+        additional_redirect_urls: ['http://localhost:3000'],
+      },
+      storage: {
+        buckets: {
+          avatars: { public: true },
+          'user-files': { public: false },
+        },
+      },
+    });
+  });
+
+  it('throws ConfigValidationError on bad type', () => {
+    expect(() => parseConfigToml('[auth]\njwt_expiry = "60m"')).toThrow(/jwt_expiry.*positive integer/);
+  });
+
+  it('throws on malformed TOML with a clear message', () => {
+    expect(() => parseConfigToml('[auth\nbroken')).toThrow(/TOML parse error/);
+  });
+});
+
+describe('stringifyConfigToml', () => {
+  it('round-trips a config through stringify → parse', () => {
+    const original = {
+      project_id: 'proj-abc',
+      auth: { jwt_expiry: 3600, enable_signup: false },
+      storage: { buckets: { avatars: { public: true } } },
+    };
+    expect(parseConfigToml(stringifyConfigToml(original))).toEqual(original);
+  });
+
+  it('emits stable, predictable section ordering', () => {
+    const out = stringifyConfigToml({
+      storage: { buckets: { z: { public: true }, a: { public: false } } },
+      auth: { enable_signup: true },
+      project_id: 'proj-x',
+    });
+    // project_id first, then auth, then storage; bucket keys sorted
+    expect(out.indexOf('project_id')).toBeLessThan(out.indexOf('[auth]'));
+    expect(out.indexOf('[auth]')).toBeLessThan(out.indexOf('[storage.buckets.a]'));
+    expect(out.indexOf('[storage.buckets.a]')).toBeLessThan(out.indexOf('[storage.buckets.z]'));
+  });
+});

--- a/src/lib/config-toml.ts
+++ b/src/lib/config-toml.ts
@@ -1,0 +1,48 @@
+// CLI/src/lib/config-toml.ts
+import * as smolToml from 'smol-toml';
+import { validateConfig, type InsforgeConfig } from './config-schema.js';
+
+export function parseConfigToml(input: string): InsforgeConfig {
+  let parsed: unknown;
+  try {
+    parsed = smolToml.parse(input);
+  } catch (err) {
+    throw new Error(`TOML parse error: ${(err as Error).message}`);
+  }
+  return validateConfig(parsed);
+}
+
+export function stringifyConfigToml(config: InsforgeConfig): string {
+  // Build sections in deterministic order. smol-toml stringify doesn't
+  // guarantee section ordering, so we assemble the file ourselves.
+  const lines: string[] = [];
+
+  if (config.project_id !== undefined) {
+    lines.push(`project_id = ${JSON.stringify(config.project_id)}`);
+    lines.push('');
+  }
+
+  if (config.auth) {
+    lines.push('[auth]');
+    if (config.auth.jwt_expiry !== undefined) lines.push(`jwt_expiry = ${config.auth.jwt_expiry}`);
+    if (config.auth.enable_signup !== undefined) lines.push(`enable_signup = ${config.auth.enable_signup}`);
+    if (config.auth.site_url !== undefined) lines.push(`site_url = ${JSON.stringify(config.auth.site_url)}`);
+    if (config.auth.additional_redirect_urls !== undefined) {
+      const urls = config.auth.additional_redirect_urls.map((u) => JSON.stringify(u)).join(', ');
+      lines.push(`additional_redirect_urls = [${urls}]`);
+    }
+    lines.push('');
+  }
+
+  if (config.storage?.buckets) {
+    const names = Object.keys(config.storage.buckets).sort();
+    for (const name of names) {
+      const b = config.storage.buckets[name];
+      lines.push(`[storage.buckets.${name}]`);
+      if (b.public !== undefined) lines.push(`public = ${b.public}`);
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n').replace(/\n+$/, '\n');
+}

--- a/src/lib/config-toml.ts
+++ b/src/lib/config-toml.ts
@@ -24,9 +24,6 @@ export function stringifyConfigToml(config: InsforgeConfig): string {
 
   if (config.auth) {
     lines.push('[auth]');
-    if (config.auth.jwt_expiry !== undefined) lines.push(`jwt_expiry = ${config.auth.jwt_expiry}`);
-    if (config.auth.enable_signup !== undefined) lines.push(`enable_signup = ${config.auth.enable_signup}`);
-    if (config.auth.site_url !== undefined) lines.push(`site_url = ${JSON.stringify(config.auth.site_url)}`);
     if (config.auth.additional_redirect_urls !== undefined) {
       const urls = config.auth.additional_redirect_urls.map((u) => JSON.stringify(u)).join(', ');
       lines.push(`additional_redirect_urls = [${urls}]`);


### PR DESCRIPTION
**Companion to:** `InsForge/InsForge#<TBD>` (backend half — adds the routes this CLI talks to)

## What

Adds a declarative `insforge.toml` at repo root and three CLI commands to manage it:

```bash
insforge config export    # live state → insforge.toml
insforge config plan      # show file ↔ live diff
insforge config apply     # plan, confirm, apply (idempotent)
```

The DB stays the source of truth for live state. The TOML is the *intent layer* — files diff in PRs, agents can read/edit them, projects become reproducible.

## Why

Today, configuration changes happen via MCP tool calls or dashboard clicks — invisible in PR review, no `git revert`, no record in the repo of what the project should look like. Cloning a repo doesn't reproduce a working project. This is the same gap Supabase solved with `supabase/config.toml`; we're shape-mirroring it but avoiding the documented Supabase footguns (silent dashboard overwrites, no drift detection, no `pull`-then-`push` round-trip).

## What's in this PR (CLI half)

10 commits, ~475 LOC across 7 files in `src/lib/` plus 4 files in `src/commands/config/`:

- TOML ↔ JSON codec (`smol-toml` wrapper with stable section ordering)
- Per-section structured diff with `kept`/`prune` semantics
- Human-readable plan formatter + `--json` for agents
- Three commands: `export`, `plan`, `apply` (apply does plan-then-confirm-then-apply via two POSTs)
- 12 vitest tests, all green

MVP scope is intentionally narrow: `[auth] additional_redirect_urls` and `[storage.buckets.<name>] public`. Everything else (OAuth providers, function metadata, full SMTP, AI providers) is incremental matrix-fill — same architecture, just plumbing.

## Key behaviors (the parts that distinguish this from Supabase)

1. **Plan first, always.** `apply` posts with `dry_run: true`, prints the plan, prompts, then posts with `dry_run: false`. `--auto-approve` skips the prompt; `--dry-run` skips the apply.
2. **Default-keep, not default-overwrite.** Items in DB but missing from file are kept and warned: `KEPT; use --prune to delete`. `--prune` opts in.
3. **Drift visibility.** Dashboard edits show as `~` modifications in the plan *before* apply. The Supabase silent-clobber failure mode is eliminated.
4. **Idempotent.** Re-applying converged state is a no-op (`No changes. Live state matches insforge.toml.`).
5. **Secrets via `env(NAME)` only.** Never literal values in the file.

## Demo

End-to-end demo against a mock backend (`/tmp/insforge-config-demo/`) verified all nine spec behaviors: export, converged-plan no-op, real-diff plan, apply, idempotent re-apply, drift visibility, default-keep, --prune opt-in, re-export convergence.

## Docs / context

- Design memo: `design-insforge-config-toml.md` (high-level reasoning)
- Implementation spec: `docs/superpowers/specs/2026-05-05-insforge-config-toml-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-05-insforge-config-toml.md`
- Field inventory: `config-fields-inventory.md` (all 120+ fields mapped to phases)
- Sample TOMLs: `starter-insforge.toml` (typical project, 102 lines), `sample-insforge.toml` (full surface, ~250 lines)

## Test plan

- [x] `npx vitest run src/lib/config-toml.test.ts src/lib/config-diff.test.ts src/lib/config-format.test.ts` — 12 passing
- [x] `npm run build` clean (290KB ESM dist)
- [x] `node dist/index.js config --help` shows export/plan/apply
- [x] End-to-end against mock backend: export → modify → plan → apply → idempotent re-apply → drift visible → prune
- [ ] Live E2E against running InsForge backend (requires backend half merged + auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `config` command for managing project configuration:
    - `export`: Export live project configuration to insforge.toml
    - `plan`: Preview configuration changes before applying
    - `apply`: Apply configuration changes with confirmation prompt; supports --dry-run and --auto-approve modes

* **Tests**
  * Added tests for TOML parsing, schema validation, configuration diffing, and plan formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->