### PR TITLE
fix(link): npm install after --auth overlay in no-template path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -450,8 +450,26 @@ export function registerProjectLinkCommand(program: Command): void {
               const result = await applyAuthProvider(opts.auth as AuthProvider, process.cwd(), projectConfig, json);
               if (!json) {
                 clack.log.success(`Wired in ${opts.auth}: ${result.written.length} new, ${result.overwritten.length} replaced`);
-                clack.note(result.nextSteps, "What's next");
               }
+
+              // Re-install so deps added by packageJsonPatch (pg, better-auth,
+              // jsonwebtoken, @insforge/sdk) actually land in node_modules.
+              // Without this, `npm run setup` fails with `Cannot find package 'pg'`.
+              const hasPackageJson = await fs.stat(path.join(process.cwd(), 'package.json')).catch(() => null);
+              if (hasPackageJson && !json) {
+                const installSpinner = clack.spinner();
+                installSpinner.start('Installing dependencies...');
+                try {
+                  await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
+                  installSpinner.stop('Dependencies installed');
+                } catch (err) {
+                  installSpinner.stop('Failed to install dependencies');
+                  clack.log.warn(`npm install failed: ${(err as Error).message}`);
+                  clack.log.info('Run `npm install` manually to install dependencies.');
+                }
+              }
+
+              if (!json) clack.note(result.nextSteps, "What's next");
             } catch (err) {
               const msg = `Failed to apply --auth ${opts.auth}: ${(err as Error).message}`;
               if (json) console.error(JSON.stringify({ warning: msg }));

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -29,6 +29,19 @@ function buildOssHost(appkey: string, region: string): string {
   return `https://${appkey}.${region}.insforge.app`;
 }
 
+async function runNpmInstall(startMessage = 'Installing dependencies...'): Promise<void> {
+  const spinner = clack.spinner();
+  spinner.start(startMessage);
+  try {
+    await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
+    spinner.stop('Dependencies installed');
+  } catch (err) {
+    spinner.stop('Failed to install dependencies');
+    clack.log.warn(`npm install failed: ${(err as Error).message}`);
+    clack.log.info('Run `npm install` manually to install dependencies.');
+  }
+}
+
 export function registerProjectLinkCommand(program: Command): void {
   program
     .command('link')
@@ -152,16 +165,7 @@ export function registerProjectLinkCommand(program: Command): void {
               }
 
               if (templateDownloaded && !json) {
-                const installSpinner = clack.spinner();
-                installSpinner.start('Installing dependencies...');
-                try {
-                  await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
-                  installSpinner.stop('Dependencies installed');
-                } catch (err) {
-                  installSpinner.stop('Failed to install dependencies');
-                  clack.log.warn(`npm install failed: ${(err as Error).message}`);
-                  clack.log.info('Run `npm install` manually to install dependencies.');
-                }
+                await runNpmInstall();
               }
 
               await installSkills(json);
@@ -208,20 +212,12 @@ export function registerProjectLinkCommand(program: Command): void {
                 if (!json) {
                   clack.log.success(`Wired in ${opts.auth}: ${result.written.length} new, ${result.overwritten.length} replaced`);
                 }
-                // Run npm install if we patched package.json with new deps.
-                // The overlay added better-auth, pg, jsonwebtoken etc.; without
-                // a re-install, `npm run setup` fails with module-not-found.
+                // Re-install when the overlay patched package.json — otherwise
+                // its new deps (better-auth, pg, jsonwebtoken, …) are listed
+                // but never installed and `npm run setup` fails with
+                // "Cannot find package 'pg'".
                 if (result.packageJsonPatched && !json) {
-                  const installSpinner = clack.spinner();
-                  installSpinner.start('Installing new dependencies...');
-                  try {
-                    await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
-                    installSpinner.stop('Dependencies installed');
-                  } catch (err) {
-                    installSpinner.stop('Failed to install dependencies');
-                    clack.log.warn(`npm install failed: ${(err as Error).message}`);
-                    clack.log.info('Run `npm install` manually to install dependencies.');
-                  }
+                  await runNpmInstall('Installing new dependencies...');
                 }
                 if (!json) clack.note(result.nextSteps, "What's next");
               } catch (err) {
@@ -411,16 +407,7 @@ export function registerProjectLinkCommand(program: Command): void {
           }
 
           if (templateDownloaded && !json) {
-            const installSpinner = clack.spinner();
-            installSpinner.start('Installing dependencies...');
-            try {
-              await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
-              installSpinner.stop('Dependencies installed');
-            } catch (err) {
-              installSpinner.stop('Failed to install dependencies');
-              clack.log.warn(`npm install failed: ${(err as Error).message}`);
-              clack.log.info('Run `npm install` manually to install dependencies.');
-            }
+            await runNpmInstall();
           }
 
           // Install agent skills inside the project directory
@@ -452,21 +439,10 @@ export function registerProjectLinkCommand(program: Command): void {
                 clack.log.success(`Wired in ${opts.auth}: ${result.written.length} new, ${result.overwritten.length} replaced`);
               }
 
-              // Re-install so deps added by packageJsonPatch (pg, better-auth,
-              // jsonwebtoken, @insforge/sdk) actually land in node_modules.
-              // Without this, `npm run setup` fails with `Cannot find package 'pg'`.
-              const hasPackageJson = await fs.stat(path.join(process.cwd(), 'package.json')).catch(() => null);
-              if (hasPackageJson && !json) {
-                const installSpinner = clack.spinner();
-                installSpinner.start('Installing dependencies...');
-                try {
-                  await execAsync('npm install', { cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 });
-                  installSpinner.stop('Dependencies installed');
-                } catch (err) {
-                  installSpinner.stop('Failed to install dependencies');
-                  clack.log.warn(`npm install failed: ${(err as Error).message}`);
-                  clack.log.info('Run `npm install` manually to install dependencies.');
-                }
+              // Re-install when the overlay patched package.json — same as
+              // the direct-OSS bare-overlay path above.
+              if (result.packageJsonPatched && !json) {
+                await runNpmInstall('Installing new dependencies...');
               }
 
               if (!json) clack.note(result.nextSteps, "What's next");


### PR DESCRIPTION
## Summary

`insforge link --auth <provider>` (no `--template`) silently skipped `npm install` after applying the overlay, so users hit `Cannot find package 'pg'` on the next `npm run setup`.

The 3 other paths in `link.ts` that overlay an auth provider all install — only this one path missed it.

## Repro

```bash
mkdir test3 && cd test3
npm init -y
npx @insforge/cli link --project-id <id> --auth better-auth
npm run setup
# → Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pg'
```

## Fix

Add the same install block (used in the template-download paths) to the no-template branch, gated on `package.json` existing.

## Test plan

- [x] `link --auth better-auth` (no template) into a dir with `package.json` → install runs, `node_modules/pg` exists, `npm run setup` works
- [x] `link` (no `--auth`, no `--template`) → unchanged behavior, no install spam
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project linking now detects when dependencies changed and automatically installs them so updated packages are applied to your project. Installation progress and outcomes provide clearer feedback and, on failure, actionable guidance to complete installation manually.

* **Chores**
  * Package version bumped to 0.1.65.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->