### PR TITLE
feat(db): add `connection-string` command (cloud Postgres URL)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/db/connection-string.ts
+++ b/src/commands/db/connection-string.ts
@@ -1,0 +1,30 @@
+import type { Command } from 'commander';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+import { reportCliUsage } from '../../lib/skills.js';
+import type { ConnectionStringResponse } from '../../types.js';
+
+export function registerDbConnectionStringCommand(dbCmd: Command): void {
+  dbCmd
+    .command('connection-string')
+    .description('Print the project Postgres connection URL (cloud projects only)')
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+        const res = await ossFetch('/api/metadata/database-connection-string');
+        const body = (await res.json()) as ConnectionStringResponse;
+        if (json) {
+          outputJson(body);
+        } else {
+          console.log(body.connectionURL);
+        }
+        await reportCliUsage('cli.db.connection-string', true);
+      } catch (err) {
+        await reportCliUsage('cli.db.connection-string', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { registerDbRpcCommand } from './commands/db/rpc.js';
 import { registerDbExportCommand } from './commands/db/export.js';
 import { registerDbImportCommand } from './commands/db/import.js';
 import { registerDbMigrationsCommand } from './commands/db/migrations.js';
+import { registerDbConnectionStringCommand } from './commands/db/connection-string.js';
 import { registerRecordsCommands } from './commands/records/list.js';
 import { registerRecordsCreateCommand } from './commands/records/create.js';
 import { registerRecordsUpdateCommand } from './commands/records/update.js';
@@ -132,6 +133,7 @@ registerDbRpcCommand(dbCmd);
 registerDbExportCommand(dbCmd);
 registerDbImportCommand(dbCmd);
 registerDbMigrationsCommand(dbCmd);
+registerDbConnectionStringCommand(dbCmd);
 
 // Records commands (hidden — do not use for now)
 const recordsCmd = program.command('records', { hidden: true }).description('CRUD operations on table records');


### PR DESCRIPTION
## Summary

Cloud projects expose a Postgres connection URL via \`/api/metadata/database-connection-string\` — but the CLI didn't surface it, so users (and agent-driven flows like \`link --auth better-auth\`) had no easy way to fetch it. This adds the missing command.

## Usage

```bash
$ insforge db connection-string
postgresql://USER:PASS@HOST:PORT/DB?sslmode=require

$ insforge --json db connection-string
{ "connectionURL": "...", "parameters": { "host": "...", "port": 5432, ... } }
```

## Why now

The Better Auth scaffold's \`.env.local\` previously said \"Cloud: bring your own Postgres — InsForge cloud doesn't expose direct DB.\" That was wrong. The endpoint already exists; we just hadn't wired the CLI through. Pairs with templates [#30](https://github.com/InsForge/insforge-templates/pull/30) which replaces that comment with \`run \`npx @insforge/cli db connection-string\` to fetch it\`.

## Behavior on self-hosted

Backend returns \`500 INTERNAL_ERROR: PROJECT_ID is not configured. Cannot access cloud API without cloud project setup.\` — we let that bubble up rather than fabricating a fallback (self-hosted users already know their connection string from their docker-compose).

## Test plan

- [x] \`build\` passes
- [x] \`lint\` 0 errors
- [x] Command registered (\`insforge db --help\` lists \`connection-string\`)
- [ ] (post-merge) hit against a cloud project, verify URL works as DATABASE_URL for \`better-auth migrate\`

## Bump

0.1.65 → 0.1.66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to retrieve the database connection string.
  * Supports JSON and plain-text output.
  * Requires authentication and reports success/failure.

* **Chores**
  * Bumped package version to 0.1.66.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->