### PR TITLE
feat(link): auto-fill DATABASE_URL from cloud project (+ bump 0.1.67)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/auth-providers/apply.ts
+++ b/src/auth-providers/apply.ts
@@ -18,7 +18,7 @@ import { promisify } from 'node:util';
 import { randomBytes } from 'node:crypto';
 import * as clack from '@clack/prompts';
 
-import { getAnonKey, getJwtSecret } from '../lib/api/oss.js';
+import { getAnonKey, getDatabaseConnectionString, getJwtSecret } from '../lib/api/oss.js';
 import type { ProjectConfig } from '../types.js';
 
 const execFileAsync = promisify(execFile);
@@ -284,8 +284,11 @@ export async function applyAuthProvider(
     const existingLocal = envLocalExists ? await fs.readFile(envLocalPath, 'utf-8') : '';
     const existingLocalKeys = envLocalExists ? extractEnvKeys(existingLocal) : new Set<string>();
 
-    const anonKey = await getAnonKey();
-    const jwtSecret = await getJwtSecret();
+    const [anonKey, jwtSecret, databaseUrl] = await Promise.all([
+      getAnonKey(),
+      getJwtSecret(),
+      getDatabaseConnectionString(),
+    ]);
     const filled = manifest.envExampleAppend.replace(
       /^([A-Z][A-Z0-9_]*=)(.*)$/gm,
       (_, prefix: string, value: string) => {
@@ -295,6 +298,7 @@ export async function applyAuthProvider(
         if (key === 'NEXT_PUBLIC_APP_URL') return `${prefix}https://${projectConfig.appkey}.insforge.site`;
         if (/JWT_SECRET$/.test(key)) return `${prefix}${jwtSecret ?? value}`;
         if (key === 'BETTER_AUTH_SECRET') return `${prefix}${randomBytes(32).toString('hex')}`;
+        if (key === 'DATABASE_URL') return `${prefix}${databaseUrl ?? value}`;
         return `${prefix}${value}`;
       },
     );

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -50,6 +50,21 @@ export async function getJwtSecret(): Promise<string | null> {
   }
 }
 
+export async function getDatabaseConnectionString(): Promise<string | null> {
+  // Cloud-only: returns the project's Postgres URL (with sslmode). Self-hosted
+  // returns null so callers leave DATABASE_URL at the localhost default —
+  // self-hosters know their own connection string.
+  try {
+    const res = await ossFetch('/api/metadata/database-connection-string');
+    const data = await res.json() as { connectionURL?: string };
+    return typeof data.connectionURL === 'string' && data.connectionURL.length > 0
+      ? data.connectionURL
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function ossFetch(
   path: string,
   options: RequestInit = {},


### PR DESCRIPTION
Cloud projects expose their Postgres URL via
`/api/metadata/database-connection-string`, but the BA scaffold's `.env.local` was leaving DATABASE_URL at the localhost default — cloud users had to fetch and paste the URL manually before `npm run setup` would work.

Add a `getDatabaseConnectionString()` helper alongside the existing `getJwtSecret()` / `getAnonKey()`, and use it in `applyAuthProvider` so DATABASE_URL gets the same pre-fill treatment as the other env vars. Self-hosted projects keep the localhost default (the helper returns null when the cloud endpoint 500s on missing PROJECT_ID).

Pairs with insforge-templates#31 which fixes the SSL cert error that the cloud connection string would otherwise trigger.

Bump 0.1.66 → 0.1.67.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database connection string is now automatically fetched and configured during authentication provider setup.

* **Chores**
  * Version updated to v0.1.67.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->