### PR TITLE
fix(link): refresh stale platform defaults in .env.local on re-link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/auth-providers/apply.ts
+++ b/src/auth-providers/apply.ts
@@ -74,6 +74,7 @@ interface ApplyResult {
   envExampleAppended: boolean;
   envLocalWritten: boolean;
   envKeysSkipped: string[];
+  envKeysRefreshed: string[];
   nextSteps: string;
 }
 
@@ -90,6 +91,49 @@ export function extractEnvKeys(content: string): Set<string> {
     if (m) keys.add(m[1]);
   }
   return keys;
+}
+
+// Parse `KEY=value` lines into a Map. Comments and blank lines are ignored.
+// We use this to compare the user's .env.local values against the manifest's
+// literal defaults so we can distinguish "user customized" from "user has
+// the stale default".
+// Exported for unit testing.
+export function extractEnvPairs(content: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const line of content.split('\n')) {
+    const trimmed = line.replace(/^\s*export\s+/, '').trimStart();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const m = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/);
+    if (m) out.set(m[1], m[2]);
+  }
+  return out;
+}
+
+// Refresh stale platform defaults in the user's .env.local. If the user's
+// value matches the manifest's literal default AND the platform now has a
+// real value (e.g., cloud DATABASE_URL), overwrite the line. User-customized
+// values (anything that differs from the manifest default) are preserved.
+// Exported for unit testing.
+export function refreshStaleEnvDefaults(
+  existing: string,
+  manifestDefaults: Map<string, string>,
+  platformValues: Map<string, string>,
+): { updated: string; refreshed: string[] } {
+  const refreshed: string[] = [];
+  const lines = existing.split('\n').map((line) => {
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/);
+    if (!m) return line;
+    const key = m[1];
+    const userValue = m[2];
+    const def = manifestDefaults.get(key);
+    const real = platformValues.get(key);
+    if (def !== undefined && real !== undefined && userValue === def && real !== def) {
+      refreshed.push(key);
+      return `${key}=${real}`;
+    }
+    return line;
+  });
+  return { updated: lines.join('\n'), refreshed };
 }
 
 // Remove any `KEY=value` lines from `append` whose KEY already appears in
@@ -216,6 +260,7 @@ export async function applyAuthProvider(
       written: [], skipped: [], overwritten: [],
       packageJsonPatched: false, envExampleAppended: false, envLocalWritten: false,
       envKeysSkipped: [],
+      envKeysRefreshed: [],
       nextSteps: manifest.nextSteps,
     };
 
@@ -307,13 +352,29 @@ export async function applyAuthProvider(
       await fs.writeFile(envLocalPath, filled + '\n');
       result.envLocalWritten = true;
     } else {
-      const { filtered, dropped } = filterCollidingEnvLines(filled, existingLocalKeys);
+      // Two passes:
+      //  1. Refresh stale platform defaults in-place. If the user's existing
+      //     value matches the manifest's literal default AND we now have a
+      //     real platform value (e.g., they re-linked against a cloud project
+      //     after the CLI started fetching DATABASE_URL), update the line.
+      //     User-customized values are preserved untouched.
+      //  2. Append any genuinely new keys at the end.
+      const manifestDefaults = extractEnvPairs(manifest.envExampleAppend);
+      const platformValues = extractEnvPairs(filled);
+      const { updated, refreshed } = refreshStaleEnvDefaults(existingLocal, manifestDefaults, platformValues);
+
+      const refreshedSet = new Set(refreshed);
+      const keysAfterRefresh = new Set([...existingLocalKeys, ...refreshedSet]);
+      const { filtered, dropped } = filterCollidingEnvLines(filled, keysAfterRefresh);
       const hasNewKey = filtered.split('\n').some((l) => /^[A-Z][A-Z0-9_]*=/.test(l));
-      if (hasNewKey) {
-        await fs.writeFile(envLocalPath, existingLocal.replace(/\n*$/, '\n\n') + filtered + '\n');
+
+      if (refreshed.length > 0 || hasNewKey) {
+        const base = hasNewKey ? updated.replace(/\n*$/, '\n\n') + filtered + '\n' : updated;
+        await fs.writeFile(envLocalPath, base);
         result.envLocalWritten = true;
       }
       result.envKeysSkipped = Array.from(new Set([...result.envKeysSkipped, ...dropped]));
+      result.envKeysRefreshed = Array.from(new Set([...result.envKeysRefreshed, ...refreshed]));
     }
 
     if (!jwtSecret && !json) {
@@ -324,6 +385,13 @@ export async function applyAuthProvider(
       clack.log.warn(
         `Kept your existing values for: ${result.envKeysSkipped.join(', ')}. ` +
         `If any of these need the auth-provider's defaults, see .env.example for reference.`,
+      );
+    }
+
+    if (result.envKeysRefreshed.length > 0 && !json) {
+      clack.log.info(
+        `Refreshed stale platform defaults: ${result.envKeysRefreshed.join(', ')}. ` +
+        `Your value matched the manifest's default, so we replaced it with the live one.`,
       );
     }
 


### PR DESCRIPTION
## Summary

When \`link --auth <provider>\` ran against a directory that already had \`.env.local\`, the auto-fill skipped every key the user already defined — even if the user's value was just the **manifest's literal default from a prior run**. Cloud users who re-linked after the DATABASE_URL auto-fill landed (#105) kept their old localhost URL, hit \"🚀 No migrations needed\" against the wrong DB, and got silently broken setups.

## Repro

\`\`\`bash
mkdir test && cd test && npm init -y
# scaffold once with an old CLI (or while only LOCALHOST DATABASE_URL exists in manifest)
npx @insforge/cli@0.1.66 link --project-id <cloud> --auth better-auth
# .env.local now has DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/insforge

# upgrade + re-link
npx @insforge/cli@latest link --project-id <cloud> --auth better-auth
# .env.local still has the localhost URL — the auto-fill skipped it because
# the key already existed.
\`\`\`

## Fix

Compare the user's existing value against the literal default in \`manifest.envExampleAppend\`. If they match AND the platform now has a real value, overwrite the line in-place. User-customized values stay untouched.

\`\`\`
fresh .env.local                                                  → unchanged (writes filled blob, like today)
user customized X                                                 → unchanged (stays user's, like today)
user has manifest default for X, platform has real value          → REFRESHED ✨
user has manifest default for X, platform has no value (self-host)→ unchanged (no-op)
key not in user's file                                            → unchanged (appended via existing collision flow)
\`\`\`

Adds:
- \`extractEnvPairs(content)\` — KEY → value Map (counterpart to existing \`extractEnvKeys\`)
- \`refreshStaleEnvDefaults(existing, manifestDefaults, platformValues)\` — line-level in-place rewrite
- \`ApplyResult.envKeysRefreshed\` — surfaces a \"Refreshed stale platform defaults: DATABASE_URL\" info line so the user can tell what changed

## Bump

0.1.67 → 0.1.68

## Test plan

- [x] build passes (\`npm run build\`)
- [x] lint 0 errors (\`npm run lint\`)
- [ ] (post-merge) e2e: re-link an existing dir against a cloud project, verify DATABASE_URL gets refreshed to the cloud URL while user-customized vars stay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Environment variable management improvements: intelligently refreshes stale defaults from the platform while preserving user customizations in `.env.local`
- Added tracking and logging of refreshed environment configuration keys during setup

## Chores
- Version bumped to 0.1.68

<!-- end of auto-generated comment: release notes by coderabbit.ai -->