### PR TITLE
fix(db): unmask password when fetching database connection string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.68",
+  "version": "0.1.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.68",
+      "version": "0.1.71",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/auth-providers/apply.test.ts
+++ b/src/auth-providers/apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractEnvKeys, filterCollidingEnvLines } from './apply.js';
+import { extractEnvKeys, extractEnvPairs, filterCollidingEnvLines, refreshStaleEnvDefaults } from './apply.js';
 
 describe('extractEnvKeys', () => {
   it('finds plain KEY=value lines', () => {
@@ -43,5 +43,83 @@ describe('filterCollidingEnvLines', () => {
     const { filtered, dropped } = filterCollidingEnvLines(append, new Set(['BAZ']));
     expect(dropped).toEqual([]);
     expect(filtered).toBe(append);
+  });
+});
+
+describe('extractEnvPairs', () => {
+  it('returns KEY → value pairs', () => {
+    const m = extractEnvPairs('FOO=1\nBAR=hello world\n');
+    expect(m.get('FOO')).toBe('1');
+    expect(m.get('BAR')).toBe('hello world');
+  });
+  it('preserves URL-style values verbatim', () => {
+    const m = extractEnvPairs('DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/insforge\n');
+    expect(m.get('DATABASE_URL')).toBe('postgresql://postgres:postgres@127.0.0.1:5432/insforge');
+  });
+});
+
+describe('refreshStaleEnvDefaults', () => {
+  it('replaces user value when it matches manifest default and platform has real value', () => {
+    const existing = 'DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/insforge\nFOO=keep-me\n';
+    const defaults = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:postgres@127.0.0.1:5432/insforge'],
+    ]);
+    const platform = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:secret@cloud.host:5432/db?sslmode=require'],
+    ]);
+    const { updated, refreshed } = refreshStaleEnvDefaults(existing, defaults, platform);
+    expect(refreshed).toEqual(['DATABASE_URL']);
+    expect(updated).toContain('DATABASE_URL=postgresql://postgres:secret@cloud.host:5432/db?sslmode=require');
+    expect(updated).not.toContain('127.0.0.1');
+    expect(updated).toContain('FOO=keep-me');
+  });
+
+  it('preserves user value when it differs from the manifest default', () => {
+    const existing = 'DATABASE_URL=postgresql://customized@host/db\n';
+    const defaults = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:postgres@127.0.0.1:5432/insforge'],
+    ]);
+    const platform = new Map([
+      ['DATABASE_URL', 'postgresql://cloud@host/db?sslmode=require'],
+    ]);
+    const { updated, refreshed } = refreshStaleEnvDefaults(existing, defaults, platform);
+    expect(refreshed).toEqual([]);
+    expect(updated).toContain('postgresql://customized@host/db');
+  });
+
+  it('skips refresh when platform has no real value (self-hosted, helper returned null)', () => {
+    const existing = 'DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/insforge\n';
+    const defaults = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:postgres@127.0.0.1:5432/insforge'],
+    ]);
+    const platform = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:postgres@127.0.0.1:5432/insforge'],
+    ]);
+    const { updated, refreshed } = refreshStaleEnvDefaults(existing, defaults, platform);
+    expect(refreshed).toEqual([]);
+    expect(updated).toBe(existing);
+  });
+
+  it('handles multiple keys, refreshing only the stale ones', () => {
+    const existing = [
+      'DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/insforge',
+      'BETTER_AUTH_SECRET=user-set-this-already',
+      'INSFORGE_JWT_SECRET=replace-with-output-of-cli-secrets-get-JWT_SECRET',
+    ].join('\n') + '\n';
+    const defaults = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:postgres@127.0.0.1:5432/insforge'],
+      ['BETTER_AUTH_SECRET', 'replace-with-32-random-bytes'],
+      ['INSFORGE_JWT_SECRET', 'replace-with-output-of-cli-secrets-get-JWT_SECRET'],
+    ]);
+    const platform = new Map([
+      ['DATABASE_URL', 'postgresql://cloud@host/db?sslmode=require'],
+      ['BETTER_AUTH_SECRET', 'random-bytes-1234'],
+      ['INSFORGE_JWT_SECRET', 'real-jwt-secret-from-platform'],
+    ]);
+    const { updated, refreshed } = refreshStaleEnvDefaults(existing, defaults, platform);
+    expect(refreshed.sort()).toEqual(['DATABASE_URL', 'INSFORGE_JWT_SECRET']);
+    expect(updated).toContain('DATABASE_URL=postgresql://cloud@host/db?sslmode=require');
+    expect(updated).toContain('BETTER_AUTH_SECRET=user-set-this-already');
+    expect(updated).toContain('INSFORGE_JWT_SECRET=real-jwt-secret-from-platform');
   });
 });

--- a/src/commands/db/connection-string.ts
+++ b/src/commands/db/connection-string.ts
@@ -1,10 +1,9 @@
 import type { Command } from 'commander';
-import { ossFetch } from '../../lib/api/oss.js';
+import { getDatabaseConnectionString } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
-import { handleError, getRootOpts } from '../../lib/errors.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
-import type { ConnectionStringResponse } from '../../types.js';
 
 export function registerDbConnectionStringCommand(dbCmd: Command): void {
   dbCmd
@@ -14,12 +13,14 @@ export function registerDbConnectionStringCommand(dbCmd: Command): void {
       const { json } = getRootOpts(cmd);
       try {
         await requireAuth();
-        const res = await ossFetch('/api/metadata/database-connection-string');
-        const body = (await res.json()) as ConnectionStringResponse;
+        const url = await getDatabaseConnectionString();
+        if (!url) {
+          throw new CLIError('Could not fetch the database connection string. This command requires a cloud project (self-hosted instances expose Postgres directly via your docker-compose).');
+        }
         if (json) {
-          outputJson(body);
+          outputJson({ connectionURL: url });
         } else {
-          console.log(body.connectionURL);
+          console.log(url);
         }
         await reportCliUsage('cli.db.connection-string', true);
       } catch (err) {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -38,6 +38,33 @@ async function runNpmInstall(startMessage = 'Installing dependencies...'): Promi
   }
 }
 
+// Run `npm run setup` if the auth-provider's packageJsonPatch added that
+// script. The BA scaffold's setup chains schema → BA migrate → app SQL,
+// hitting DATABASE_URL — so this is the step that actually creates tables.
+// We always attempt it after a successful --auth overlay; if DATABASE_URL is
+// wrong (network issue, missing IP allowlist, etc.) the user gets a clear
+// error and can re-run `npm run setup` after fixing.
+async function runNpmSetupIfPresent(): Promise<void> {
+  const pkgPath = path.join(process.cwd(), 'package.json');
+  let hasSetup = false;
+  try {
+    const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8')) as { scripts?: Record<string, string> };
+    hasSetup = typeof pkg.scripts?.setup === 'string';
+  } catch { /* no package.json or unreadable — skip */ }
+  if (!hasSetup) return;
+
+  const spinner = clack.spinner();
+  spinner.start('Running setup (schema + migrations)...');
+  try {
+    await execAsync('npm run setup', { cwd: process.cwd(), maxBuffer: 20 * 1024 * 1024 });
+    spinner.stop('Setup complete');
+  } catch (err) {
+    spinner.stop('Setup failed');
+    clack.log.warn(`npm run setup failed: ${(err as Error).message.split('\n')[0]}`);
+    clack.log.info('Inspect the error, fix DATABASE_URL or network access, then run `npm run setup` manually.');
+  }
+}
+
 export function registerProjectLinkCommand(program: Command): void {
   program
     .command('link')
@@ -162,6 +189,9 @@ export function registerProjectLinkCommand(program: Command): void {
 
               if (templateDownloaded && !json) {
                 await runNpmInstall();
+                if (opts.auth) {
+                  await runNpmSetupIfPresent();
+                }
               }
 
               await installSkills(json);
@@ -214,6 +244,7 @@ export function registerProjectLinkCommand(program: Command): void {
                 // "Cannot find package 'pg'".
                 if (result.packageJsonPatched && !json) {
                   await runNpmInstall('Installing new dependencies...');
+                  await runNpmSetupIfPresent();
                 }
                 if (!json) clack.note(result.nextSteps, "What's next");
               } catch (err) {
@@ -404,6 +435,9 @@ export function registerProjectLinkCommand(program: Command): void {
 
           if (templateDownloaded && !json) {
             await runNpmInstall();
+            if (opts.auth) {
+              await runNpmSetupIfPresent();
+            }
           }
 
           // Install agent skills inside the project directory
@@ -439,6 +473,7 @@ export function registerProjectLinkCommand(program: Command): void {
               // the direct-OSS bare-overlay path above.
               if (result.packageJsonPatched && !json) {
                 await runNpmInstall('Installing new dependencies...');
+                await runNpmSetupIfPresent();
               }
 
               if (!json) clack.note(result.nextSteps, "What's next");

--- a/src/lib/api/oss.test.ts
+++ b/src/lib/api/oss.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { spliceDatabasePassword } from './oss.js';
+
+describe('spliceDatabasePassword', () => {
+  // Real shape from cloud `/api/metadata/database-connection-string`
+  const masked = 'postgresql://postgres:********@b4jh2kvi.us-east.database.insforge.app:5432/insforge?sslmode=require';
+
+  it('replaces the masked password with the real one', () => {
+    const result = spliceDatabasePassword(masked, '66666b99c46288a34220009437d8a3c2');
+    expect(result).toBe('postgresql://postgres:66666b99c46288a34220009437d8a3c2@b4jh2kvi.us-east.database.insforge.app:5432/insforge?sslmode=require');
+    expect(result).not.toContain('********');
+  });
+
+  it('preserves the rest of the URL exactly (host, port, db, query)', () => {
+    const result = spliceDatabasePassword(masked, 'pw');
+    expect(result).toContain('@b4jh2kvi.us-east.database.insforge.app:5432/insforge?sslmode=require');
+  });
+
+  it('handles passwords containing special characters', () => {
+    // Backend already URL-encodes special chars; we just inject verbatim.
+    const result = spliceDatabasePassword(masked, 'p%40ss%3Aword');
+    expect(result).toContain(':p%40ss%3Aword@');
+  });
+
+  it('only replaces the first `://user:...@` block (in case the URL has @ elsewhere)', () => {
+    const m = 'postgresql://postgres:********@db.host.app:5432/insforge?options=user%3D%40admin';
+    const result = spliceDatabasePassword(m, 'realpw');
+    expect(result).toBe('postgresql://postgres:realpw@db.host.app:5432/insforge?options=user%3D%40admin');
+  });
+});

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -50,16 +50,37 @@ export async function getJwtSecret(): Promise<string | null> {
   }
 }
 
+// Splice the real password into a masked Postgres URL like
+// `postgresql://postgres:********@host:5432/db?sslmode=require`. Replaces
+// the segment between the first `://<user>:` and the next `@`. Exported
+// for unit testing.
+export function spliceDatabasePassword(maskedUrl: string, password: string): string {
+  return maskedUrl.replace(/^(postgresql:\/\/[^:]+:)[^@]+(@)/, `$1${password}$2`);
+}
+
 export async function getDatabaseConnectionString(): Promise<string | null> {
-  // Cloud-only: returns the project's Postgres URL (with sslmode). Self-hosted
-  // returns null so callers leave DATABASE_URL at the localhost default —
-  // self-hosters know their own connection string.
+  // Cloud-only: returns the project's Postgres URL with the real password
+  // substituted in. The platform's `/database-connection-string` endpoint
+  // masks the password (`postgresql://postgres:********@...`), so we also
+  // hit `/database-password` and splice the unmasked value in. Without this
+  // splice, callers (e.g., `link`'s .env.local auto-fill) would write a URL
+  // BA's pg pool can't authenticate with.
+  // Self-hosted returns null on either endpoint (PROJECT_ID not configured)
+  // so we fall back gracefully.
   try {
-    const res = await ossFetch('/api/metadata/database-connection-string');
-    const data = await res.json() as { connectionURL?: string };
-    return typeof data.connectionURL === 'string' && data.connectionURL.length > 0
-      ? data.connectionURL
-      : null;
+    const [urlRes, pwRes] = await Promise.all([
+      ossFetch('/api/metadata/database-connection-string'),
+      ossFetch('/api/metadata/database-password'),
+    ]);
+    const urlBody = await urlRes.json() as { connectionURL?: string };
+    const pwBody = await pwRes.json() as { databasePassword?: string };
+
+    const masked = urlBody.connectionURL;
+    const password = pwBody.databasePassword;
+    if (typeof masked !== 'string' || !masked) return null;
+    if (typeof password !== 'string' || !password) return null;
+
+    return spliceDatabasePassword(masked, password);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

The platform endpoint \`/api/metadata/database-connection-string\` returns the URL with the password **masked as \`********\`** for safety. The CLI was passing this masked URL through unchanged:

- \`insforge db connection-string\` printed it (unusable for \`psql\`)
- \`link --auth better-auth\`'s auto-fill (0.1.67) wrote it to \`.env.local\` (BA's pg pool can't authenticate with \`********\`)

Hence after the previous round of fixes landed, users still hit \"can't connect\" — even when the URL was technically being filled.

## Fix

\`getDatabaseConnectionString()\` now also calls \`/api/metadata/database-password\` in parallel and splices the unmasked password into the URL between \`://<user>:\` and \`@\`. Self-hosted projects still get null (both endpoints 500 on missing PROJECT_ID), preserving the localhost default.

## Test plan

- [x] build + lint pass
- [ ] (post-merge, on cloud project) \`insforge db connection-string\` prints a working URL → \`psql \"$URL\" -c 'SELECT 1'\` returns 1
- [ ] (post-merge, on cloud project) \`link --auth better-auth\` writes a working URL → \`npm run setup\` runs \`auth:migrate\` against the cloud DB without auth failure

Bump 0.1.68 → 0.1.69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unmasks the cloud database password so `insforge db connection-string` and `.env.local` auto-fill produce a working Postgres URL, and auto-runs `npm run setup` after `link --auth` to create tables. Self-hosted behavior is unchanged.

- **Bug Fixes**
  - `getDatabaseConnectionString()` now fetches `/api/metadata/database-connection-string` and `/api/metadata/database-password` in parallel, then splices the real password; `insforge db connection-string` prints/returns the unmasked URL, shows a clear error on self-hosted projects, and JSON output returns `{ connectionURL }`; adds unit tests for `spliceDatabasePassword`, `extractEnvPairs`, and `refreshStaleEnvDefaults`.
  - After `link --auth <provider>`, runs `npm run setup` if the scaffold added it to apply schema and migrations; failures are surfaced with guidance but don’t stop the link flow.

<sup>Written for commit a67a1ecb4dabcf4efffbfffbcd780917f153c061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * After installing dependencies, the CLI will now run an optional project setup step when applicable (e.g., when auth flow is used).

* **Bug Fixes**
  * Database connection command now returns a full, usable connection URL, prints the raw URL in plain mode, emits a clearer error when no cloud project is present, and returns an object in JSON mode.

* **Tests**
  * Expanded unit tests for environment-variable parsing, refreshing stale defaults, and reconstructing masked connection URLs.

* **Chores**
  * Version bumped to 0.1.71.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->