### PR TITLE
feat(cli): config-as-code (export/plan/apply) + env() validation + compute port fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "commander": "^13.1.0",
         "open": "^10.1.0",
         "picocolors": "^1.1.1",
-        "posthog-node": "^5.28.9"
+        "posthog-node": "^5.28.9",
+        "smol-toml": "^1.6.1"
       },
       "bin": {
         "insforge": "dist/index.js"
@@ -4194,6 +4195,18 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "commander": "^13.1.0",
     "open": "^10.1.0",
     "picocolors": "^1.1.1",
-    "posthog-node": "^5.28.9"
+    "posthog-node": "^5.28.9",
+    "smol-toml": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -142,6 +142,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
             const verb = existing ? 'updated' : 'deployed';
             outputSuccess(`Service "${service.name}" ${verb} [${service.status}]`);
             if (service.endpointUrl) console.log(`  Endpoint: ${service.endpointUrl}`);
+            if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
           }
           await reportCliUsage('cli.compute.deploy', true);
           return;
@@ -269,6 +270,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
           const verb = existing ? 'updated' : 'deployed';
           outputSuccess(`Service "${service.name}" ${verb} [${service.status}]`);
           if (service.endpointUrl) console.log(`  Endpoint: ${service.endpointUrl}`);
+          if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
           console.log(`  Image: ${imageRef} (built remotely; no local image to clean up)`);
         }
 

--- a/src/commands/compute/update.ts
+++ b/src/commands/compute/update.ts
@@ -131,6 +131,8 @@ export function registerComputeUpdateCommand(computeCmd: Command): void {
           outputJson(service);
         } else {
           outputSuccess(`Service "${service.name}" updated [${service.status}]`);
+          if (service.endpointUrl) console.log(`  Endpoint: ${service.endpointUrl}`);
+          if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
         }
         await reportCliUsage('cli.compute.update', true);
       } catch (err) {

--- a/src/commands/config/apply.test.ts
+++ b/src/commands/config/apply.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { registerConfigApplyCommand } from './apply.js';
+import type * as ErrorsModule from '../../lib/errors.js';
 
 // Per-test we override what /api/metadata returns by reassigning this.
 let nextMetadataResponse: unknown = {};
@@ -33,7 +34,7 @@ vi.mock('../../lib/skills.js', () => ({
 }));
 
 vi.mock('../../lib/errors.js', async (orig) => {
-  const actual = await orig<typeof import('../../lib/errors.js')>();
+  const actual = await orig<typeof ErrorsModule>();
   return {
     ...actual,
     // Force handleError to throw rather than process.exit so tests can inspect.

--- a/src/commands/config/apply.test.ts
+++ b/src/commands/config/apply.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerConfigApplyCommand } from './apply.js';
+
+// Per-test we override what /api/metadata returns by reassigning this.
+let nextMetadataResponse: unknown = {};
+const ossFetchMock = vi.fn(async (path: string, init?: RequestInit) => {
+  if (path === '/api/metadata' && (!init || init.method === undefined || init.method === 'GET')) {
+    return new Response(JSON.stringify(nextMetadataResponse), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+});
+
+vi.mock('../../lib/api/oss.js', () => ({
+  ossFetch: (path: string, init?: RequestInit) => ossFetchMock(path, init),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok', userId: 'u' })),
+}));
+
+vi.mock('../../lib/skills.js', () => ({
+  reportCliUsage: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/errors.js', async (orig) => {
+  const actual = await orig<typeof import('../../lib/errors.js')>();
+  return {
+    ...actual,
+    // Force handleError to throw rather than process.exit so tests can inspect.
+    handleError: vi.fn((err: unknown) => {
+      throw err;
+    }),
+  };
+});
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--yes').option('--api-url <url>');
+  const cfg = program.command('config');
+  registerConfigApplyCommand(cfg);
+  return program;
+}
+
+async function runJson(program: Command, argv: string[]): Promise<unknown[]> {
+  const out: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    out.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return out.flatMap((s) => {
+    try {
+      return [JSON.parse(s)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmp = mkdtempSync(join(tmpdir(), 'insforge-apply-test-'));
+});
+
+describe('config apply (capability probe)', () => {
+  it('applies changes when backend exposes the field', async () => {
+    nextMetadataResponse = {
+      auth: { allowedRedirectUrls: ['https://old.com'] },
+    };
+    const tomlPath = join(tmp, 'insforge.toml');
+    writeFileSync(
+      tomlPath,
+      '[auth]\nallowed_redirect_urls = ["https://new.com", "https://old.com"]\n',
+    );
+
+    const program = makeProgram();
+    const docs = await runJson(program, [
+      '--json',
+      '--yes',
+      'config',
+      'apply',
+      '--file',
+      tomlPath,
+    ]);
+
+    // Single JSON doc emitted (one of the prior review items).
+    expect(docs).toHaveLength(1);
+    const result = docs[0] as { applied: unknown[]; skipped: unknown[] };
+    expect(result.applied).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+    // PUT was issued.
+    const putCalls = ossFetchMock.mock.calls.filter(
+      (c) => c[1]?.method === 'PUT' && c[0] === '/api/auth/config',
+    );
+    expect(putCalls).toHaveLength(1);
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('skips changes (and never PUTs) when the backend omits the field', async () => {
+    // Legacy backend: auth slice exists but no allowedRedirectUrls field.
+    nextMetadataResponse = { auth: { someOtherField: 'x' } };
+    const tomlPath = join(tmp, 'insforge.toml');
+    writeFileSync(tomlPath, '[auth]\nallowed_redirect_urls = ["https://new.com"]\n');
+
+    const program = makeProgram();
+    const docs = await runJson(program, [
+      '--json',
+      '--yes',
+      'config',
+      'apply',
+      '--file',
+      tomlPath,
+    ]);
+
+    const result = docs[0] as {
+      applied: unknown[];
+      skipped: Array<{ key: string; reason: string }>;
+    };
+    expect(result.applied).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].key).toBe('auth.allowed_redirect_urls');
+    expect(result.skipped[0].reason).toMatch(/upgrade/);
+    // No PUT ever issued — protects against silent-drop on permissive servers.
+    const putCalls = ossFetchMock.mock.calls.filter((c) => c[1]?.method === 'PUT');
+    expect(putCalls).toHaveLength(0);
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('treats an empty array on the wire as supported (empty != absent)', async () => {
+    nextMetadataResponse = { auth: { allowedRedirectUrls: [] } };
+    const tomlPath = join(tmp, 'insforge.toml');
+    writeFileSync(tomlPath, '[auth]\nallowed_redirect_urls = ["https://new.com"]\n');
+
+    const program = makeProgram();
+    const docs = await runJson(program, [
+      '--json',
+      '--yes',
+      'config',
+      'apply',
+      '--file',
+      tomlPath,
+    ]);
+
+    const result = docs[0] as { applied: unknown[]; skipped: unknown[] };
+    expect(result.applied).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/src/commands/config/apply.ts
+++ b/src/commands/config/apply.ts
@@ -1,0 +1,97 @@
+// CLI/src/commands/config/apply.ts
+import type { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { parseConfigToml } from '../../lib/config-toml.js';
+import { diffConfig, type DiffChange } from '../../lib/config-diff.js';
+import { formatPlan } from '../../lib/config-format.js';
+import type { InsforgeConfig } from '../../lib/config-schema.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+export function registerConfigApplyCommand(cfg: Command): void {
+  cfg
+    .command('apply')
+    .description('Apply insforge.toml to the live project')
+    .option('--file <path>', 'path to insforge.toml', 'insforge.toml')
+    .option('--dry-run', 'show plan, do not apply')
+    .option('--auto-approve', 'skip confirmation prompt')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const tomlPath = resolve(process.cwd(), opts.file);
+        const tomlSource = readFileSync(tomlPath, 'utf8');
+        const file = parseConfigToml(tomlSource);
+
+        const res = await ossFetch('/api/metadata');
+        const raw = (await res.json()) as {
+          auth?: { allowedRedirectUrls?: string[] };
+        };
+        const live: InsforgeConfig = {
+          auth: { allowed_redirect_urls: raw.auth?.allowedRedirectUrls ?? [] },
+        };
+
+        const result = diffConfig({ live, file });
+
+        if (json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(formatPlan(result));
+        }
+
+        if (result.changes.length === 0 || opts.dryRun) {
+          await reportCliUsage('cli.config.apply', true);
+          return;
+        }
+
+        if (!opts.autoApprove && !json) {
+          const ok = await p.confirm({
+            message: 'Apply these changes?',
+            initialValue: false,
+          });
+          if (!ok || p.isCancel(ok)) {
+            console.log('Aborted.');
+            await reportCliUsage('cli.config.apply', true);
+            return;
+          }
+        }
+
+        for (const change of result.changes) {
+          await applyChange(change, file);
+        }
+
+        if (json) {
+          console.log(JSON.stringify({ applied: true, changes: result.changes }));
+        } else {
+          const s = result.summary;
+          console.log(
+            `${pc.green('✓')} Applied (${s.add} added, ${s.modify} modified, ${s.remove} removed)`,
+          );
+        }
+        await reportCliUsage('cli.config.apply', true);
+      } catch (err) {
+        await reportCliUsage('cli.config.apply', false);
+        handleError(err, json);
+      }
+    });
+}
+
+async function applyChange(
+  change: DiffChange,
+  file: InsforgeConfig,
+): Promise<void> {
+  if (change.section === 'auth' && change.key === 'allowed_redirect_urls') {
+    await ossFetch('/api/auth/config', {
+      method: 'PUT',
+      body: JSON.stringify({ allowedRedirectUrls: change.to }),
+    });
+    return;
+  }
+  throw new Error(`Unsupported change type: ${change.section}.${change.key}`);
+}

--- a/src/commands/config/apply.ts
+++ b/src/commands/config/apply.ts
@@ -10,6 +10,7 @@ import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { parseConfigToml } from '../../lib/config-toml.js';
 import { diffConfig, type DiffChange } from '../../lib/config-diff.js';
 import { formatPlan } from '../../lib/config-format.js';
+import { metadataSupports, changePath } from '../../lib/config-capabilities.js';
 import type { InsforgeConfig } from '../../lib/config-schema.js';
 import { reportCliUsage } from '../../lib/skills.js';
 
@@ -78,19 +79,44 @@ export function registerConfigApplyCommand(cfg: Command): void {
           }
         }
 
+        // Per-change capability gate. Each change is independent: a backend
+        // that supports `auth.allowed_redirect_urls` but not (future)
+        // `email.smtp` should apply the first and skip the second with a
+        // named warning. Better than failing the whole batch.
+        const applied: DiffChange[] = [];
+        const skipped: Array<{ key: string; reason: string }> = [];
         for (const change of result.changes) {
+          const path = changePath(change);
+          if (!metadataSupports(raw, change)) {
+            skipped.push({
+              key: path,
+              reason: `your backend doesn't expose ${path} — upgrade the project to apply this section`,
+            });
+            continue;
+          }
           await applyChange(change);
+          applied.push(change);
         }
 
         if (json) {
           console.log(
-            JSON.stringify({ plan: result, applied: true, changes: result.changes }, null, 2),
+            JSON.stringify({ plan: result, applied, skipped }, null, 2),
           );
         } else {
-          const s = result.summary;
-          console.log(
-            `${pc.green('✓')} Applied (${s.add} added, ${s.modify} modified, ${s.remove} removed)`,
-          );
+          if (skipped.length) {
+            console.warn(
+              pc.yellow(`⚠ Skipped ${skipped.length} section(s):`) +
+                '\n' +
+                skipped.map((s) => `  - ${s.key}: ${s.reason}`).join('\n'),
+            );
+          }
+          if (applied.length) {
+            console.log(
+              `${pc.green('✓')} Applied ${applied.length} of ${result.changes.length} change(s).`,
+            );
+          } else {
+            console.log('Nothing applied.');
+          }
         }
         await reportCliUsage('cli.config.apply', true);
       } catch (err) {

--- a/src/commands/config/apply.ts
+++ b/src/commands/config/apply.ts
@@ -6,7 +6,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
-import { handleError, getRootOpts } from '../../lib/errors.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { parseConfigToml } from '../../lib/config-toml.js';
 import { diffConfig, type DiffChange } from '../../lib/config-diff.js';
 import { formatPlan } from '../../lib/config-format.js';
@@ -21,7 +21,7 @@ export function registerConfigApplyCommand(cfg: Command): void {
     .option('--dry-run', 'show plan, do not apply')
     .option('--auto-approve', 'skip confirmation prompt')
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, yes } = getRootOpts(cmd);
       try {
         await requireAuth();
 
@@ -38,19 +38,35 @@ export function registerConfigApplyCommand(cfg: Command): void {
         };
 
         const result = diffConfig({ live, file });
+        const approved = opts.autoApprove || yes;
 
-        if (json) {
-          console.log(JSON.stringify(result, null, 2));
-        } else {
+        // Render the plan immediately in interactive mode so the user can read
+        // it before confirming. In --json mode hold output until the end so
+        // we emit a single JSON document (parsable by jq, etc.).
+        if (!json) {
           console.log(formatPlan(result));
         }
 
         if (result.changes.length === 0 || opts.dryRun) {
+          if (json) {
+            console.log(
+              JSON.stringify({ plan: result, applied: false, dryRun: !!opts.dryRun }, null, 2),
+            );
+          }
           await reportCliUsage('cli.config.apply', true);
           return;
         }
 
-        if (!opts.autoApprove && !json) {
+        if (!approved) {
+          if (json) {
+            // No TTY in --json runs; require explicit consent rather than
+            // silently applying or hanging on a prompt.
+            throw new CLIError(
+              'Refusing to apply in --json mode without --auto-approve or --yes.',
+              1,
+              'CONFIRMATION_REQUIRED',
+            );
+          }
           const ok = await p.confirm({
             message: 'Apply these changes?',
             initialValue: false,
@@ -63,11 +79,13 @@ export function registerConfigApplyCommand(cfg: Command): void {
         }
 
         for (const change of result.changes) {
-          await applyChange(change, file);
+          await applyChange(change);
         }
 
         if (json) {
-          console.log(JSON.stringify({ applied: true, changes: result.changes }));
+          console.log(
+            JSON.stringify({ plan: result, applied: true, changes: result.changes }, null, 2),
+          );
         } else {
           const s = result.summary;
           console.log(
@@ -82,10 +100,7 @@ export function registerConfigApplyCommand(cfg: Command): void {
     });
 }
 
-async function applyChange(
-  change: DiffChange,
-  file: InsforgeConfig,
-): Promise<void> {
+async function applyChange(change: DiffChange): Promise<void> {
   if (change.section === 'auth' && change.key === 'allowed_redirect_urls') {
     await ossFetch('/api/auth/config', {
       method: 'PUT',

--- a/src/commands/config/export.test.ts
+++ b/src/commands/config/export.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { registerConfigExportCommand } from './export.js';
+import type * as ErrorsModule from '../../lib/errors.js';
 
 let nextMetadataResponse: unknown = {};
 const ossFetchMock = vi.fn(async () => {
@@ -26,7 +27,7 @@ vi.mock('../../lib/skills.js', () => ({
 }));
 
 vi.mock('../../lib/errors.js', async (orig) => {
-  const actual = await orig<typeof import('../../lib/errors.js')>();
+  const actual = await orig<typeof ErrorsModule>();
   return {
     ...actual,
     handleError: vi.fn((err: unknown) => {

--- a/src/commands/config/export.test.ts
+++ b/src/commands/config/export.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerConfigExportCommand } from './export.js';
+
+let nextMetadataResponse: unknown = {};
+const ossFetchMock = vi.fn(async () => {
+  return new Response(JSON.stringify(nextMetadataResponse), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+});
+
+vi.mock('../../lib/api/oss.js', () => ({
+  ossFetch: () => ossFetchMock(),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok', userId: 'u' })),
+}));
+
+vi.mock('../../lib/skills.js', () => ({
+  reportCliUsage: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/errors.js', async (orig) => {
+  const actual = await orig<typeof import('../../lib/errors.js')>();
+  return {
+    ...actual,
+    handleError: vi.fn((err: unknown) => {
+      throw err;
+    }),
+  };
+});
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>');
+  const cfg = program.command('config');
+  registerConfigExportCommand(cfg);
+  return program;
+}
+
+async function runJson(program: Command, argv: string[]): Promise<unknown[]> {
+  const out: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    out.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return out.flatMap((s) => {
+    try {
+      return [JSON.parse(s)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmp = mkdtempSync(join(tmpdir(), 'insforge-export-test-'));
+});
+
+describe('config export (capability probe)', () => {
+  it('emits the auth section when the backend exposes the field', async () => {
+    nextMetadataResponse = {
+      auth: { allowedRedirectUrls: ['https://a.com', 'https://b.com'] },
+    };
+    const target = join(tmp, 'insforge.toml');
+    const program = makeProgram();
+    const docs = await runJson(program, [
+      '--json',
+      'config',
+      'export',
+      '--out',
+      target,
+      '--force',
+    ]);
+
+    const result = docs[0] as { config: { auth?: unknown }; skipped: string[] };
+    expect(result.config.auth).toEqual({
+      allowed_redirect_urls: ['https://a.com', 'https://b.com'],
+    });
+    expect(result.skipped).toEqual([]);
+
+    const written = readFileSync(target, 'utf8');
+    expect(written).toContain('allowed_redirect_urls');
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('omits the auth section and reports skipped when the field is absent', async () => {
+    // Older backend — auth metadata returns, but no allowedRedirectUrls key.
+    nextMetadataResponse = { auth: { someOtherField: 'x' } };
+    const target = join(tmp, 'insforge.toml');
+    const program = makeProgram();
+    const docs = await runJson(program, [
+      '--json',
+      'config',
+      'export',
+      '--out',
+      target,
+      '--force',
+    ]);
+
+    const result = docs[0] as { config: { auth?: unknown }; skipped: string[] };
+    expect(result.config.auth).toBeUndefined();
+    expect(result.skipped).toEqual(['auth.allowed_redirect_urls']);
+    // File is still written so future apply cycles work — just empty.
+    expect(existsSync(target)).toBe(true);
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/src/commands/config/export.ts
+++ b/src/commands/config/export.ts
@@ -6,7 +6,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
-import { handleError, getRootOpts } from '../../lib/errors.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { stringifyConfigToml } from '../../lib/config-toml.js';
 import type { InsforgeConfig } from '../../lib/config-schema.js';
 import { reportCliUsage } from '../../lib/skills.js';
@@ -24,6 +24,15 @@ export function registerConfigExportCommand(cfg: Command): void {
 
         const target = resolve(process.cwd(), opts.out);
         if (existsSync(target) && !opts.force) {
+          if (json) {
+            // No TTY in --json runs; bail with an actionable error instead
+            // of hanging on an interactive prompt.
+            throw new CLIError(
+              `${opts.out} exists. Re-run with --force to overwrite.`,
+              1,
+              'OUTPUT_EXISTS',
+            );
+          }
           const ok = await p.confirm({
             message: `${opts.out} exists. Overwrite?`,
             initialValue: false,

--- a/src/commands/config/export.ts
+++ b/src/commands/config/export.ts
@@ -48,19 +48,39 @@ export function registerConfigExportCommand(cfg: Command): void {
           auth?: { allowedRedirectUrls?: string[] };
         };
 
-        const config: InsforgeConfig = {
-          auth: {
-            allowed_redirect_urls: raw.auth?.allowedRedirectUrls ?? [],
-          },
-        };
+        // Only emit sections the backend actually exposes. The TOML file
+        // should describe what THIS backend can do — not aspirational fields
+        // that would break on apply. Probe presence in the raw response;
+        // an older backend without the field gets an empty config,
+        // not a TOML littered with defaults that pretend to work.
+        const config: InsforgeConfig = {};
+        const skipped: string[] = [];
+
+        const authSlice = raw?.auth;
+        if (authSlice && typeof authSlice === 'object' && 'allowedRedirectUrls' in authSlice) {
+          config.auth = {
+            allowed_redirect_urls: authSlice.allowedRedirectUrls ?? [],
+          };
+        } else {
+          skipped.push('auth.allowed_redirect_urls');
+        }
 
         const toml = stringifyConfigToml(config);
         writeFileSync(target, toml, 'utf8');
 
         if (json) {
-          console.log(JSON.stringify({ written: target, config }));
+          console.log(JSON.stringify({ written: target, config, skipped }, null, 2));
         } else {
           console.log(`${pc.green('✓')} Wrote ${target}`);
+          if (skipped.length) {
+            console.warn(
+              pc.yellow(
+                `⚠ Skipped ${skipped.length} section(s) not supported by this backend:`,
+              ) +
+                '\n' +
+                skipped.map((k) => `  - ${k}`).join('\n'),
+            );
+          }
         }
         await reportCliUsage('cli.config.export', true);
       } catch (err) {

--- a/src/commands/config/export.ts
+++ b/src/commands/config/export.ts
@@ -1,0 +1,62 @@
+// CLI/src/commands/config/export.ts
+import type { Command } from 'commander';
+import { writeFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { stringifyConfigToml } from '../../lib/config-toml.js';
+import type { InsforgeConfig } from '../../lib/config-schema.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+export function registerConfigExportCommand(cfg: Command): void {
+  cfg
+    .command('export')
+    .description('Pull live project config and write insforge.toml')
+    .option('--out <path>', 'output path', 'insforge.toml')
+    .option('--force', 'overwrite without confirmation')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const target = resolve(process.cwd(), opts.out);
+        if (existsSync(target) && !opts.force) {
+          const ok = await p.confirm({
+            message: `${opts.out} exists. Overwrite?`,
+            initialValue: false,
+          });
+          if (!ok || p.isCancel(ok)) {
+            console.log('Aborted.');
+            return;
+          }
+        }
+
+        const res = await ossFetch('/api/metadata');
+        const raw = (await res.json()) as {
+          auth?: { allowedRedirectUrls?: string[] };
+        };
+
+        const config: InsforgeConfig = {
+          auth: {
+            allowed_redirect_urls: raw.auth?.allowedRedirectUrls ?? [],
+          },
+        };
+
+        const toml = stringifyConfigToml(config);
+        writeFileSync(target, toml, 'utf8');
+
+        if (json) {
+          console.log(JSON.stringify({ written: target, config }));
+        } else {
+          console.log(`${pc.green('✓')} Wrote ${target}`);
+        }
+        await reportCliUsage('cli.config.export', true);
+      } catch (err) {
+        await reportCliUsage('cli.config.export', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,0 +1,14 @@
+// CLI/src/commands/config/index.ts
+import type { Command } from 'commander';
+import { registerConfigExportCommand } from './export.js';
+import { registerConfigPlanCommand } from './plan.js';
+import { registerConfigApplyCommand } from './apply.js';
+
+export function registerConfigCommand(program: Command): void {
+  const cfg = program
+    .command('config')
+    .description('Manage insforge.toml (declarative project configuration)');
+  registerConfigExportCommand(cfg);
+  registerConfigPlanCommand(cfg);
+  registerConfigApplyCommand(cfg);
+}

--- a/src/commands/config/plan.test.ts
+++ b/src/commands/config/plan.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerConfigPlanCommand } from './plan.js';
+
+let nextMetadataResponse: unknown = {};
+const ossFetchMock = vi.fn(async () => {
+  return new Response(JSON.stringify(nextMetadataResponse), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+});
+
+vi.mock('../../lib/api/oss.js', () => ({
+  ossFetch: () => ossFetchMock(),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok', userId: 'u' })),
+}));
+
+vi.mock('../../lib/skills.js', () => ({
+  reportCliUsage: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/errors.js', async (orig) => {
+  const actual = await orig<typeof import('../../lib/errors.js')>();
+  return {
+    ...actual,
+    handleError: vi.fn((err: unknown) => {
+      throw err;
+    }),
+  };
+});
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>');
+  const cfg = program.command('config');
+  registerConfigPlanCommand(cfg);
+  return program;
+}
+
+async function runJson(program: Command, argv: string[]): Promise<unknown[]> {
+  const out: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    out.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return out.flatMap((s) => {
+    try {
+      return [JSON.parse(s)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmp = mkdtempSync(join(tmpdir(), 'insforge-plan-test-'));
+});
+
+describe('config plan (capability probe)', () => {
+  it('reports skipped[] empty when backend supports all sections', async () => {
+    nextMetadataResponse = {
+      auth: { allowedRedirectUrls: ['https://a.com'] },
+    };
+    const tomlPath = join(tmp, 'insforge.toml');
+    writeFileSync(tomlPath, '[auth]\nallowed_redirect_urls = ["https://b.com"]\n');
+
+    const program = makeProgram();
+    const docs = await runJson(program, ['--json', 'config', 'plan', '--file', tomlPath]);
+    const result = docs[0] as { changes: unknown[]; skipped: string[] };
+    expect(result.changes).toHaveLength(1);
+    expect(result.skipped).toEqual([]);
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reports skipped paths when backend omits the field', async () => {
+    nextMetadataResponse = { auth: { someOtherField: 'x' } };
+    const tomlPath = join(tmp, 'insforge.toml');
+    writeFileSync(tomlPath, '[auth]\nallowed_redirect_urls = ["https://b.com"]\n');
+
+    const program = makeProgram();
+    const docs = await runJson(program, ['--json', 'config', 'plan', '--file', tomlPath]);
+    const result = docs[0] as { changes: unknown[]; skipped: string[] };
+    expect(result.changes).toHaveLength(1);
+    expect(result.skipped).toEqual(['auth.allowed_redirect_urls']);
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/src/commands/config/plan.test.ts
+++ b/src/commands/config/plan.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { registerConfigPlanCommand } from './plan.js';
+import type * as ErrorsModule from '../../lib/errors.js';
 
 let nextMetadataResponse: unknown = {};
 const ossFetchMock = vi.fn(async () => {
@@ -26,7 +27,7 @@ vi.mock('../../lib/skills.js', () => ({
 }));
 
 vi.mock('../../lib/errors.js', async (orig) => {
-  const actual = await orig<typeof import('../../lib/errors.js')>();
+  const actual = await orig<typeof ErrorsModule>();
   return {
     ...actual,
     handleError: vi.fn((err: unknown) => {

--- a/src/commands/config/plan.ts
+++ b/src/commands/config/plan.ts
@@ -1,0 +1,50 @@
+// CLI/src/commands/config/plan.ts
+import type { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { parseConfigToml } from '../../lib/config-toml.js';
+import { diffConfig } from '../../lib/config-diff.js';
+import { formatPlan } from '../../lib/config-format.js';
+import type { InsforgeConfig } from '../../lib/config-schema.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+export function registerConfigPlanCommand(cfg: Command): void {
+  cfg
+    .command('plan')
+    .description('Show diff between insforge.toml and live project state')
+    .option('--file <path>', 'path to insforge.toml', 'insforge.toml')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const tomlPath = resolve(process.cwd(), opts.file);
+        const tomlSource = readFileSync(tomlPath, 'utf8');
+        const file = parseConfigToml(tomlSource);
+
+        const res = await ossFetch('/api/metadata');
+        const raw = (await res.json()) as {
+          auth?: { allowedRedirectUrls?: string[] };
+        };
+        const live: InsforgeConfig = {
+          auth: { allowed_redirect_urls: raw.auth?.allowedRedirectUrls ?? [] },
+        };
+
+        const result = diffConfig({ live, file });
+
+        if (json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Plan for insforge.toml (file: ${opts.file}):\n`);
+          console.log(formatPlan(result));
+        }
+        await reportCliUsage('cli.config.plan', true);
+      } catch (err) {
+        await reportCliUsage('cli.config.plan', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/config/plan.ts
+++ b/src/commands/config/plan.ts
@@ -5,9 +5,11 @@ import { resolve } from 'node:path';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
+import pc from 'picocolors';
 import { parseConfigToml } from '../../lib/config-toml.js';
 import { diffConfig } from '../../lib/config-diff.js';
 import { formatPlan } from '../../lib/config-format.js';
+import { metadataSupports, changePath } from '../../lib/config-capabilities.js';
 import type { InsforgeConfig } from '../../lib/config-schema.js';
 import { reportCliUsage } from '../../lib/skills.js';
 
@@ -35,11 +37,26 @@ export function registerConfigPlanCommand(cfg: Command): void {
 
         const result = diffConfig({ live, file });
 
+        // Tag each change with whether the backend supports it. Apply will
+        // skip unsupported changes; plan surfaces this up front so the user
+        // isn't surprised.
+        const skipped = result.changes
+          .filter((c) => !metadataSupports(raw, c))
+          .map((c) => changePath(c));
+
         if (json) {
-          console.log(JSON.stringify(result, null, 2));
+          console.log(JSON.stringify({ ...result, skipped }, null, 2));
         } else {
           console.log(`Plan for insforge.toml (file: ${opts.file}):\n`);
           console.log(formatPlan(result));
+          if (skipped.length) {
+            console.warn(
+              '\n' +
+                pc.yellow(`⚠ Apply will skip ${skipped.length} section(s) — backend doesn't support them yet:`) +
+                '\n' +
+                skipped.map((k) => `  - ${k}`).join('\n'),
+            );
+          }
         }
         await reportCliUsage('cli.config.plan', true);
       } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ import { registerMetadataCommand } from './commands/metadata.js';
 import { registerDiagnoseCommands } from './commands/diagnose/index.js';
 import { registerPaymentsCommands } from './commands/payments/index.js';
 import { registerPosthogSetupCommand } from './commands/posthog/setup.js';
+import { registerConfigCommand } from './commands/config/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
@@ -216,6 +217,9 @@ registerSchedulesCreateCommand(schedulesCmd);
 registerSchedulesUpdateCommand(schedulesCmd);
 registerSchedulesDeleteCommand(schedulesCmd);
 registerSchedulesLogsCommand(schedulesCmd);
+
+// Config commands
+registerConfigCommand(program);
 
 if (process.argv.length <= 2 && process.stdout.isTTY) {
   await showInteractiveMenu();

--- a/src/lib/config-capabilities.test.ts
+++ b/src/lib/config-capabilities.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { metadataSupports, changePath } from './config-capabilities.js';
+import type { DiffChange } from './config-diff.js';
+
+const change: DiffChange = {
+  section: 'auth',
+  op: 'modify',
+  key: 'allowed_redirect_urls',
+  from: [],
+  to: ['https://a.com'],
+};
+
+describe('metadataSupports', () => {
+  it('returns true when the field is present in the raw response', () => {
+    const raw = { auth: { allowedRedirectUrls: ['https://b.com'] } };
+    expect(metadataSupports(raw, change)).toBe(true);
+  });
+
+  it('returns true even when the field value is an empty array', () => {
+    // Empty != absent. A modern backend with no URLs configured still
+    // emits the key; the CLI must treat that as "supported, currently empty."
+    const raw = { auth: { allowedRedirectUrls: [] } };
+    expect(metadataSupports(raw, change)).toBe(true);
+  });
+
+  it('returns true when the field value is null', () => {
+    // Server choice; not the CLI's place to second-guess. Presence is the
+    // signal — null is a valid emitted value.
+    const raw = { auth: { allowedRedirectUrls: null } };
+    expect(metadataSupports(raw, change)).toBe(true);
+  });
+
+  it('returns false when the auth slice exists but omits the field', () => {
+    // This is the legacy-backend case: auth metadata is returned, but the
+    // pre-v1.4 build doesn't know about the field at all.
+    const raw = { auth: { someOtherField: 'value' } };
+    expect(metadataSupports(raw, change)).toBe(false);
+  });
+
+  it('returns false when the auth slice is absent', () => {
+    const raw = {};
+    expect(metadataSupports(raw, change)).toBe(false);
+  });
+
+  it('returns false when raw is malformed', () => {
+    expect(metadataSupports({ auth: null as unknown as Record<string, unknown> }, change)).toBe(
+      false,
+    );
+  });
+
+  it('returns false for unknown section/key combinations', () => {
+    const unknown: DiffChange = {
+      section: 'auth',
+      op: 'modify',
+      key: 'something_new' as 'allowed_redirect_urls',
+      from: [],
+      to: [],
+    };
+    const raw = { auth: { allowedRedirectUrls: [] } };
+    expect(metadataSupports(raw, unknown)).toBe(false);
+  });
+});
+
+describe('changePath', () => {
+  it('joins section and key with a dot', () => {
+    expect(changePath(change)).toBe('auth.allowed_redirect_urls');
+  });
+});

--- a/src/lib/config-capabilities.ts
+++ b/src/lib/config-capabilities.ts
@@ -1,0 +1,53 @@
+// CLI/src/lib/config-capabilities.ts
+//
+// Capability detection by metadata-shape probing.
+//
+// InsForge backends evolve independently per project. A user's CLI is always
+// the latest from npm; the project's backend may be on any prior release.
+// We need to know which TOML sections the connected backend actually supports
+// so apply/plan/export can degrade gracefully instead of silently dropping
+// fields or hanging on schema mismatch.
+//
+// The protocol: a feature is supported iff its corresponding key appears in
+// the raw `/api/metadata` response. Older backends that predate a feature
+// simply omit the key. The CLI infers support from presence/absence — no
+// version handshake, no new server endpoint.
+//
+// IMPORTANT: probe the RAW JSON, never the Zod-parsed object. Zod's
+// `.default([])` on the consumer schema would silently fill in absent fields
+// and erase the signal we're checking for.
+//
+// Server contract (documented in shared-schemas/metadata.schema.ts): when a
+// backend doesn't yet support a TOML-relevant field, its `/api/metadata`
+// response must OMIT the key — not emit it with an empty default. A
+// `cfg.allowedRedirectUrls ?? []` on the response builder for an unsupported
+// backend would defeat this probe.
+
+import type { DiffChange } from './config-diff.js';
+
+type RawMetadata = {
+  auth?: Record<string, unknown>;
+};
+
+/**
+ * True iff the backend's metadata response carries the field this change
+ * targets. Used to skip unsupported changes before we'd PUT to an endpoint
+ * that may silently drop the body.
+ */
+export function metadataSupports(raw: RawMetadata, change: DiffChange): boolean {
+  if (change.section === 'auth' && change.key === 'allowed_redirect_urls') {
+    return (
+      raw?.auth != null &&
+      typeof raw.auth === 'object' &&
+      'allowedRedirectUrls' in raw.auth
+    );
+  }
+  return false;
+}
+
+/**
+ * Human-readable path for a change, used in skipped/applied summaries.
+ */
+export function changePath(change: DiffChange): string {
+  return `${change.section}.${change.key}`;
+}

--- a/src/lib/config-capabilities.ts
+++ b/src/lib/config-capabilities.ts
@@ -37,7 +37,8 @@ type RawMetadata = {
 export function metadataSupports(raw: RawMetadata, change: DiffChange): boolean {
   if (change.section === 'auth' && change.key === 'allowed_redirect_urls') {
     return (
-      raw?.auth != null &&
+      raw?.auth !== undefined &&
+      raw.auth !== null &&
       typeof raw.auth === 'object' &&
       'allowedRedirectUrls' in raw.auth
     );

--- a/src/lib/config-diff.test.ts
+++ b/src/lib/config-diff.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { diffConfig } from './config-diff.js';
+
+describe('diffConfig', () => {
+  it('detects an array change in allowed_redirect_urls', () => {
+    const live = { auth: { allowed_redirect_urls: ['https://a.com'] } };
+    const file = { auth: { allowed_redirect_urls: ['https://a.com', 'https://b.com'] } };
+    expect(diffConfig({ live, file })).toEqual({
+      changes: [
+        {
+          section: 'auth',
+          op: 'modify',
+          key: 'allowed_redirect_urls',
+          from: ['https://a.com'],
+          to: ['https://a.com', 'https://b.com'],
+        },
+      ],
+      summary: { add: 0, modify: 1, remove: 0, kept: 0 },
+    });
+  });
+
+  it('returns no changes for converged state', () => {
+    const same = { auth: { allowed_redirect_urls: ['https://a.com'] } };
+    expect(diffConfig({ live: same, file: same })).toEqual({
+      changes: [],
+      summary: { add: 0, modify: 0, remove: 0, kept: 0 },
+    });
+  });
+
+  it('treats missing field in file as no-op (no remove)', () => {
+    const live = { auth: { allowed_redirect_urls: ['https://a.com'] } };
+    const file = {};
+    expect(diffConfig({ live, file })).toEqual({
+      changes: [],
+      summary: { add: 0, modify: 0, remove: 0, kept: 0 },
+    });
+  });
+
+  it('treats empty-array vs non-empty as a real change', () => {
+    const live = { auth: { allowed_redirect_urls: ['https://a.com'] } };
+    const file = { auth: { allowed_redirect_urls: [] } };
+    expect(diffConfig({ live, file }).changes).toEqual([
+      {
+        section: 'auth',
+        op: 'modify',
+        key: 'allowed_redirect_urls',
+        from: ['https://a.com'],
+        to: [],
+      },
+    ]);
+  });
+});

--- a/src/lib/config-diff.test.ts
+++ b/src/lib/config-diff.test.ts
@@ -49,4 +49,32 @@ describe('diffConfig', () => {
       },
     ]);
   });
+
+  it('treats reordered redirect URLs as no-op', () => {
+    const live = { auth: { allowed_redirect_urls: ['https://b.com', 'https://a.com'] } };
+    const file = { auth: { allowed_redirect_urls: ['https://a.com', 'https://b.com'] } };
+    expect(diffConfig({ live, file }).changes).toEqual([]);
+  });
+
+  it('deduplicates redirect URLs before comparing', () => {
+    const live = { auth: { allowed_redirect_urls: ['https://a.com', 'https://a.com'] } };
+    const file = { auth: { allowed_redirect_urls: ['https://a.com'] } };
+    expect(diffConfig({ live, file }).changes).toEqual([]);
+  });
+
+  it('emits normalized values when there is a real change', () => {
+    const live = { auth: { allowed_redirect_urls: ['https://b.com', 'https://a.com'] } };
+    const file = {
+      auth: { allowed_redirect_urls: ['https://c.com', 'https://a.com', 'https://b.com'] },
+    };
+    expect(diffConfig({ live, file }).changes).toEqual([
+      {
+        section: 'auth',
+        op: 'modify',
+        key: 'allowed_redirect_urls',
+        from: ['https://a.com', 'https://b.com'],
+        to: ['https://a.com', 'https://b.com', 'https://c.com'],
+      },
+    ]);
+  });
 });

--- a/src/lib/config-diff.ts
+++ b/src/lib/config-diff.ts
@@ -1,0 +1,67 @@
+import type { InsforgeConfig } from './config-schema.js';
+
+export type DiffChange = {
+  section: 'auth';
+  op: 'modify';
+  key: 'allowed_redirect_urls';
+  from: string[];
+  to: string[];
+};
+
+export interface DiffSummary {
+  add: number;
+  modify: number;
+  remove: number;
+  kept: number;
+}
+
+export interface DiffResult {
+  changes: DiffChange[];
+  summary: DiffSummary;
+}
+
+export interface DiffInput {
+  live: InsforgeConfig;
+  file: InsforgeConfig;
+}
+
+/**
+ * Compute the changes the file would impose on the live state.
+ * v1 scope: auth.allowed_redirect_urls only. Default-keep for absent fields
+ * — if the file omits a section, live state is left alone.
+ */
+export function diffConfig({ live, file }: DiffInput): DiffResult {
+  const changes: DiffChange[] = [];
+
+  const fileAuth = file.auth;
+  const liveAuth = live.auth ?? {};
+
+  if (fileAuth && 'allowed_redirect_urls' in fileAuth) {
+    const fromV = liveAuth.allowed_redirect_urls ?? [];
+    const toV = fileAuth.allowed_redirect_urls ?? [];
+    if (!arrayEquals(fromV, toV)) {
+      changes.push({
+        section: 'auth',
+        op: 'modify',
+        key: 'allowed_redirect_urls',
+        from: fromV,
+        to: toV,
+      });
+    }
+  }
+
+  return { changes, summary: summarize(changes) };
+}
+
+function summarize(changes: DiffChange[]): DiffSummary {
+  const s: DiffSummary = { add: 0, modify: 0, remove: 0, kept: 0 };
+  for (const c of changes) {
+    if (c.op === 'modify') s.modify++;
+  }
+  return s;
+}
+
+function arrayEquals(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((v, i) => v === b[i]);
+}

--- a/src/lib/config-diff.ts
+++ b/src/lib/config-diff.ts
@@ -37,8 +37,12 @@ export function diffConfig({ live, file }: DiffInput): DiffResult {
   const liveAuth = live.auth ?? {};
 
   if (fileAuth && 'allowed_redirect_urls' in fileAuth) {
-    const fromV = liveAuth.allowed_redirect_urls ?? [];
-    const toV = fileAuth.allowed_redirect_urls ?? [];
+    // Treat the redirect allowlist as a set: order and duplicates in the TOML
+    // shouldn't produce a diff. Reorder/dedupe both sides before comparing,
+    // and emit the normalized values so the change rendered to the user
+    // (and the request body sent on apply) matches what's actually different.
+    const fromV = normalizeUrlList(liveAuth.allowed_redirect_urls);
+    const toV = normalizeUrlList(fileAuth.allowed_redirect_urls);
     if (!arrayEquals(fromV, toV)) {
       changes.push({
         section: 'auth',
@@ -59,6 +63,10 @@ function summarize(changes: DiffChange[]): DiffSummary {
     if (c.op === 'modify') s.modify++;
   }
   return s;
+}
+
+function normalizeUrlList(input: string[] | undefined): string[] {
+  return Array.from(new Set(input ?? [])).sort();
 }
 
 function arrayEquals(a: string[], b: string[]): boolean {

--- a/src/lib/config-format.test.ts
+++ b/src/lib/config-format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatPlan } from './config-format.js';
+
+describe('formatPlan', () => {
+  it('renders a single-section plan', () => {
+    const out = formatPlan({
+      changes: [
+        {
+          section: 'auth',
+          op: 'modify',
+          key: 'allowed_redirect_urls',
+          from: ['https://a.com'],
+          to: ['https://a.com', 'https://b.com'],
+        },
+      ],
+      summary: { add: 0, modify: 1, remove: 0, kept: 0 },
+    });
+    expect(out).toContain('auth:');
+    expect(out).toContain('~ allowed_redirect_urls:');
+    expect(out).toContain('["https://a.com"]');
+    expect(out).toContain('["https://a.com","https://b.com"]');
+    expect(out).toContain('0 add, 1 modify, 0 remove, 0 untracked kept.');
+  });
+
+  it('renders no-change plans cleanly', () => {
+    const out = formatPlan({
+      changes: [],
+      summary: { add: 0, modify: 0, remove: 0, kept: 0 },
+    });
+    expect(out).toContain('No changes. Live state matches insforge.toml.');
+  });
+});

--- a/src/lib/config-format.ts
+++ b/src/lib/config-format.ts
@@ -1,0 +1,34 @@
+import type { DiffChange, DiffResult } from './config-diff.js';
+
+export function formatPlan(result: DiffResult): string {
+  if (result.changes.length === 0) {
+    return 'No changes. Live state matches insforge.toml.';
+  }
+
+  const bySection = new Map<string, DiffChange[]>();
+  for (const c of result.changes) {
+    const arr = bySection.get(c.section) ?? [];
+    arr.push(c);
+    bySection.set(c.section, arr);
+  }
+
+  const lines: string[] = [];
+  for (const [section, changes] of bySection) {
+    lines.push(`  ${section}:`);
+    for (const c of changes) {
+      lines.push(`    ${formatChange(c)}`);
+    }
+    lines.push('');
+  }
+
+  const s = result.summary;
+  lines.push(
+    `${s.add} add, ${s.modify} modify, ${s.remove} remove, ${s.kept} untracked kept.`,
+  );
+
+  return lines.join('\n');
+}
+
+function formatChange(c: DiffChange): string {
+  return `~ ${c.key}: ${JSON.stringify(c.from)} → ${JSON.stringify(c.to)}`;
+}

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -1,0 +1,66 @@
+// CLI/src/lib/config-schema.ts
+
+/**
+ * The shape of insforge.toml after parsing. v1 MVP scope: only the
+ * [auth] allowed_redirect_urls field is wired. Every future section
+ * (SMTP, OAuth providers, deployments, etc.) extends this type.
+ */
+export interface InsforgeConfig {
+  project_id?: string;
+  auth?: AuthConfig;
+}
+
+export interface AuthConfig {
+  allowed_redirect_urls?: string[];
+}
+
+export class ConfigValidationError extends Error {
+  constructor(public readonly path: string, message: string) {
+    super(`config.${path}: ${message}`);
+    this.name = 'ConfigValidationError';
+  }
+}
+
+/**
+ * Validates a parsed TOML object against the v1 schema.
+ * Throws ConfigValidationError with the path of the first violation.
+ */
+export function validateConfig(input: unknown): InsforgeConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ConfigValidationError('', 'must be an object');
+  }
+  const obj = input as Record<string, unknown>;
+  const out: InsforgeConfig = {};
+
+  if ('project_id' in obj) {
+    if (typeof obj.project_id !== 'string') {
+      throw new ConfigValidationError('project_id', 'must be a string');
+    }
+    out.project_id = obj.project_id;
+  }
+
+  if ('auth' in obj) out.auth = validateAuth(obj.auth);
+
+  return out;
+}
+
+function validateAuth(input: unknown): AuthConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ConfigValidationError('auth', 'must be an object');
+  }
+  const obj = input as Record<string, unknown>;
+  const out: AuthConfig = {};
+
+  if ('allowed_redirect_urls' in obj) {
+    const v = obj.allowed_redirect_urls;
+    if (!Array.isArray(v) || !v.every((u) => typeof u === 'string')) {
+      throw new ConfigValidationError(
+        'auth.allowed_redirect_urls',
+        'must be an array of strings',
+      );
+    }
+    out.allowed_redirect_urls = v;
+  }
+
+  return out;
+}

--- a/src/lib/config-secrets.test.ts
+++ b/src/lib/config-secrets.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnvRef, validateSensitiveString } from './config-secrets.js';
+import { ConfigValidationError } from './config-schema.js';
+
+describe('parseEnvRef', () => {
+  it('extracts the secret name from a well-formed env() reference', () => {
+    expect(parseEnvRef('env(GOOGLE_CLIENT_SECRET)')).toBe('GOOGLE_CLIENT_SECRET');
+    expect(parseEnvRef('env(SMTP_PASSWORD)')).toBe('SMTP_PASSWORD');
+    expect(parseEnvRef('env(_INTERNAL)')).toBe('_INTERNAL');
+  });
+
+  it('returns null for literal values', () => {
+    expect(parseEnvRef('actual-secret-123')).toBeNull();
+    expect(parseEnvRef('')).toBeNull();
+    expect(parseEnvRef('env(lower_case)')).toBeNull();
+    expect(parseEnvRef('env(WITH SPACE)')).toBeNull();
+    expect(parseEnvRef('env()')).toBeNull();
+    expect(parseEnvRef('something env(GOOD)')).toBeNull();
+    expect(parseEnvRef('env(GOOD) and more')).toBeNull();
+  });
+});
+
+describe('validateSensitiveString', () => {
+  it('accepts well-formed env() references', () => {
+    expect(
+      validateSensitiveString(
+        'email.smtp.password',
+        'env(SMTP_PASSWORD)',
+        'SMTP_PASSWORD',
+      ),
+    ).toBe('env(SMTP_PASSWORD)');
+  });
+
+  it('rejects literal values with an actionable error', () => {
+    let caught: ConfigValidationError | null = null;
+    try {
+      validateSensitiveString(
+        'email.smtp.password',
+        'MyActualPassword',
+        'SMTP_PASSWORD',
+      );
+    } catch (err) {
+      caught = err as ConfigValidationError;
+    }
+    expect(caught).toBeInstanceOf(ConfigValidationError);
+    expect(caught!.path).toBe('email.smtp.password');
+    expect(caught!.message).toContain('sensitive field must be an env() reference');
+    expect(caught!.message).toContain('insforge secrets add SMTP_PASSWORD');
+    expect(caught!.message).toContain('password = "env(SMTP_PASSWORD)"');
+  });
+
+  it('rejects malformed env() references (lowercase, empty, etc.)', () => {
+    expect(() =>
+      validateSensitiveString('x.y', 'env(lower_case)', 'GOOD_NAME'),
+    ).toThrow(ConfigValidationError);
+    expect(() => validateSensitiveString('x.y', 'env()', 'GOOD_NAME')).toThrow(
+      ConfigValidationError,
+    );
+  });
+
+  it('rejects non-string values', () => {
+    expect(() => validateSensitiveString('x.y', 123, 'GOOD_NAME')).toThrow(
+      /must be a string/,
+    );
+    expect(() => validateSensitiveString('x.y', null, 'GOOD_NAME')).toThrow(
+      /must be a string/,
+    );
+    expect(() =>
+      validateSensitiveString('x.y', undefined, 'GOOD_NAME'),
+    ).toThrow(/must be a string/);
+  });
+});

--- a/src/lib/config-secrets.ts
+++ b/src/lib/config-secrets.ts
@@ -1,0 +1,72 @@
+// CLI/src/lib/config-secrets.ts
+//
+// Sensitive-field validation for insforge.toml.
+//
+// Sensitive fields (OAuth client_secret, SMTP password, S3 secret key, etc.)
+// MUST be `env(NAME)` references in the TOML — never literal values. This is
+// the same convention used by Vercel (vercel.json), Fly.io (fly.toml), and
+// Supabase (supabase/config.toml). Rejecting literals at validation time
+// makes the file unconditionally safe to commit to git.
+//
+// The actual secret VALUES live in the project's secrets store
+// (`insforge secrets add NAME <value>`). The server resolves env() refs at
+// apply time and fails loudly if the named secret is missing.
+//
+// This module is registered in config-schema.ts when sensitive fields are
+// added to the TOML surface (SMTP password, OAuth client_secret, etc.).
+// The MVP scope ([auth] allowed_redirect_urls only) has zero sensitive
+// fields, so the validator is foundation-laid-but-not-yet-used. The first
+// section to use it will be [email.smtp] or [auth.providers.<built_in>].
+
+import { ConfigValidationError } from './config-schema.js';
+
+/** Matches `env(NAME)` where NAME is upper-snake-case. */
+const ENV_REF_PATTERN = /^env\(([A-Z_][A-Z0-9_]*)\)$/;
+
+/**
+ * Returns the secret name (e.g. "GOOGLE_CLIENT_SECRET") if the value is a
+ * well-formed env() reference. Returns null otherwise.
+ */
+export function parseEnvRef(value: string): string | null {
+  const match = value.match(ENV_REF_PATTERN);
+  return match ? match[1] : null;
+}
+
+/**
+ * Validate a sensitive string field. Returns the env() reference unchanged
+ * if it's well-formed; otherwise throws ConfigValidationError with an
+ * actionable error message that names the exact `insforge secrets add`
+ * command the user should run.
+ *
+ * @param path  The dotted path of the field (e.g. "email.smtp.password"),
+ *              used in the error message.
+ * @param value The value parsed from TOML — typically a string, but we
+ *              accept unknown to keep the validator caller simple.
+ * @param suggestedSecretName The conventional name to suggest in the error
+ *              if the user pasted a literal (e.g. "SMTP_PASSWORD"). Should
+ *              be UPPER_SNAKE_CASE.
+ */
+export function validateSensitiveString(
+  path: string,
+  value: unknown,
+  suggestedSecretName: string,
+): string {
+  if (typeof value !== 'string') {
+    throw new ConfigValidationError(path, 'must be a string');
+  }
+
+  if (parseEnvRef(value) !== null) {
+    return value;
+  }
+
+  // Literal value (or malformed env() ref). Reject with an actionable error.
+  throw new ConfigValidationError(
+    path,
+    `sensitive field must be an env() reference; got literal value.\n` +
+      `  fix:\n` +
+      `    1. insforge secrets add ${suggestedSecretName} "<value>"\n` +
+      `    2. update insforge.toml:\n` +
+      `         ${path.split('.').pop()} = "env(${suggestedSecretName})"\n` +
+      `    3. insforge config apply`,
+  );
+}

--- a/src/lib/config-toml.test.ts
+++ b/src/lib/config-toml.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { parseConfigToml, stringifyConfigToml } from './config-toml.js';
+
+describe('parseConfigToml', () => {
+  it('parses MVP fields end-to-end', () => {
+    const toml = `
+project_id = "proj-abc"
+
+[auth]
+allowed_redirect_urls = ["https://app.example.com", "http://localhost:3000"]
+`;
+    expect(parseConfigToml(toml)).toEqual({
+      project_id: 'proj-abc',
+      auth: {
+        allowed_redirect_urls: ['https://app.example.com', 'http://localhost:3000'],
+      },
+    });
+  });
+
+  it('throws ConfigValidationError on bad type', () => {
+    expect(() =>
+      parseConfigToml('[auth]\nallowed_redirect_urls = "not-an-array"'),
+    ).toThrow(/allowed_redirect_urls.*array of strings/);
+  });
+
+  it('throws on malformed TOML with a clear message', () => {
+    expect(() => parseConfigToml('[auth\nbroken')).toThrow(/TOML parse error/);
+  });
+
+  it('accepts an empty config', () => {
+    expect(parseConfigToml('')).toEqual({});
+  });
+});
+
+describe('stringifyConfigToml', () => {
+  it('round-trips a config through stringify → parse', () => {
+    const original = {
+      project_id: 'proj-abc',
+      auth: { allowed_redirect_urls: ['https://a.com', 'http://localhost:3000'] },
+    };
+    expect(parseConfigToml(stringifyConfigToml(original))).toEqual(original);
+  });
+
+  it('omits sections that are undefined', () => {
+    const out = stringifyConfigToml({ project_id: 'proj-x' });
+    expect(out).toContain('project_id');
+    expect(out).not.toContain('[auth]');
+  });
+});

--- a/src/lib/config-toml.ts
+++ b/src/lib/config-toml.ts
@@ -6,7 +6,7 @@ export function parseConfigToml(input: string): InsforgeConfig {
   try {
     parsed = smolToml.parse(input);
   } catch (err) {
-    throw new Error(`TOML parse error: ${(err as Error).message}`);
+    throw new Error(`TOML parse error: ${(err as Error).message}`, { cause: err });
   }
   return validateConfig(parsed);
 }

--- a/src/lib/config-toml.ts
+++ b/src/lib/config-toml.ts
@@ -1,0 +1,38 @@
+import * as smolToml from 'smol-toml';
+import { validateConfig, type InsforgeConfig } from './config-schema.js';
+
+export function parseConfigToml(input: string): InsforgeConfig {
+  let parsed: unknown;
+  try {
+    parsed = smolToml.parse(input);
+  } catch (err) {
+    throw new Error(`TOML parse error: ${(err as Error).message}`);
+  }
+  return validateConfig(parsed);
+}
+
+/**
+ * Render a normalized config back to TOML. Section ordering is deterministic
+ * (project_id → auth) so diffs are stable across runs of `insforge config export`.
+ */
+export function stringifyConfigToml(config: InsforgeConfig): string {
+  const lines: string[] = [];
+
+  if (config.project_id !== undefined) {
+    lines.push(`project_id = ${JSON.stringify(config.project_id)}`);
+    lines.push('');
+  }
+
+  if (config.auth) {
+    lines.push('[auth]');
+    if (config.auth.allowed_redirect_urls !== undefined) {
+      const urls = config.auth.allowed_redirect_urls
+        .map((u) => JSON.stringify(u))
+        .join(', ');
+      lines.push(`allowed_redirect_urls = [${urls}]`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').replace(/\n+$/, '\n');
+}


### PR DESCRIPTION
**Companion to:** `InsForge/InsForge#1216` (backend half — extends \`/api/metadata\` to surface \`auth.allowed_redirect_urls\`)

## What

Adds three CLI commands that round-trip a single TOML field — `[auth] allowed_redirect_urls` — between \`insforge.toml\` and the live project state:

\`\`\`bash
insforge config export    # GET /api/metadata → write insforge.toml
insforge config plan      # diff TOML vs metadata, print plan
insforge config apply     # plan → confirm → PUT /api/auth/config
\`\`\`

This is the smallest possible vertical slice of the config-as-code feature. Everything else (SMTP, OAuth providers, custom domains, etc.) is matrix-fill on top of this architecture.

## Why

Agents can't make fine-grained config changes today — setting up a custom domain, configuring SMTP, changing an auth redirect URL all require dashboard clicks (invisible, not reproducible) or per-field CLI subcommands (sprawls fast, no PR diff). With ~100 config knobs across the platform, per-field CLI is the wrong shape.

This PR ships the TOML + apply loop with the smallest possible scope so the architecture proves out before we widen the surface. Full design in \`spec-toml-mvp.md\` and \`proposal-insforge-config-toml.md\`.

## What this PR contains

9 commits, all on \`feat/insforge-toml-mvp\` off \`main\`:

- \`chore(cli): add smol-toml for insforge.toml parsing\`
- \`feat(cli): add config schema for v1 MVP\` — types + validator
- \`feat(cli): add TOML <-> JSON codec\` — parse + stringify with stable ordering
- \`feat(cli): add structured per-section config diff\` — default-keep semantics
- \`feat(cli): add human-readable plan formatter\` — human + JSON output
- \`feat(cli): scaffold insforge config subcommand\` — registrar in src/index.ts
- \`feat(cli): add insforge config export\`
- \`feat(cli): add insforge config plan\`
- \`feat(cli): add insforge config apply\` — plan-confirm-apply with --dry-run / --auto-approve

**Lib:** 6 files in \`src/lib/config-{schema,toml,diff,format}.ts\` + tests
**Commands:** 4 files in \`src/commands/config/{index,export,plan,apply}.ts\`
**Tests:** 12 vitest tests, all green

## What this PR does NOT do

- No new server endpoints (read uses existing \`/api/metadata\`; write uses existing \`PUT /api/auth/config\`)
- No matrix-fill — only \`[auth] allowed_redirect_urls\` is wired. Future sections each add ~50 LOC to this same dispatch table.
- No \`config pull\` — \`config export\` does that job (overwrites with --force, prompts otherwise)
- No three-way diff with \`last_applied\` — v1 stateless; \`plan\` shows file ↔ live, that's enough for now

## Behaviors that distinguish this from Supabase \`config push\`

1. **Plan first, always.** \`apply\` prints the diff before any write; prompts (unless \`--auto-approve\`).
2. **Default-keep.** Items in DB that aren't in the file are kept (no silent overwrite). \`--prune\` opt-in coming with future sections that need it.
3. **Idempotent.** Re-applying converged state is a strict no-op — verified in the smoke test.

## Smoke test (against mock backend)

End-to-end loop verified locally:

1. \`config export\` writes \`insforge.toml\` from \`GET /api/metadata\` ✓
2. \`config plan\` on converged state: \"No changes. Live state matches insforge.toml.\" ✓
3. Edit TOML → \`config plan\` shows: \`~ allowed_redirect_urls: [\"a\"] → [\"a\",\"b\",\"c\"]\` ✓
4. \`config apply --auto-approve\` calls \`PUT /api/auth/config\`, reports \`✓ Applied (0 added, 1 modified, 0 removed)\` ✓
5. Re-apply is a no-op (idempotence) ✓
6. Mock backend live state matches what's in TOML ✓

## Test plan

- [x] \`npx vitest run src/lib/config-toml.test.ts src/lib/config-diff.test.ts src/lib/config-format.test.ts\` — 12/12 green
- [x] \`npm run build\` — clean, 311KB ESM dist
- [x] \`node dist/index.js config --help\` shows export/plan/apply
- [x] End-to-end against mock backend (above)
- [ ] Live E2E against running InsForge backend (requires backend PR \`#1216\` merged + project linked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `insforge config export/plan/apply` to manage `[auth] allowed_redirect_urls` in `insforge.toml`. Probes `/api/metadata`, shows a plan, and applies only supported fields; also adds `env(NAME)` validation foundation for sensitive fields and prints the service port in compute deploy/update.

- **New Features**
  - Config commands: export writes only supported fields and reports `skipped`; plan diffs file vs live (human or JSON) and surfaces `skipped`; apply shows plan, supports `--dry-run`, prompts unless `--auto-approve`/`-y`, writes via `PUT /api/auth/config`, and `--json` prints one object.
  - Minimal v1 schema and TOML↔JSON codec using `smol-toml` with stable ordering; human plan formatter.
  - `env()` reference validator for sensitive fields (foundation; not yet wired).

- **Bug Fixes**
  - Diff normalizes `allowed_redirect_urls` (sort + dedupe); reorders/dupes are no-ops; emitted values are normalized.
  - JSON/confirm behavior: `apply --json` requires explicit consent and honors `-y/--yes`; `export --json` fails fast if the output file exists without `--force`.
  - CLI UX: clearer TOML parse errors (preserve cause); compute `deploy/update` now prints `Port: <n>` on success.

<sup>Written for commit a9947c65bf110dea3378299c1603d29a259636cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level "config" command with export, plan, and apply subcommands; plan shows diffs (text or JSON), export writes TOML with overwrite/force handling, apply supports dry-run, auto‑approve, and JSON output.

* **Bug Fixes / Behavior**
  * Apply only updates allowed redirect URLs, skips unsupported sections and reports skipped items with reasons.

* **Tests**
  * Added comprehensive tests for diffing, plan formatting, TOML parse/serialize, validation, capability probing, and CLI flows.

* **Chores**
  * Added smol-toml dependency; posthog-node remains at the same version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->