### PR TITLE
fix(branch): -y flag was shadowed by same-named global option (+ bump 0.1.69)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/branch/delete.ts
+++ b/src/commands/branch/delete.ts
@@ -12,9 +12,8 @@ export function registerBranchDeleteCommand(branch: Command): void {
   branch
     .command('delete <name>')
     .description('Delete a branch')
-    .option('-y, --yes', 'Skip confirmation')
-    .action(async (name: string, opts: { yes?: boolean }, cmd) => {
-      const { json, apiUrl } = getRootOpts(cmd);
+    .action(async (name: string, _opts: Record<string, never>, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
       try {
         await requireAuth(apiUrl);
         const project = getProjectConfig();
@@ -25,7 +24,7 @@ export function registerBranchDeleteCommand(branch: Command): void {
         const target = branches.find(b => b.name === name);
         if (!target) throw new CLIError(`Branch '${name}' not found.`);
 
-        if (!opts.yes && !json) {
+        if (!yes && !json) {
           const confirmed = await clack.confirm({
             message: `Delete branch '${name}'? This terminates its EC2 instance.`,
           });

--- a/src/commands/branch/merge.test.ts
+++ b/src/commands/branch/merge.test.ts
@@ -53,10 +53,18 @@ vi.mock('../../lib/analytics.js', () => ({
   shutdownAnalytics: vi.fn(async () => {}),
 }));
 
+const clackConfirmMock = vi.hoisted(() => vi.fn(async () => true));
+vi.mock('@clack/prompts', () => ({
+  confirm: clackConfirmMock,
+  isCancel: () => false,
+}));
+
 describe('branch merge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fsMock.writeFileSync.mockReset();
+    clackConfirmMock.mockClear();
+    clackConfirmMock.mockResolvedValue(true);
   });
 
   it('--dry-run prints rendered_sql + summary, does not call execute', async () => {
@@ -108,6 +116,27 @@ describe('branch merge', () => {
     } finally {
       console.log = origLog;
     }
+    const { mergeBranchExecuteApi } = await import('../../lib/api/platform.js');
+    expect(mergeBranchExecuteApi).toHaveBeenCalledWith('b1', undefined);
+  });
+
+  // Regression: -y on the merge subcommand previously got shadowed by the
+  // same-named global option, so the prompt fired even when the user passed -y.
+  // Test nests under a `branch` parent to mirror the real CLI wiring, since
+  // the shadowing only manifested through that registration path.
+  it('-y after positional skips confirmation prompt (no --json)', async () => {
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    const branch = program.command('branch');
+    registerBranchMergeCommand(branch);
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await program.parseAsync(['branch', 'merge', 'feat-x', '-y'], { from: 'user' });
+    } finally {
+      console.log = origLog;
+    }
+    expect(clackConfirmMock).not.toHaveBeenCalled();
     const { mergeBranchExecuteApi } = await import('../../lib/api/platform.js');
     expect(mergeBranchExecuteApi).toHaveBeenCalledWith('b1', undefined);
   });

--- a/src/commands/branch/merge.ts
+++ b/src/commands/branch/merge.ts
@@ -14,7 +14,6 @@ import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 
 interface MergeOptions {
   dryRun?: boolean;
-  yes?: boolean;
   saveSql?: string;
 }
 
@@ -23,10 +22,9 @@ export function registerBranchMergeCommand(branch: Command): void {
     .command('merge <name>')
     .description('Merge a branch back to its parent project')
     .option('--dry-run', 'Compute the diff and print rendered SQL; do not apply')
-    .option('-y, --yes', 'Skip confirmation prompt')
     .option('--save-sql <path>', 'Write rendered SQL preview to a file')
     .action(async (name: string, opts: MergeOptions, cmd) => {
-      const { json, apiUrl } = getRootOpts(cmd);
+      const { json, apiUrl, yes } = getRootOpts(cmd);
       try {
         await requireAuth(apiUrl);
         const project = getProjectConfig();
@@ -89,7 +87,7 @@ export function registerBranchMergeCommand(branch: Command): void {
         }
 
         // Confirm before executing (unless --yes or --json).
-        if (!opts.yes && !json) {
+        if (!yes && !json) {
           const parentLabel = project.branched_from?.project_name ?? project.project_name;
           const confirmed = await clack.confirm({
             message: `Apply this merge to parent project '${parentLabel}'?`,

--- a/src/commands/branch/reset.ts
+++ b/src/commands/branch/reset.ts
@@ -18,9 +18,8 @@ export function registerBranchResetCommand(branch: Command): void {
   branch
     .command('reset <name>')
     .description("Reset a branch's database back to T0 (the parent snapshot at branch creation)")
-    .option('-y, --yes', 'Skip confirmation')
-    .action(async (name: string, opts: { yes?: boolean }, cmd) => {
-      const { json, apiUrl } = getRootOpts(cmd);
+    .action(async (name: string, _opts: Record<string, never>, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
       try {
         await requireAuth(apiUrl);
         const project = getProjectConfig();
@@ -40,7 +39,7 @@ export function registerBranchResetCommand(branch: Command): void {
         }
         const entryState = target.branch_state;
 
-        if (!opts.yes && !json) {
+        if (!yes && !json) {
           const confirmed = await clack.confirm({
             message:
               `Reset branch '${name}' back to T0? This wipes all schema/data/policy/function/migration changes made on the branch since creation.` +


### PR DESCRIPTION
## Summary
- `npx @insforge/cli branch merge <name> -y` (and `branch reset` / `branch delete`) still prompted for confirmation, blocking agent-driven automation. Commander v13 assigns the value to the **parent program's** option when both parent and subcommand declare the same flag, leaving the subcommand's `opts.yes` undefined. `-y, --yes` is already a global option on the root program, so the redundant local declarations on these subcommands were what triggered the shadowing.
- Fix: drop the local `-y, --yes` declarations and read `yes` from `getRootOpts(cmd)`, which already walks to the root program.
- Bumps version to 0.1.69.

## Test plan
- [x] `npx vitest run` — 188 passed, 13 skipped
- [x] New regression test in `merge.test.ts` nests under a `branch` parent (matching the real CLI wiring) and asserts `clack.confirm` is **not** called when `-y` is passed without `--json`. The prior `--yes` test paired with `--json`, where `--json` alone bypassed the prompt — so it never actually exercised `-y`.
- [ ] Manual verification after release: `npx @insforge/cli@0.1.69 branch merge <name> -y` exits without prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `-y/--yes` being ignored on `branch merge`, `branch reset`, and `branch delete`, so these commands no longer prompt when `-y` is passed. Bumps `@insforge/cli` to 0.1.69.

- **Bug Fixes**
  - Removed local `-y, --yes` from branch subcommands and read `yes` from root via `getRootOpts(cmd)`.
  - Added a regression test (nested under `branch`) to ensure no confirmation prompt when `-y` is used without `--json`.

<sup>Written for commit 053a3088b2b77e33aa49b10eebc5c37c6a83ec55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.1.69

* **Tests**
  * Added regression test for the `--yes` flag on branch merge subcommand

<!-- end of auto-generated comment: release notes by coderabbit.ai -->