### PR TITLE
fix switch bug(oss host), and optimise branch create flow.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/branch/create.test.ts
+++ b/src/commands/branch/create.test.ts
@@ -203,6 +203,50 @@ describe('branch create', () => {
     expect(() => JSON.parse(logs.join('\n'))).not.toThrow();
   });
 
+  it('switch failure after a successful create reports "switch failed", not "creation failed"', async () => {
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as any).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+      appkey: 'p1ky',
+      region: 'us-east',
+      api_key: 'k',
+      oss_host: 'https://p1ky.us-east.insforge.app',
+    });
+    const { runBranchSwitch } = await import('./switch.js');
+    (runBranchSwitch as any).mockRejectedValueOnce(new Error('network down'));
+
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    let exitCode: number | undefined;
+    const origExit = process.exit;
+    (process.exit as any) = (code?: number) => {
+      exitCode = code;
+      throw new Error('__exit__');
+    };
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as any;
+    try {
+      await program
+        .parseAsync(['create', 'feat-x', '--mode', 'full'], { from: 'user' })
+        .catch(() => {});
+    } finally {
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+    }
+    expect(exitCode).toBe(1);
+    // The crucial assertion: spinner stops with switch-failure copy, not
+    // the misleading "creation failed" line.
+    expect(spinnerMock.stop).toHaveBeenCalledTimes(1);
+    const [stopMsg, stopCode] = spinnerMock.stop.mock.calls[0];
+    expect(stopMsg).toContain('switching context failed');
+    expect(stopMsg).toContain('insforge branch switch feat-x');
+    expect(stopMsg).not.toContain('creation failed');
+    expect(stopCode).toBe(1);
+  });
+
   it('non-JSON path drives the spinner and keeps it active through switch', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
     (getProjectConfig as any).mockReturnValue({

--- a/src/commands/branch/create.test.ts
+++ b/src/commands/branch/create.test.ts
@@ -50,9 +50,22 @@ vi.mock('./switch.js', () => ({
   registerBranchSwitchCommand: vi.fn(),
 }));
 
+// Capture spinner method calls so the non-JSON path can assert on them.
+const spinnerMock = {
+  start: vi.fn(),
+  message: vi.fn(),
+  stop: vi.fn(),
+};
+vi.mock('@clack/prompts', () => ({
+  spinner: () => spinnerMock,
+}));
+
 describe('branch create', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    spinnerMock.start.mockReset();
+    spinnerMock.message.mockReset();
+    spinnerMock.stop.mockReset();
   });
 
   it('rejects when no project linked', async () => {
@@ -188,5 +201,39 @@ describe('branch create', () => {
     );
     // Single JSON payload, parseable as one document.
     expect(() => JSON.parse(logs.join('\n'))).not.toThrow();
+  });
+
+  it('non-JSON path drives the spinner and keeps it active through switch', async () => {
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as any).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+      appkey: 'p1ky',
+      region: 'us-east',
+      api_key: 'k',
+      oss_host: 'https://p1ky.us-east.insforge.app',
+    });
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    await program.parseAsync(['create', 'feat-x', '--mode', 'full'], { from: 'user' });
+
+    // start fires once for the slow POST...
+    expect(spinnerMock.start).toHaveBeenCalledTimes(1);
+    expect(spinnerMock.start).toHaveBeenCalledWith(expect.stringContaining("Creating branch 'feat-x'"));
+    // ...and stop fires exactly once (after the switch completes), with the
+    // unified "ready and active" message — never with the misleading "ready"
+    // line that a separate stop+restart pair would produce.
+    expect(spinnerMock.stop).toHaveBeenCalledTimes(1);
+    expect(spinnerMock.stop).toHaveBeenCalledWith(
+      expect.stringContaining('ready and active'),
+    );
+    // Switch ran silently so its outputSuccess does not interleave with the
+    // active spinner frame.
+    const { runBranchSwitch } = await import('./switch.js');
+    expect(runBranchSwitch).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'feat-x', json: false, silent: true }),
+    );
   });
 });

--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -1,9 +1,10 @@
 import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
 import { createBranchApi, getBranchApi } from '../../lib/api/platform.js';
 import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { getProjectConfig } from '../../lib/config.js';
-import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
+import { outputJson, outputInfo } from '../../lib/output.js';
 import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 import { runBranchSwitch } from './switch.js';
 import type { Branch, BranchMode } from '../../types.js';
@@ -37,20 +38,33 @@ export function registerBranchCreateCommand(branch: Command): void {
         }
         const mode = opts.mode as BranchMode;
 
-        const created = await createBranchApi(project.project_id, { mode, name }, apiUrl);
-        captureEvent(project.project_id, 'cli_branch_create', {
-          mode,
-          parent_project_id: project.project_id,
-        });
-
-        if (!json) {
-          outputSuccess(`Branch '${name}' created (appkey: ${created.appkey}). Provisioning…`);
+        // Single spinner spans the slow POST and the provisioning poll so the
+        // user sees continuous progress instead of a 2-minute silent hang.
+        // JSON mode skips the spinner — `outputJson({ branch: ready })` below
+        // remains the sole authoritative output.
+        const spinner = !json ? clack.spinner() : null;
+        let ready: Branch;
+        try {
+          spinner?.start(`Creating branch '${name}'...`);
+          const created = await createBranchApi(project.project_id, { mode, name }, apiUrl);
+          captureEvent(project.project_id, 'cli_branch_create', {
+            mode,
+            parent_project_id: project.project_id,
+          });
+          spinner?.message(`Branch '${name}' created (appkey: ${created.appkey}). Provisioning...`);
+          ready = await pollUntilReady(created.id, apiUrl, spinner);
+          if (ready.branch_state === 'ready') {
+            spinner?.stop(`Branch '${name}' is ready`);
+          } else {
+            spinner?.stop(`Branch '${name}' is in '${ready.branch_state}' state`);
+          }
+        } catch (err) {
+          spinner?.stop(`Branch '${name}' creation failed`, 1);
+          throw err;
         }
 
-        const ready = await pollUntilReady(created.id, apiUrl, !json);
-
-        // Run auto-switch BEFORE emitting the final success/JSON payload so a
-        // failed switch does not surface as a successful create.
+        // Run auto-switch BEFORE emitting the final JSON payload so a failed
+        // switch does not surface as a successful create.
         if (opts.switch && ready.branch_state === 'ready') {
           // silent in JSON mode so we don't emit two JSON documents — the
           // single `outputJson({ branch: ready })` below is authoritative.
@@ -60,7 +74,6 @@ export function registerBranchCreateCommand(branch: Command): void {
         if (json) {
           outputJson({ branch: ready });
         } else if (ready.branch_state === 'ready') {
-          outputSuccess(`Branch '${name}' is ready.`);
           if (opts.switch) {
             outputInfo(
               '⚠ Re-source your dev server env (.env) to pick up the new INSFORGE_URL / ANON_KEY.',
@@ -82,7 +95,7 @@ export function registerBranchCreateCommand(branch: Command): void {
 async function pollUntilReady(
   branchId: string,
   apiUrl: string | undefined,
-  showProgress: boolean,
+  spinner: ReturnType<typeof clack.spinner> | null,
 ): Promise<Branch> {
   const start = Date.now();
   let lastState = '';
@@ -92,8 +105,8 @@ async function pollUntilReady(
     if (branch.branch_state === 'deleted' || branch.branch_state === 'conflicted') {
       throw new CLIError(`Branch creation failed (state: ${branch.branch_state})`);
     }
-    if (showProgress && branch.branch_state !== lastState) {
-      outputInfo(`  state: ${branch.branch_state}…`);
+    if (spinner && branch.branch_state !== lastState) {
+      spinner.message(`Provisioning branch (state: ${branch.branch_state})...`);
       lastState = branch.branch_state;
     }
     await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));

--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -38,10 +38,12 @@ export function registerBranchCreateCommand(branch: Command): void {
         }
         const mode = opts.mode as BranchMode;
 
-        // Single spinner spans the slow POST and the provisioning poll so the
-        // user sees continuous progress instead of a 2-minute silent hang.
-        // JSON mode skips the spinner — `outputJson({ branch: ready })` below
-        // remains the sole authoritative output.
+        // Single spinner spans the slow POST, provisioning poll, and the
+        // optional auto-switch. The user sees continuous progress instead of a
+        // 2-minute silent hang, and a switch failure is rendered with the same
+        // red error frame as a create failure (no misleading "ready" line
+        // before an error). JSON mode skips the spinner — `outputJson({ branch:
+        // ready })` below remains the sole authoritative output.
         const spinner = !json ? clack.spinner() : null;
         let ready: Branch;
         try {
@@ -53,7 +55,15 @@ export function registerBranchCreateCommand(branch: Command): void {
           });
           spinner?.message(`Branch '${name}' created (appkey: ${created.appkey}). Provisioning...`);
           ready = await pollUntilReady(created.id, apiUrl, spinner);
-          if (ready.branch_state === 'ready') {
+
+          if (ready.branch_state === 'ready' && opts.switch) {
+            spinner?.message('Branch ready. Switching context...');
+            // silent: true always — the spinner owns user-facing output, and
+            // runBranchSwitch's outputSuccess would otherwise interleave with
+            // the active spinner frame.
+            await runBranchSwitch({ name, apiUrl, json, silent: true });
+            spinner?.stop(`Branch '${name}' is ready and active`);
+          } else if (ready.branch_state === 'ready') {
             spinner?.stop(`Branch '${name}' is ready`);
           } else {
             spinner?.stop(`Branch '${name}' is in '${ready.branch_state}' state`);
@@ -61,14 +71,6 @@ export function registerBranchCreateCommand(branch: Command): void {
         } catch (err) {
           spinner?.stop(`Branch '${name}' creation failed`, 1);
           throw err;
-        }
-
-        // Run auto-switch BEFORE emitting the final JSON payload so a failed
-        // switch does not surface as a successful create.
-        if (opts.switch && ready.branch_state === 'ready') {
-          // silent in JSON mode so we don't emit two JSON documents — the
-          // single `outputJson({ branch: ready })` below is authoritative.
-          await runBranchSwitch({ name, apiUrl, json, silent: json });
         }
 
         if (json) {

--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -46,6 +46,11 @@ export function registerBranchCreateCommand(branch: Command): void {
         // ready })` below remains the sole authoritative output.
         const spinner = !json ? clack.spinner() : null;
         let ready: Branch;
+        // Tracks whether the branch reached `ready` state in the cloud — once
+        // true, any later throw is a switch failure (local), not a creation
+        // failure. Lets the catch render an accurate message instead of the
+        // misleading "creation failed" line for an already-created branch.
+        let provisioned = false;
         try {
           spinner?.start(`Creating branch '${name}'...`);
           const created = await createBranchApi(project.project_id, { mode, name }, apiUrl);
@@ -55,21 +60,29 @@ export function registerBranchCreateCommand(branch: Command): void {
           });
           spinner?.message(`Branch '${name}' created (appkey: ${created.appkey}). Provisioning...`);
           ready = await pollUntilReady(created.id, apiUrl, spinner);
+          provisioned = ready.branch_state === 'ready';
 
-          if (ready.branch_state === 'ready' && opts.switch) {
+          if (provisioned && opts.switch) {
             spinner?.message('Branch ready. Switching context...');
             // silent: true always — the spinner owns user-facing output, and
             // runBranchSwitch's outputSuccess would otherwise interleave with
             // the active spinner frame.
             await runBranchSwitch({ name, apiUrl, json, silent: true });
             spinner?.stop(`Branch '${name}' is ready and active`);
-          } else if (ready.branch_state === 'ready') {
+          } else if (provisioned) {
             spinner?.stop(`Branch '${name}' is ready`);
           } else {
             spinner?.stop(`Branch '${name}' is in '${ready.branch_state}' state`);
           }
         } catch (err) {
-          spinner?.stop(`Branch '${name}' creation failed`, 1);
+          if (provisioned) {
+            spinner?.stop(
+              `Branch '${name}' is ready, but switching context failed — run \`insforge branch switch ${name}\` to retry`,
+              1,
+            );
+          } else {
+            spinner?.stop(`Branch '${name}' creation failed`, 1);
+          }
           throw err;
         }
 

--- a/src/commands/branch/switch.test.ts
+++ b/src/commands/branch/switch.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../lib/config.js', () => ({
   saveProjectConfig: vi.fn((c: any) => saveCalls.push(c)),
   getProjectConfigFile: () => '/tmp/_test_/.insforge/project.json',
   getParentBackupFile: () => '/tmp/_test_/.insforge/project.parent.json',
+  buildOssHost: (appkey: string, region: string) => `https://${appkey}.${region}.insforge.app`,
   FAKE_PROJECT_ID: '00000000-0000-0000-0000-000000000000',
 }));
 
@@ -78,6 +79,7 @@ describe('runBranchSwitch', () => {
       project_id: 'b1',
       project_name: 'feat-x',
       api_key: 'branch-api-key',
+      oss_host: 'https://p1ky-x9p.us-east.insforge.app',
       branched_from: { project_id: 'p1', project_name: 'parent' },
     });
   });

--- a/src/commands/branch/switch.ts
+++ b/src/commands/branch/switch.ts
@@ -5,6 +5,7 @@ import {
   saveProjectConfig,
   getProjectConfigFile,
   getParentBackupFile,
+  buildOssHost,
 } from '../../lib/config.js';
 import { listBranchesApi, getProjectApiKey } from '../../lib/api/platform.js';
 import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
@@ -88,7 +89,7 @@ export async function runBranchSwitch(input: RunBranchSwitchOptions): Promise<vo
   }
 
   const apiKey = await getProjectApiKey(target.id, input.apiUrl);
-  const ossHost = `${target.appkey}.${target.region}.insforge.app`;
+  const ossHost = buildOssHost(target.appkey, target.region);
   const branched_from = current.branched_from ?? {
     project_id: current.project_id,
     project_name: current.project_name,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -14,7 +14,7 @@ import {
 } from '../lib/api/platform.js';
 import { getAnonKey, runRawSql } from '../lib/api/oss.js';
 import { applyAuthProvider, VALID_AUTH_PROVIDERS, type AuthProvider } from '../auth-providers/apply.js';
-import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl } from '../lib/config.js';
+import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, buildOssHost } from '../lib/config.js';
 import { requireAuth } from '../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../lib/errors.js';
 import { outputJson } from '../lib/output.js';
@@ -35,10 +35,6 @@ const SAFE_REPO_PATTERN = /^(https?:\/\/|git@)[A-Za-z0-9._:/@~+-]+(\.git)?$/;
 const SAFE_BRANCH_PATTERN = /^[A-Za-z0-9._/-]+$/;
 
 export type Framework = 'react' | 'nextjs';
-
-function buildOssHost(appkey: string, region: string): string {
-  return `https://${appkey}.${region}.insforge.app`;
-}
 
 async function waitForProjectActive(projectId: string, apiUrl?: string, timeoutMs = 120_000): Promise<void> {
   const start = Date.now();

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -13,7 +13,7 @@ import {
   getProjectApiKey,
   reportAgentConnected,
 } from '../../lib/api/platform.js';
-import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, FAKE_PROJECT_ID, FAKE_ORG_ID } from '../../lib/config.js';
+import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, buildOssHost, FAKE_PROJECT_ID, FAKE_ORG_ID } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
@@ -24,10 +24,6 @@ import { downloadGitHubTemplate } from '../create.js';
 import type { ProjectConfig } from '../../types.js';
 
 const execAsync = promisify(exec);
-
-function buildOssHost(appkey: string, region: string): string {
-  return `https://${appkey}.${region}.insforge.app`;
-}
 
 async function runNpmInstall(startMessage = 'Installing dependencies...'): Promise<void> {
   const spinner = clack.spinner();

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildOssHost } from './config.js';
+
+describe('buildOssHost', () => {
+  it('always returns an https URL', () => {
+    expect(buildOssHost('p1ky-x9p', 'us-east')).toBe(
+      'https://p1ky-x9p.us-east.insforge.app',
+    );
+  });
+
+  // Regression for the bug where `branch switch` wrote a bare hostname into
+  // oss_host and every later fetch threw "Failed to parse URL". Asserting the
+  // scheme directly here (independent of any caller) catches future drift.
+  it('output is parseable as a URL', () => {
+    const url = new URL(buildOssHost('app', 'eu-west'));
+    expect(url.protocol).toBe('https:');
+    expect(url.host).toBe('app.eu-west.insforge.app');
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -102,6 +102,15 @@ export function saveProjectConfig(config: ProjectConfig): void {
   writeFileSync(getLocalConfigFile(), JSON.stringify(config, null, 2), { mode: 0o600 });
 }
 
+/**
+ * Canonical OSS host URL for a cloud project. Always includes the `https://`
+ * scheme — `oss_host` is fed straight into `fetch()`, which rejects bare
+ * hostnames with "Failed to parse URL".
+ */
+export function buildOssHost(appkey: string, region: string): string {
+  return `https://${appkey}.${region}.insforge.app`;
+}
+
 // --- Resolved values (env vars > flags > config) ---
 
 export function getPlatformApiUrl(override?: string): string {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -91,7 +91,15 @@ export function getProjectConfig(): ProjectConfig | null {
     return null;
   }
   const raw = readFileSync(file, 'utf-8');
-  return JSON.parse(raw);
+  const config = JSON.parse(raw) as ProjectConfig;
+  // Heal legacy configs written by `branch switch` before 0.1.70 — that build
+  // stored `oss_host` as a bare hostname, which `fetch()` rejects with
+  // "Failed to parse URL". Normalize in-memory so existing links keep working;
+  // the next `saveProjectConfig` call persists the fix to disk.
+  if (config.oss_host && !/^https?:\/\//.test(config.oss_host) && config.appkey && config.region) {
+    config.oss_host = buildOssHost(config.appkey, config.region);
+  }
+  return config;
 }
 
 export function saveProjectConfig(config: ProjectConfig): void {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes branch switch writing a bare `oss_host` and auto-heals existing configs. Improves branch create with a single `@clack/prompts` spinner covering create, provisioning, and the auto-switch, with clear switch‑failure messaging; JSON mode unchanged.

- **Bug Fixes**
  - Switch saves `oss_host` via `buildOssHost()` (https); `getProjectConfig()` normalizes legacy bare-host values on read.
  - After a successful create, a switch error is reported as “switching context failed” with a retry hint, not “creation failed”.

- **New Features**
  - One spinner spans create → provisioning → switch, stays active through switch, and failures render in the same frame; `runBranchSwitch` now runs with `silent: true`.
  - JSON mode still outputs only the final `{ branch }` payload.

<sup>Written for commit 34f5383bcc5d3645aa9211258372a8ea2bec29d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spinner feedback now spans branch creation, provisioning, and optional auto-switch for clearer CLI progress.

* **Bug Fixes**
  * Legacy OSS host values are normalized to a valid HTTPS URL; OSS host construction centralized to ensure consistent URLs.

* **Chores**
  * Bumped package version to 0.1.70.

* **Tests**
  * Added tests for spinner lifecycle and OSS host construction; updated branch-switch tests to reflect URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->