### PR TITLE
bump to version 0.1.72

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Re-ship of [#108](https://github.com/InsForge/CLI/pull/108) — the v0.1.71 release tag was cut at 18:24, but #108 only merged at 18:28, so npm `0.1.71` is missing both fixes shipped in that PR.
- No code changes vs `main`; pure version bump so the next GitHub release tag picks up the merged code.

## What's actually in the npm artifact after this ships
- `getDatabaseConnectionString()` splices the unmasked password from `/api/metadata/database-password` into the masked URL (so `.env.local` gets a usable `DATABASE_URL` after `link --auth better-auth`).
- `runNpmSetupIfPresent()` runs after `npm install` on the `--auth` overlay paths, so `npm run setup` (BA migrate + schema + RLS SQL) fires automatically.

## Test plan
- [ ] Merge → tag `v0.1.72` → publish `Release` → `Publish to npm` workflow succeeds.
- [ ] `npx @insforge/cli@latest --version` → `0.1.72`.
- [ ] `grep "Running setup" $(npm root -g)/@insforge/cli/dist/index.js` → match.
- [ ] Cloud project: `insforge link --project-id <id> --auth better-auth` → `.env.local` has unmasked password, "Setup complete" appears, `\dt better_auth.*` lists 4 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@insforge/cli` to 0.1.72 to re-ship the fixes from #108 that were missed in 0.1.71 due to release timing. No code changes; only version update so the GitHub release and npm pick up the merged code.

- **Bug Fixes**
  - `getDatabaseConnectionString()` injects the unmasked password from `/api/metadata/database-password` into the masked URL, so `.env.local` has a usable `DATABASE_URL` after `link --auth better-auth`.
  - `runNpmSetupIfPresent()` runs after `npm install` on `--auth` overlay paths to auto-trigger `npm run setup` (migrations, schema, RLS SQL).

<sup>Written for commit 60a28cc15ac378c55a7be6cfbbb4b7db942824ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.72

<!-- end of auto-generated comment: release notes by coderabbit.ai -->