### PR TITLE
fix(link): drop stale What's next panel after auto-setup

### DIFF
--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -246,7 +246,6 @@ export function registerProjectLinkCommand(program: Command): void {
                   await runNpmInstall('Installing new dependencies...');
                   await runNpmSetupIfPresent();
                 }
-                if (!json) clack.note(result.nextSteps, "What's next");
               } catch (err) {
                 const msg = `Failed to apply --auth ${opts.auth}: ${(err as Error).message}`;
                 if (json) console.error(JSON.stringify({ warning: msg }));
@@ -475,8 +474,6 @@ export function registerProjectLinkCommand(program: Command): void {
                 await runNpmInstall('Installing new dependencies...');
                 await runNpmSetupIfPresent();
               }
-
-              if (!json) clack.note(result.nextSteps, "What's next");
             } catch (err) {
               const msg = `Failed to apply --auth ${opts.auth}: ${(err as Error).message}`;
               if (json) console.error(JSON.stringify({ warning: msg }));


### PR DESCRIPTION
## Summary

After 0.1.71's `runNpmSetupIfPresent` runs schema + BA migrate + app SQL in-place, the BA overlay's manifest \`nextSteps\` told the user to do the same steps over again ("1. Set DATABASE_URL... 2. npm install... 3. npm run setup..."). Drop the two \`clack.note(result.nextSteps, ...)\` calls on the bare-overlay paths — auto-setup now handles those, and "Setup complete" is the signal.

The template-path panels (lines 216 and 456) still print \`cd <dirName> && npm run dev\`, which is correct.

## Verified

Re-ran \`link --auth better-auth\` against ba-sdk-test stack:
- Before fix: 3-line "What's next" panel telling user to run the steps that just auto-ran
- After fix: clean output ending at "Setup complete" + "skills installed"

## Test plan
- [x] \`npm run build\` clean, types pass
- [x] Re-ran \`link --auth\` end-to-end against local stack — output is clean
- [ ] \`--template nextjs\` still prints its \`cd dirName && npm run dev\` panel (covered by line 216 / 456 — untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the stale “What’s next” panel in `link --auth` bare-overlay flows now that `runNpmSetupIfPresent` auto-runs migrations/setup, so output ends at “Setup complete”.
Template flows still print `cd <dirName> && npm run dev`.

<sup>Written for commit 8f8dd12b0b2a922a0ce50ce15c41f114e675c69d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The link command with the --auth flag now correctly installs newly added dependencies and automatically runs available setup scripts.

* **Changes**
  * Improved failure reporting for setup runs: error output now surfaces the most relevant message to help diagnose failures.
  * Removed the "What's next" informational message from certain command flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->