### PR TITLE
fix(cli): surface container port in compute deploy/update output

### DIFF
--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -142,6 +142,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
             const verb = existing ? 'updated' : 'deployed';
             outputSuccess(`Service "${service.name}" ${verb} [${service.status}]`);
             if (service.endpointUrl) console.log(`  Endpoint: ${service.endpointUrl}`);
+            if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
           }
           await reportCliUsage('cli.compute.deploy', true);
           return;
@@ -269,6 +270,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
           const verb = existing ? 'updated' : 'deployed';
           outputSuccess(`Service "${service.name}" ${verb} [${service.status}]`);
           if (service.endpointUrl) console.log(`  Endpoint: ${service.endpointUrl}`);
+          if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
           console.log(`  Image: ${imageRef} (built remotely; no local image to clean up)`);
         }
 

--- a/src/commands/compute/update.ts
+++ b/src/commands/compute/update.ts
@@ -131,6 +131,8 @@ export function registerComputeUpdateCommand(computeCmd: Command): void {
           outputJson(service);
         } else {
           outputSuccess(`Service "${service.name}" updated [${service.status}]`);
+          if (service.endpointUrl) console.log(`  Endpoint: ${service.endpointUrl}`);
+          if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
         }
         await reportCliUsage('cli.compute.update', true);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Print `Port: <n>` alongside `Endpoint:` on `compute deploy` and `compute update` success output (both image mode and source mode)
- Helps users spot image-vs-port mismatches — e.g. `nginx:alpine` (listens on 80) deployed with the default `--port 8080` results in an unreachable endpoint with no signal in the CLI output

## Before
```
✓ Service "my-api" deployed [running]
  Endpoint: https://my-api-....fly.dev
```

## After
```
✓ Service "my-api" deployed [running]
  Endpoint: https://my-api-....fly.dev
  Port: 8080 (container must listen on this port)
```

## Test plan
- [ ] `npx @insforge/cli compute deploy --name test --image nginx:alpine` shows `Port: 8080` (and endpoint is unreachable — confirms the line surfaces the misconfiguration)
- [ ] `npx @insforge/cli compute deploy --name test --image nginx:alpine --port 80` shows `Port: 80` (and endpoint serves the nginx welcome page)
- [ ] `npx @insforge/cli compute update <id> --port 80` shows the updated port

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the container port alongside the endpoint in `@insforge/cli` compute deploy and update success output. This helps catch image-vs-port mismatches (e.g., nginx on 80 vs `--port 8080`).

- **Bug Fixes**
  - compute deploy: prints “Port: <n> (container must listen on this port)” in both image and source modes.
  - compute update: includes “Endpoint:” and “Port:” in the success output.

<sup>Written for commit 299e2b60a85ce44c542088ffdd91013d780ea13c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `compute deploy` now shows the configured container port in text output for both image and source deployments.
  * `compute update` now shows the service endpoint URL and the configured container port in text output after successful updates.
  * Port lines include a note that the container must listen on the specified port.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/116)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->