### PR TITLE
fix(link): refresh masked-password URLs on re-link

### DIFF
--- a/src/auth-providers/apply.test.ts
+++ b/src/auth-providers/apply.test.ts
@@ -100,6 +100,23 @@ describe('refreshStaleEnvDefaults', () => {
     expect(updated).toBe(existing);
   });
 
+  it('refreshes a masked-password URL even if it differs from the manifest default', () => {
+    // Pre-0.1.72 cloud links wrote `postgresql://postgres:********@...`
+    // (placeholder password) to .env.local. Re-linking under 0.1.72+ should
+    // replace that with the real spliced password from /database-password.
+    const existing = 'DATABASE_URL=postgresql://postgres:********@m8s5kmam.us-east.database.insforge.app:5432/insforge?sslmode=require\n';
+    const defaults = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:postgres@127.0.0.1:5432/insforge'],
+    ]);
+    const platform = new Map([
+      ['DATABASE_URL', 'postgresql://postgres:realsecret@m8s5kmam.us-east.database.insforge.app:5432/insforge?sslmode=require'],
+    ]);
+    const { updated, refreshed } = refreshStaleEnvDefaults(existing, defaults, platform);
+    expect(refreshed).toEqual(['DATABASE_URL']);
+    expect(updated).toContain('postgres:realsecret@');
+    expect(updated).not.toContain('********');
+  });
+
   it('handles multiple keys, refreshing only the stale ones', () => {
     const existing = [
       'DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/insforge',

--- a/src/auth-providers/apply.ts
+++ b/src/auth-providers/apply.ts
@@ -113,7 +113,16 @@ export function extractEnvPairs(content: string): Map<string, string> {
 // value matches the manifest's literal default AND the platform now has a
 // real value (e.g., cloud DATABASE_URL), overwrite the line. User-customized
 // values (anything that differs from the manifest default) are preserved.
+//
+// One extra case beyond "matches the default": the cloud's
+// `database-connection-string` endpoint used to return a placeholder URL
+// like `postgresql://postgres:********@host/db?sslmode=require` before
+// 0.1.72 spliced the real password in. Users linked under that older CLI
+// still have the masked URL in their .env.local. The masked value can
+// never authenticate to Postgres, so it's clearly stale — detect any
+// `:****@` (one or more `*`) password and refresh from the platform.
 // Exported for unit testing.
+const MASKED_PASSWORD_PATTERN = /:\*+@/;
 export function refreshStaleEnvDefaults(
   existing: string,
   manifestDefaults: Map<string, string>,
@@ -127,7 +136,10 @@ export function refreshStaleEnvDefaults(
     const userValue = m[2];
     const def = manifestDefaults.get(key);
     const real = platformValues.get(key);
-    if (def !== undefined && real !== undefined && userValue === def && real !== def) {
+    if (def === undefined || real === undefined || real === def) return line;
+    const matchesDefault = userValue === def;
+    const isMaskedPassword = MASKED_PASSWORD_PATTERN.test(userValue);
+    if (matchesDefault || isMaskedPassword) {
       refreshed.push(key);
       return `${key}=${real}`;
     }


### PR DESCRIPTION
## Why

Pre-0.1.72 cloud \`link --auth\` wrote DATABASE_URL with a literal placeholder password:

\`\`\`
DATABASE_URL=postgresql://postgres:********@m8s5kmam.us-east.database.insforge.app:5432/insforge?sslmode=require
\`\`\`

The cloud's \`/database-connection-string\` endpoint masks the password as \`********\`; the unmask via the separate \`/database-password\` endpoint only landed in #108 (shipped in 0.1.72).

Users who linked under an older CLI still have the masked URL in \`.env.local\`. Re-linking under 0.1.72+ doesn't fix it because \`refreshStaleEnvDefaults\` only replaces values that match the manifest's literal default (\`postgresql://postgres:postgres@127.0.0.1:5432/insforge\`). The masked-cloud URL matches neither the default nor a real user customization — it falls into a gap.

The symptom is BA's pg pool failing on every sign-up:

\`\`\`
password authentication failed for user "postgres"
\`\`\`

## What this PR does

Treat any \`:****@\` (one or more \`*\`) password pattern as stale and refresh from the platform value, alongside the existing "matches the manifest default" branch.

\`\`\`diff
-    if (def !== undefined && real !== undefined && userValue === def && real !== def) {
+    if (def === undefined || real === undefined || real === def) return line;
+    const matchesDefault = userValue === def;
+    const isMaskedPassword = MASKED_PASSWORD_PATTERN.test(userValue);
+    if (matchesDefault || isMaskedPassword) {
       refreshed.push(key);
       return \`\${key}=\${real}\`;
     }
\`\`\`

The masked password is never a valid Postgres credential, so the "treat as stale" carries no risk of clobbering real user data.

## Test plan
- [x] Unit test added: \`refreshes a masked-password URL even if it differs from the manifest default\`
- [x] 14/14 \`apply.test.ts\` tests pass
- [x] Existing "preserves user value when it differs from the manifest default" test still passes — a real user customization without the \`:****@\` pattern is left alone
- [ ] Manual: re-link a project that has the masked URL → \`.env.local\` gets the real password spliced in → \`npm run setup\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes re-linking so masked `DATABASE_URL` values from older cloud links are replaced with the real password. Detects `:****@` patterns and refreshes from platform values to prevent Postgres auth failures.

- **Bug Fixes**
  - Extend `refreshStaleEnvDefaults` to refresh values with masked passwords (`:\*+@`) in addition to default-match cases.
  - Preserve real user edits and add a unit test for the masked-URL refresh case.

<sup>Written for commit 50709e252d3014ca92ac92276473341735ead5f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed refresh handling for database connection strings containing masked passwords in environment configuration files. Previously, connection strings with placeholder passwords were not being updated to use actual platform credentials.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->