### PR TITLE
bump to version 0.1.73

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Re-link UX fix shipping with this bump:

- **#117** — \`refreshStaleEnvDefaults\` now detects the \`:****@\` masked-password pattern as stale. Users who linked any cloud project under 0.1.71 or earlier had \`postgresql://postgres:********@cloud-host/db?sslmode=require\` in \`.env.local\`. Re-linking under 0.1.72 didn't refresh it because the masked URL doesn't match the manifest's localhost default, and BA's pg pool would then fail every sign-up with \`password authentication failed for user "postgres"\`.

## Test plan
- [x] Unit test \`refreshes a masked-password URL even if it differs from the manifest default\` passes (14/14 in \`apply.test.ts\`)
- [ ] After ship: re-link a project with the masked URL → \`.env.local\` gets real password → \`npm run setup\` succeeds → sign-up works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@insforge/cli` to 0.1.73 to ship the masked `DATABASE_URL` refresh fix from #117. Prevents Postgres auth errors after re-link for projects linked on <=0.1.71.

- **Bug Fixes**
  - Re-link now detects the `:****@` masked-password pattern and replaces it with the real cloud password, fixing “password authentication failed for user 'postgres'”.

- **Migration**
  - Update to 0.1.73, re-link your cloud project, then run `npm run setup`.

<sup>Written for commit 0e9b0d851c5857c70707c7f4d0bf56ba5bf129ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.73.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/118)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->