### PR TITLE
feat(skills): install better-auth/skills when --auth better-auth

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -401,7 +401,7 @@ export function registerCreateCommand(program: Command): void {
         }
 
         // Install agent skills
-        await installSkills(json);
+        await installSkills(json, opts.auth as string | undefined);
         trackCommand('create', orgId);
         await reportCliUsage('cli.create', true, 6);
 

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -194,7 +194,7 @@ export function registerProjectLinkCommand(program: Command): void {
                 }
               }
 
-              await installSkills(json);
+              await installSkills(json, opts.auth as string | undefined);
               trackCommand('link', 'oss-org', { direct: true, template });
               await reportCliUsage('cli.link_direct', true, 6, projectConfig);
 
@@ -256,7 +256,7 @@ export function registerProjectLinkCommand(program: Command): void {
             trackCommand('link', 'oss-org', { direct: true });
 
             // Install agent skills
-            await installSkills(json);
+            await installSkills(json, opts.auth as string | undefined);
             await reportCliUsage('cli.link_direct', true, 6, projectConfig);
 
             // Report agent-connected event (best-effort)
@@ -440,7 +440,7 @@ export function registerProjectLinkCommand(program: Command): void {
           }
 
           // Install agent skills inside the project directory
-          await installSkills(json);
+          await installSkills(json, opts.auth as string | undefined);
           await reportCliUsage('cli.link', true, 6, projectConfig);
 
           if (!json) {
@@ -482,7 +482,7 @@ export function registerProjectLinkCommand(program: Command): void {
           }
 
           // No template — install agent skills in the current directory
-          await installSkills(json);
+          await installSkills(json, opts.auth as string | undefined);
           await reportCliUsage('cli.link', true, 6, projectConfig);
 
           if (!json) {

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -68,10 +68,25 @@ function updateGitignore(): void {
   appendFileSync(gitignorePath, block);
 }
 
-export async function installSkills(json: boolean): Promise<void> {
+// Agents that the `npx skills add -a <agent>` CLI knows how to target. Kept
+// here so the BA-provider install below stays in lockstep with the main
+// InsForge install — no per-call-site drift if we add a new agent in future.
+const AGENT_FLAGS =
+  '-a antigravity -a augment -a claude-code -a cline -a codex -a cursor -a gemini-cli -a github-copilot -a kilo -a qoder -a qwen-code -a roo -a trae -a windsurf';
+
+// Provider-specific skill packs we install on top of the InsForge skills when
+// the user wires that provider in via `link --auth <provider>` / `create
+// --auth <provider>`. Each is its own marketplace/skill repo — they
+// complement (not duplicate) `insforge-integrations`, which covers the
+// InsForge bridge side of each provider.
+const PROVIDER_SKILLS: Record<string, { repo: string; label: string }> = {
+  'better-auth': { repo: 'better-auth/skills', label: 'Better Auth skills' },
+};
+
+export async function installSkills(json: boolean, authProvider?: string): Promise<void> {
   try {
     if (!json) clack.log.info('Installing InsForge agent skills (global)...');
-    await execAsync('npx skills add insforge/agent-skills -g -y -a antigravity -a augment -a claude-code -a cline -a codex -a cursor -a gemini-cli -a github-copilot -a kilo -a qoder -a qwen-code -a roo -a trae -a windsurf', {
+    await execAsync(`npx skills add insforge/agent-skills -g -y ${AGENT_FLAGS}`, {
       cwd: process.cwd(),
       timeout: SKILL_INSTALL_TIMEOUT_MS,
     });
@@ -95,6 +110,28 @@ export async function installSkills(json: boolean): Promise<void> {
     if (!json) {
       clack.log.warn(`Could not install find-skills: ${describeExecError(err)}`);
       clack.log.info('Run `npx skills add https://github.com/vercel-labs/skills --skill find-skills` once resolved.');
+    }
+  }
+
+  // Provider-specific skills: install the upstream pack (e.g. better-auth's
+  // own skills repo) when the user opted into a third-party auth provider.
+  // Complements `insforge-integrations` rather than replacing it — that one
+  // covers the InsForge bridge side; this one covers the provider's own
+  // patterns (BA scaffolding, email/password, 2FA, organizations, etc.).
+  const providerEntry = authProvider ? PROVIDER_SKILLS[authProvider] : undefined;
+  if (providerEntry) {
+    try {
+      if (!json) clack.log.info(`Installing ${providerEntry.label} (global)...`);
+      await execAsync(`npx skills add ${providerEntry.repo} -g -y ${AGENT_FLAGS}`, {
+        cwd: process.cwd(),
+        timeout: SKILL_INSTALL_TIMEOUT_MS,
+      });
+      if (!json) clack.log.success(`${providerEntry.label} installed.`);
+    } catch (err) {
+      if (!json) {
+        clack.log.warn(`Could not install ${providerEntry.label}: ${describeExecError(err)}`);
+        clack.log.info(`Run \`npx skills add ${providerEntry.repo}\` once resolved to see the full output.`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Fold provider-specific skill installs into the existing `installSkills` function instead of adding a second `execAsync` block at every call site
- When `link --auth better-auth` or `create --auth better-auth` is used, also install [`better-auth/skills`](https://github.com/better-auth/skills) alongside `insforge/agent-skills` and `vercel-labs/skills`
- Lookup map (`PROVIDER_SKILLS`) makes it trivial to add more providers later without touching call sites
- Shared `AGENT_FLAGS` constant keeps the agent target list in lockstep across all three installs

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 228/228 pass
- [x] `npm run lint` — warnings only (pre-existing)
- [x] Live-fire: `link --auth better-auth` against cloud project showed all three install lines:
  - `Installing InsForge agent skills (global)...` → success
  - `Installing find-skills (global)...` → success
  - `Installing Better Auth skills (global)...` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically installs `better-auth/skills` when `--auth better-auth` is used with `create` or `link`. Provider installs are centralized in `installSkills`, and the selected auth provider is now passed from call sites.

- **New Features**
  - Auto-install `better-auth/skills` alongside `insforge/agent-skills` and `vercel-labs/skills` when `--auth better-auth` is specified.

- **Refactors**
  - Centralize provider-specific installs in `installSkills`; `create` and `link` now pass the selected `--auth` provider.
  - Add `AGENT_FLAGS` and a `PROVIDER_SKILLS` map to keep agent targets aligned and make adding providers easy.

<sup>Written for commit 160593ddfb343da2980afeeacd23d0d0619df774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--org-id` CLI option to specify target organization during project creation, with automatic fallback to saved default.

* **Improvements**
  * Skill installation now respects the selected authentication provider and can install provider-specific skills when applicable, improving setup accuracy and feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/119)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->