### PR TITLE
feat(link): install skills only when called with no args

### DIFF
--- a/src/commands/projects/link.test.ts
+++ b/src/commands/projects/link.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+import { registerProjectLinkCommand } from './link.js';
+
+vi.mock('../../lib/skills.js', () => ({
+  installSkills: vi.fn(async () => {}),
+  reportCliUsage: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/analytics.js', () => ({
+  captureEvent: vi.fn(),
+  trackCommand: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/api/platform.js', () => ({
+  listOrganizations: vi.fn(),
+  listProjects: vi.fn(),
+  getProject: vi.fn(),
+  getProjectApiKey: vi.fn(),
+  reportAgentConnected: vi.fn(),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  getGlobalConfig: vi.fn(() => ({})),
+  saveGlobalConfig: vi.fn(),
+  saveProjectConfig: vi.fn(),
+  getFrontendUrl: () => 'https://example.test',
+  buildOssHost: vi.fn(),
+  FAKE_PROJECT_ID: '00000000-0000-0000-0000-000000000000',
+  FAKE_ORG_ID: '00000000-0000-0000-0000-000000000000',
+}));
+
+vi.mock('../../lib/output.js', () => ({
+  outputJson: vi.fn(),
+  outputSuccess: vi.fn(),
+}));
+
+vi.mock('../create.js', () => ({
+  downloadGitHubTemplate: vi.fn(),
+}));
+
+vi.mock('../../auth-providers/apply.js', () => ({
+  applyAuthProvider: vi.fn(),
+  VALID_AUTH_PROVIDERS: ['better-auth'],
+}));
+
+vi.mock('../../lib/prompts.js', () => ({
+  text: vi.fn(),
+  select: vi.fn(),
+  isCancel: () => false,
+}));
+
+vi.mock('@clack/prompts', () => ({
+  spinner: () => ({ start: vi.fn(), message: vi.fn(), stop: vi.fn() }),
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+  },
+  note: vi.fn(),
+}));
+
+function buildProgram(): Command {
+  const program = new Command().exitOverride();
+  // Mirror the global flags the action handler reads via getRootOpts(cmd).
+  program.option('--json').option('--api-url <url>');
+  registerProjectLinkCommand(program);
+  return program;
+}
+
+describe('project link: skills-only fast path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('with no args, installs skills and skips auth + project picker', async () => {
+    const program = buildProgram();
+    await program.parseAsync(['link'], { from: 'user' });
+
+    const { installSkills, reportCliUsage } = await import('../../lib/skills.js');
+    const { trackCommand } = await import('../../lib/analytics.js');
+    const { requireAuth } = await import('../../lib/credentials.js');
+    const { listOrganizations } = await import('../../lib/api/platform.js');
+
+    expect(installSkills).toHaveBeenCalledWith(false);
+    expect(trackCommand).toHaveBeenCalledWith('link', 'skills-only', { skills_only: true });
+    expect(reportCliUsage).toHaveBeenCalledWith('cli.link_skills_only', true, 1);
+    // Skills-only path must never trigger auth or the org picker.
+    expect(requireAuth).not.toHaveBeenCalled();
+    expect(listOrganizations).not.toHaveBeenCalled();
+  });
+
+  it('with --json, emits a single skills_only success payload', async () => {
+    const program = buildProgram();
+    await program.parseAsync(['link', '--json'], { from: 'user' });
+
+    const { installSkills } = await import('../../lib/skills.js');
+    const { outputJson } = await import('../../lib/output.js');
+
+    expect(installSkills).toHaveBeenCalledWith(true);
+    expect(outputJson).toHaveBeenCalledWith({ success: true, skills_only: true });
+  });
+
+  it('when installSkills throws, reports failure and exits non-zero', async () => {
+    const { installSkills } = await import('../../lib/skills.js');
+    (installSkills as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network down'));
+
+    const program = buildProgram();
+    let exitCode: number | undefined;
+    const origExit = process.exit;
+    (process.exit as unknown) = (code?: number) => {
+      exitCode = code;
+      throw new Error('__exit__');
+    };
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await program.parseAsync(['link'], { from: 'user' }).catch(() => {});
+    } finally {
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+    }
+
+    const { reportCliUsage } = await import('../../lib/skills.js');
+    expect(reportCliUsage).toHaveBeenCalledWith('cli.link_skills_only', false);
+    expect(exitCode).toBe(1);
+  });
+
+  it('with --project-id, bypasses skills-only and falls through to auth path', async () => {
+    const { requireAuth } = await import('../../lib/credentials.js');
+    // Reject auth so we short-circuit without needing to mock the rest of the
+    // OAuth flow — the assertion is just that the skills-only fast path was
+    // skipped because --project-id was provided.
+    (requireAuth as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('not authed'));
+
+    const program = buildProgram();
+    const origExit = process.exit;
+    (process.exit as unknown) = (_code?: number) => {
+      throw new Error('__exit__');
+    };
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await program
+        .parseAsync(['link', '--project-id', 'p1', '--json'], { from: 'user' })
+        .catch(() => {});
+    } finally {
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+    }
+
+    const { installSkills } = await import('../../lib/skills.js');
+    expect(installSkills).not.toHaveBeenCalled();
+    expect(requireAuth).toHaveBeenCalled();
+  });
+});

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -68,7 +68,7 @@ async function runNpmSetupIfPresent(): Promise<void> {
 export function registerProjectLinkCommand(program: Command): void {
   program
     .command('link')
-    .description('Link current directory to an InsForge project')
+    .description('Link current directory to an InsForge project (no args: installs agent skills only)')
     .option('--project-id <id>', 'Project ID to link')
     .option('--org-id <id>', 'Organization ID')
     .option('--template <template>', 'Download a template after linking: react, nextjs, chatbot, crm, e-commerce, todo')
@@ -94,6 +94,35 @@ export function registerProjectLinkCommand(program: Command): void {
       try {
         if (opts.template && !validTemplates.includes(opts.template)) {
           throw new CLIError(`Invalid template "${opts.template}". Valid options: ${validTemplates.join(', ')}`);
+        }
+
+        // Skills-only fast path: bare `link` with no args installs agent skills
+        // into the current directory without auth, org/project picker, or
+        // writing .insforge/project.json. The agent walks the user through
+        // provisioning later, when it actually needs InsForge backend services.
+        const isSkillsOnly = Object.values(opts).every((v) => v === undefined);
+
+        if (isSkillsOnly) {
+          try {
+            await installSkills(json);
+            trackCommand('link', 'skills-only', { skills_only: true });
+            await reportCliUsage('cli.link_skills_only', true, 1);
+
+            if (json) {
+              outputJson({ success: true, skills_only: true });
+            } else {
+              clack.note(
+                `Open your coding agent (Claude Code, Codex, Cursor, etc.) and ask it to build something. It will walk you through provisioning an InsForge project when needed.`,
+                "What's next",
+              );
+            }
+            return;
+          } catch (err) {
+            await reportCliUsage('cli.link_skills_only', false);
+            await shutdownAnalytics();
+            handleError(err, json);
+            return;
+          }
         }
 
         if (opts.apiBaseUrl || opts.apiKey) {

--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -100,7 +100,13 @@ export function registerProjectLinkCommand(program: Command): void {
         // into the current directory without auth, org/project picker, or
         // writing .insforge/project.json. The agent walks the user through
         // provisioning later, when it actually needs InsForge backend services.
-        const isSkillsOnly = Object.values(opts).every((v) => v === undefined);
+        const isSkillsOnly =
+          opts.projectId === undefined &&
+          opts.orgId === undefined &&
+          opts.template === undefined &&
+          opts.auth === undefined &&
+          opts.apiBaseUrl === undefined &&
+          opts.apiKey === undefined;
 
         if (isSkillsOnly) {
           try {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Running `projects link` with no args now installs InsForge agent skills only, skipping auth and project linking. This creates a fast, sign-in-free quick start; the agent will guide provisioning later.

- **New Features**
  - Bare `link` installs skills in the current directory and exits; with `--json` it returns `{ success: true, skills_only: true }`.
  - Skips auth, org/project picker, and writing `.insforge/project.json`; providing flags like `--project-id` bypasses this path.
  - Updates help text and shows a short next-steps note in the CLI.
  - Sends analytics (`trackCommand`, `reportCliUsage`) and exits with code 1 on install errors; detection uses explicit per-option checks with tests for no-args, `--json`, error, and bypass cases.

<sup>Written for commit 1a0648cb7ebf4d01c3948d5a871a8b0b0bb6c639. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command description to clarify behavior when called without arguments.

* **New Features**
  * Added optimized execution path for no-argument invocation, streamlining the agent skills installation workflow with enhanced error handling and reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->