### PR TITLE
bump to version 0.1.74

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Ship #119 (install `better-auth/skills` when `--auth better-auth` is used).

The CLI already installed `insforge/agent-skills` and `find-skills` globally on every link/create; 0.1.74 also installs the upstream `better-auth/skills` pack whenever the user opts into Better Auth, so agents get the provider's own scaffolding patterns alongside InsForge's bridge skills.

Merge order:
1. #119 (feature)
2. This PR (bump)
3. Tag `v0.1.74` on main → GitHub Actions publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.1.74 of `@insforge/cli`, enabling auto-install of `better-auth/skills` when `--auth better-auth` is used. This ships Better Auth scaffolding alongside `insforge/agent-skills` and `find-skills`.

<sup>Written for commit d60ef5c7962ed2c8a5f90447413f4db0860c27f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented package version to `0.1.74`.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/121)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->