### PR TITLE
fix(link): poll for real database password after project becomes active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/lib/api/oss.test.ts
+++ b/src/lib/api/oss.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { spliceDatabasePassword } from './oss.js';
+import { isMaskedDatabasePassword, spliceDatabasePassword } from './oss.js';
 
 describe('spliceDatabasePassword', () => {
   // Real shape from cloud `/api/metadata/database-connection-string`
@@ -26,5 +26,24 @@ describe('spliceDatabasePassword', () => {
     const m = 'postgresql://postgres:********@db.host.app:5432/insforge?options=user%3D%40admin';
     const result = spliceDatabasePassword(m, 'realpw');
     expect(result).toBe('postgresql://postgres:realpw@db.host.app:5432/insforge?options=user%3D%40admin');
+  });
+});
+
+describe('isMaskedDatabasePassword', () => {
+  it('detects the platform`s standard 8-star mask', () => {
+    expect(isMaskedDatabasePassword('********')).toBe(true);
+  });
+  it('detects any run of `*` (in case the platform shortens or lengthens it)', () => {
+    expect(isMaskedDatabasePassword('*')).toBe(true);
+    expect(isMaskedDatabasePassword('***')).toBe(true);
+    expect(isMaskedDatabasePassword('****************')).toBe(true);
+  });
+  it('does not flag real passwords (even ones that happen to contain `*`)', () => {
+    expect(isMaskedDatabasePassword('66666b99c46288a34220009437d8a3c2')).toBe(false);
+    expect(isMaskedDatabasePassword('p*ssw0rd')).toBe(false);
+    expect(isMaskedDatabasePassword('*real*')).toBe(false);
+  });
+  it('does not flag empty string (caller checks emptiness separately)', () => {
+    expect(isMaskedDatabasePassword('')).toBe(false);
   });
 });

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -58,27 +58,51 @@ export function spliceDatabasePassword(maskedUrl: string, password: string): str
   return maskedUrl.replace(/^(postgresql:\/\/[^:]+:)[^@]+(@)/, `$1${password}$2`);
 }
 
+// The platform also returns the password as `********` (or any run of `*`)
+// while the project is finishing provisioning — splicing that into the URL
+// is a silent no-op and leaves the user with an unusable masked URL in
+// `.env.local`. Treat it the same as "not ready".
+export function isMaskedDatabasePassword(value: string): boolean {
+  return /^\*+$/.test(value);
+}
+
+async function fetchDatabasePasswordOnce(): Promise<string | null> {
+  try {
+    const res = await ossFetch('/api/metadata/database-password');
+    const body = await res.json() as { databasePassword?: string };
+    const pw = body.databasePassword;
+    if (typeof pw !== 'string' || !pw || isMaskedDatabasePassword(pw)) return null;
+    return pw;
+  } catch {
+    return null;
+  }
+}
+
 export async function getDatabaseConnectionString(): Promise<string | null> {
   // Cloud-only: returns the project's Postgres URL with the real password
   // substituted in. The platform's `/database-connection-string` endpoint
-  // masks the password (`postgresql://postgres:********@...`), so we also
-  // hit `/database-password` and splice the unmasked value in. Without this
-  // splice, callers (e.g., `link`'s .env.local auto-fill) would write a URL
-  // BA's pg pool can't authenticate with.
-  // Self-hosted returns null on either endpoint (PROJECT_ID not configured)
-  // so we fall back gracefully.
+  // masks the password (`postgresql://postgres:********@...`); we hit
+  // `/database-password` separately to splice the real password in.
+  //
+  // Right after `create`, the project flips to `status=active` before the
+  // password generator has populated `/database-password` — that endpoint
+  // can return `********` itself for ~5-10s. So we poll briefly (up to 20s
+  // total) until we see a real password before giving up. Self-hosted /
+  // older projects without the endpoint return null and we fall back.
   try {
-    const [urlRes, pwRes] = await Promise.all([
-      ossFetch('/api/metadata/database-connection-string'),
-      ossFetch('/api/metadata/database-password'),
-    ]);
+    const urlRes = await ossFetch('/api/metadata/database-connection-string');
     const urlBody = await urlRes.json() as { connectionURL?: string };
-    const pwBody = await pwRes.json() as { databasePassword?: string };
-
     const masked = urlBody.connectionURL;
-    const password = pwBody.databasePassword;
     if (typeof masked !== 'string' || !masked) return null;
-    if (typeof password !== 'string' || !password) return null;
+
+    let password = await fetchDatabasePasswordOnce();
+    const POLL_ATTEMPTS = 9;
+    const POLL_DELAY_MS = 2_000;
+    for (let attempt = 0; password === null && attempt < POLL_ATTEMPTS; attempt++) {
+      await new Promise((r) => setTimeout(r, POLL_DELAY_MS));
+      password = await fetchDatabasePasswordOnce();
+    }
+    if (password === null) return null;
 
     return spliceDatabasePassword(masked, password);
   } catch {


### PR DESCRIPTION
## Symptom

User reported that on first link after \`create --auth better-auth\`, \`.env.local\` was written with a masked password:

\`\`\`
DATABASE_URL=postgresql://postgres:********@4e7yvep2.us-east.database.insforge.app:5432/insforge?sslmode=require
\`\`\`

This URL is unusable — BA's pg pool can't authenticate with it. Re-running \`link\` does fix it (0.1.73's masked-pattern refresh kicks in), but the first-run experience is broken.

## Root cause

The platform flips a project to \`status=active\` as soon as the container is up, **before** \`/api/metadata/database-password\` is populated. During that window the endpoint itself returns \`********\`. Our \`spliceDatabasePassword\` silently spliced \`********\` into the masked URL — same masked URL out.

## Fix

- Add \`isMaskedDatabasePassword(value)\` — matches \`/^\*+$/\`
- Treat a masked response from \`/database-password\` the same as "not ready"
- Poll \`/database-password\` up to 9 times at 2s intervals (~20s budget) before giving up

Most cloud projects finish provisioning within a few seconds, so the common case adds no latency. If the endpoint never returns a real password, we fall back to \`null\` and the user can re-run \`link\` — at which point 0.1.73's refresh logic handles the masked URL.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 272/272 pass (8 in oss.test.ts, +4 new for \`isMaskedDatabasePassword\`)
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes first-time link writing a masked Postgres URL by polling for the real database password after a project becomes active. Prevents unusable `postgresql://...:********@...` in `.env.local` and avoids auth failures.

- **Bug Fixes**
  - Treat `********` (any run of `*`) from `/api/metadata/database-password` as not ready.
  - Poll up to ~20s for a real password; if still missing, return `null` instead of writing a masked URL.
  - Added `isMaskedDatabasePassword` and a one-shot fetch helper; updated `getDatabaseConnectionString`; tests added.

- **Dependencies**
  - Bump `@insforge/cli` to `0.1.76`.

<sup>Written for commit 7c6822019358c4bff95437f3b3cc54339f1cc480. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database password retrieval now polls for up to ~20 seconds when credentials are masked during provisioning, improving setup reliability.
  * Connection attempts now tolerate masked credentials and wait for a usable password instead of immediately failing.

* **Tests**
  * Added comprehensive tests for masked password detection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/122)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/122)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->