### PR TITLE
fix(link): note that browser sign-in may happen at provisioning time

### DIFF
--- a/src/commands/projects/link.ts
+++ b/src/commands/projects/link.ts
@@ -118,7 +118,7 @@ export function registerProjectLinkCommand(program: Command): void {
               outputJson({ success: true, skills_only: true });
             } else {
               clack.note(
-                `Open your coding agent (Claude Code, Codex, Cursor, etc.) and ask it to build something. It will walk you through provisioning an InsForge project when needed.`,
+                `Open your coding agent (Claude Code, Codex, Cursor, etc.) and ask it to build something. It will walk you through provisioning an InsForge project when needed. If you're not signed in yet, your browser will open for sign-in at that point.`,
                 "What's next",
               );
             }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the “What’s next” note in the `projects link` flow to explain that if you’re not signed in, your browser will open for sign-in during provisioning triggered by your coding agent. This prevents confusion for skills-only users who didn’t authenticate during linking.

<sup>Written for commit fb0e63196087dedf0ef8ff0dd42461fe2d4b80d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance messages to clarify that the coding agent will guide provisioning when needed and that users will be prompted to sign in via browser if not already authenticated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->