### PR TITLE
Add ai setup command to configure openrouter key

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ npx @insforge/cli docs storage rest-api       # Show REST API storage docs
 
 ---
 
+### AI — `npx @insforge/cli ai`
+
+Configure local development for the InsForge Model Gateway. The setup command fetches the linked project's active OpenRouter key from the InsForge backend and writes it as the server-only `OPENROUTER_API_KEY` variable.
+
+```bash
+npx @insforge/cli ai setup
+npx @insforge/cli ai setup --env-file .env
+npx @insforge/cli ai setup --json
+```
+
+By default the CLI writes `.env.local` and adds `.env*.local` to `.gitignore` when needed. For deployments such as Vercel, add `OPENROUTER_API_KEY` to the provider's server/runtime environment. Do not rename the key to `NEXT_PUBLIC_`, `VITE_`, or `PUBLIC_`; those prefixes expose values to browser code.
+
+---
+
 ### Database — `npx @insforge/cli db`
 
 #### `npx @insforge/cli db query <sql>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/ai/index.ts
+++ b/src/commands/ai/index.ts
@@ -1,0 +1,7 @@
+import type { Command } from 'commander';
+import { registerAiSetupCommand } from './setup.js';
+
+export function registerAiCommands(aiCmd: Command): void {
+  aiCmd.description('Manage AI model gateway setup');
+  registerAiSetupCommand(aiCmd);
+}

--- a/src/commands/ai/index.ts
+++ b/src/commands/ai/index.ts
@@ -2,6 +2,5 @@ import type { Command } from 'commander';
 import { registerAiSetupCommand } from './setup.js';
 
 export function registerAiCommands(aiCmd: Command): void {
-  aiCmd.description('Manage AI model gateway setup');
   registerAiSetupCommand(aiCmd);
 }

--- a/src/commands/ai/setup.test.ts
+++ b/src/commands/ai/setup.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runAiSetup, ensureLocalEnvIgnored } from './setup.js';
+
+vi.mock('../../lib/api/ai.js', () => ({
+  getOpenRouterApiKey: vi.fn(async () => ({
+    apiKey: 'sk-or-secret',
+    maskedKey: 'sk-or-****cret',
+  })),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  getProjectConfig: vi.fn(() => ({
+    project_id: 'p1',
+    project_name: 'demo',
+    org_id: 'o1',
+    appkey: 'app',
+    region: 'us-east',
+    api_key: 'ik_test',
+    oss_host: 'https://app.us-east.insforge.app',
+  })),
+}));
+
+vi.mock('../../lib/analytics.js', () => ({
+  captureEvent: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+let dir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), 'cli-ai-setup-'));
+  process.chdir(dir);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('runAiSetup', () => {
+  it('writes OPENROUTER_API_KEY to .env.local and ignores local env files', async () => {
+    const result = await runAiSetup({ json: true });
+
+    expect(readFileSync(join(dir, '.env.local'), 'utf-8')).toBe(
+      'OPENROUTER_API_KEY=sk-or-secret\n',
+    );
+    expect(readFileSync(join(dir, '.gitignore'), 'utf-8')).toContain('.env*.local');
+    expect(result).toEqual({
+      envFile: '.env.local',
+      added: ['OPENROUTER_API_KEY'],
+      skipped: [],
+      mismatched: [],
+      gitignoreUpdated: true,
+      maskedKey: 'sk-or-****cret',
+    });
+  });
+
+  it('does not return the raw key in the setup result', async () => {
+    const result = await runAiSetup({ json: true });
+    expect(JSON.stringify(result)).not.toContain('sk-or-secret');
+  });
+
+  it('does not overwrite an existing different OpenRouter key', async () => {
+    writeFileSync(join(dir, '.env.local'), 'OPENROUTER_API_KEY=sk-or-existing\n');
+
+    const result = await runAiSetup({ json: true });
+
+    expect(readFileSync(join(dir, '.env.local'), 'utf-8')).toBe(
+      'OPENROUTER_API_KEY=sk-or-existing\n',
+    );
+    expect(result.added).toEqual([]);
+    expect(result.mismatched).toEqual(['OPENROUTER_API_KEY']);
+  });
+
+  it('respects --env-file paths and does not add non-local env files to gitignore', async () => {
+    const result = await runAiSetup({ json: true, envFile: '.env' });
+
+    expect(readFileSync(join(dir, '.env'), 'utf-8')).toBe(
+      'OPENROUTER_API_KEY=sk-or-secret\n',
+    );
+    expect(existsSync(join(dir, '.gitignore'))).toBe(false);
+    expect(result.envFile).toBe('.env');
+    expect(result.gitignoreUpdated).toBe(false);
+  });
+});
+
+describe('ensureLocalEnvIgnored', () => {
+  it('does not add .env*.local when .env* is already ignored', () => {
+    writeFileSync(join(dir, '.gitignore'), '.env*\n');
+    expect(ensureLocalEnvIgnored(dir, '.env.local')).toBe(false);
+    expect(readFileSync(join(dir, '.gitignore'), 'utf-8')).toBe('.env*\n');
+  });
+
+  it('does not update gitignore for env files outside the project', () => {
+    expect(ensureLocalEnvIgnored(dir, join(tmpdir(), '.env.local'))).toBe(false);
+    expect(existsSync(join(dir, '.gitignore'))).toBe(false);
+  });
+});

--- a/src/commands/ai/setup.test.ts
+++ b/src/commands/ai/setup.test.ts
@@ -78,6 +78,18 @@ describe('runAiSetup', () => {
     expect(result.mismatched).toEqual(['OPENROUTER_API_KEY']);
   });
 
+  it('skips an existing matching OpenRouter key', async () => {
+    writeFileSync(join(dir, '.env.local'), 'OPENROUTER_API_KEY=sk-or-secret\n');
+
+    const result = await runAiSetup({ json: true });
+
+    expect(readFileSync(join(dir, '.env.local'), 'utf-8')).toBe(
+      'OPENROUTER_API_KEY=sk-or-secret\n',
+    );
+    expect(result.added).toEqual([]);
+    expect(result.skipped).toEqual(['OPENROUTER_API_KEY']);
+  });
+
   it('respects --env-file paths and does not add non-local env files to gitignore', async () => {
     const result = await runAiSetup({ json: true, envFile: '.env' });
 
@@ -95,6 +107,14 @@ describe('ensureLocalEnvIgnored', () => {
     writeFileSync(join(dir, '.gitignore'), '.env*\n');
     expect(ensureLocalEnvIgnored(dir, '.env.local')).toBe(false);
     expect(readFileSync(join(dir, '.gitignore'), 'utf-8')).toBe('.env*\n');
+  });
+
+  it('adds .env*.local for non-default local env files when only .env.local is ignored', () => {
+    writeFileSync(join(dir, '.gitignore'), '.env.local\n');
+    expect(ensureLocalEnvIgnored(dir, '.env.staging.local')).toBe(true);
+    expect(readFileSync(join(dir, '.gitignore'), 'utf-8')).toBe(
+      '.env.local\n\n# Local environment secrets\n.env*.local\n',
+    );
   });
 
   it('does not update gitignore for env files outside the project', () => {

--- a/src/commands/ai/setup.ts
+++ b/src/commands/ai/setup.ts
@@ -9,6 +9,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { getRootOpts, handleError, ProjectNotLinkedError } from '../../lib/errors.js';
 import { upsertEnvFile } from '../../lib/env-writer.js';
 import { outputInfo, outputJson, outputSuccess } from '../../lib/output.js';
+import { isInteractive } from '../../lib/prompts.js';
 
 const DEFAULT_ENV_FILE = '.env.local';
 const OPENROUTER_ENV_KEY = 'OPENROUTER_API_KEY';
@@ -62,7 +63,16 @@ export async function runAiSetup(opts: RunAiSetupOptions): Promise<AiSetupResult
     outputSuccess(`Linked to InsForge project: ${project.project_name} (${project.project_id})`);
   }
 
-  const key = await getOpenRouterApiKey();
+  const spinner = !opts.json && isInteractive ? clack.spinner() : null;
+  spinner?.start('Fetching OpenRouter key...');
+  let key: Awaited<ReturnType<typeof getOpenRouterApiKey>>;
+  try {
+    key = await getOpenRouterApiKey();
+    spinner?.stop('Fetched OpenRouter key.');
+  } catch (err) {
+    spinner?.stop('Could not fetch OpenRouter key.');
+    throw err;
+  }
   const envFile = opts.envFile ?? DEFAULT_ENV_FILE;
   const envPath = resolve(process.cwd(), envFile);
   const envLabel = displayPath(envPath);
@@ -144,11 +154,12 @@ export function ensureLocalEnvIgnored(cwd: string, envFile: string): boolean {
   const gitignorePath = join(cwd, '.gitignore');
   const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : '';
   const lines = new Set(existing.split(/\r?\n/).map((line) => line.trim()));
+  const envBasename = envFile.replace(/\\/g, '/').split('/').pop() ?? envFile;
   if (
     lines.has('.env*') ||
     lines.has('.env.*') ||
     lines.has('.env*.local') ||
-    lines.has('.env.local')
+    (lines.has('.env.local') && envBasename === '.env.local')
   ) {
     return false;
   }

--- a/src/commands/ai/setup.ts
+++ b/src/commands/ai/setup.ts
@@ -1,0 +1,160 @@
+import type { Command } from 'commander';
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import * as clack from '@clack/prompts';
+import pc from 'picocolors';
+import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
+import { getOpenRouterApiKey } from '../../lib/api/ai.js';
+import { getProjectConfig } from '../../lib/config.js';
+import { getRootOpts, handleError, ProjectNotLinkedError } from '../../lib/errors.js';
+import { upsertEnvFile } from '../../lib/env-writer.js';
+import { outputInfo, outputJson, outputSuccess } from '../../lib/output.js';
+
+const DEFAULT_ENV_FILE = '.env.local';
+const OPENROUTER_ENV_KEY = 'OPENROUTER_API_KEY';
+
+export interface AiSetupResult {
+  envFile: string;
+  added: string[];
+  skipped: string[];
+  mismatched: string[];
+  gitignoreUpdated: boolean;
+  maskedKey?: string;
+}
+
+interface RunAiSetupOptions {
+  envFile?: string;
+  json: boolean;
+}
+
+export function registerAiSetupCommand(aiCmd: Command): void {
+  aiCmd
+    .command('setup')
+    .description('Write the linked project OpenRouter key to a local env file')
+    .option('--env-file <path>', `Env file to update (default: ${DEFAULT_ENV_FILE})`)
+    .action(async (opts: { envFile?: string }, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const result = await runAiSetup({
+          envFile: opts.envFile,
+          json,
+        });
+
+        if (json) {
+          outputJson({ success: true, ...result });
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+}
+
+export async function runAiSetup(opts: RunAiSetupOptions): Promise<AiSetupResult> {
+  const project = getProjectConfig();
+  if (!project) {
+    throw new ProjectNotLinkedError();
+  }
+
+  if (!opts.json) {
+    clack.intro('AI setup');
+    outputSuccess(`Linked to InsForge project: ${project.project_name} (${project.project_id})`);
+  }
+
+  const key = await getOpenRouterApiKey();
+  const envFile = opts.envFile ?? DEFAULT_ENV_FILE;
+  const envPath = resolve(process.cwd(), envFile);
+  const envLabel = displayPath(envPath);
+  const update = upsertEnvFile(envPath, { [OPENROUTER_ENV_KEY]: key.apiKey });
+  const gitignoreUpdated = ensureLocalEnvIgnored(process.cwd(), envFile);
+
+  captureEvent(project.project_id, 'cli_ai_setup', {
+    project_id: project.project_id,
+    project_name: project.project_name,
+    org_id: project.org_id,
+    region: project.region,
+    env_file: envLabel,
+    added: update.added.includes(OPENROUTER_ENV_KEY),
+    skipped: update.skipped.includes(OPENROUTER_ENV_KEY),
+    mismatched: update.mismatched.some((m) => m.key === OPENROUTER_ENV_KEY),
+  });
+
+  if (!opts.json) {
+    if (update.added.length > 0) {
+      outputSuccess(`Wrote ${envLabel}: ${update.added.join(', ')}`);
+    }
+    if (update.skipped.length > 0) {
+      outputInfo(pc.dim(`${envLabel}: ${update.skipped.join(', ')} already set (matching) - left as-is.`));
+    }
+    for (const m of update.mismatched) {
+      clack.log.warn(
+        `${envLabel} already has ${m.key}; left existing value untouched. Remove it or pass --env-file to write elsewhere.`,
+      );
+    }
+    if (gitignoreUpdated) {
+      outputInfo(pc.dim('Added .env*.local to .gitignore.'));
+    }
+    if (!isLocalEnvFile(envFile)) {
+      clack.log.warn(
+        `${envLabel} may be committed unless it is listed in .gitignore. Keep ${OPENROUTER_ENV_KEY} server-only.`,
+      );
+    }
+
+    outputInfo('');
+    outputInfo('Use this key only from server-side code as process.env.OPENROUTER_API_KEY.');
+    outputInfo('For deployment, add OPENROUTER_API_KEY to your hosting provider environment.');
+    outputInfo(`Do not rename it to ${pc.bold('NEXT_PUBLIC_')}, ${pc.bold('VITE_')}, or ${pc.bold('PUBLIC_')}.`);
+    clack.outro('Done.');
+  }
+
+  return {
+    envFile: envLabel,
+    added: update.added,
+    skipped: update.skipped,
+    mismatched: update.mismatched.map((m) => m.key),
+    gitignoreUpdated,
+    maskedKey: key.maskedKey,
+  };
+}
+
+function displayPath(path: string): string {
+  const rel = relative(process.cwd(), path);
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    return path;
+  }
+  return rel;
+}
+
+function isLocalEnvFile(envFile: string): boolean {
+  const normalized = envFile.replace(/\\/g, '/');
+  const basename = normalized.split('/').pop() ?? normalized;
+  return basename === '.env.local' || /^\.env\..+\.local$/.test(basename);
+}
+
+export function ensureLocalEnvIgnored(cwd: string, envFile: string): boolean {
+  if (!isLocalEnvFile(envFile)) return false;
+
+  const envPath = resolve(cwd, envFile);
+  const relEnvPath = relative(cwd, envPath);
+  if (!relEnvPath || relEnvPath.startsWith('..') || isAbsolute(relEnvPath)) {
+    return false;
+  }
+
+  const gitignorePath = join(cwd, '.gitignore');
+  const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : '';
+  const lines = new Set(existing.split(/\r?\n/).map((line) => line.trim()));
+  if (
+    lines.has('.env*') ||
+    lines.has('.env.*') ||
+    lines.has('.env*.local') ||
+    lines.has('.env.local')
+  ) {
+    return false;
+  }
+
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const spacer = existing.length > 0 ? '\n' : '';
+  appendFileSync(gitignorePath, `${prefix}${spacer}# Local environment secrets\n.env*.local\n`);
+  return true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import { registerDiagnoseCommands } from './commands/diagnose/index.js';
 import { registerPaymentsCommands } from './commands/payments/index.js';
 import { registerPosthogSetupCommand } from './commands/posthog/setup.js';
 import { registerConfigCommand } from './commands/config/index.js';
+import { registerAiCommands } from './commands/ai/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
@@ -208,6 +209,10 @@ registerComputeEventsCommand(computeCmd);
 // PostHog commands
 const posthogCmd = program.command('posthog').description('Manage PostHog product analytics integration');
 registerPosthogSetupCommand(posthogCmd);
+
+// AI commands
+const aiCmd = program.command('ai').description('Manage AI model gateway setup');
+registerAiCommands(aiCmd);
 
 // Schedules commands
 const schedulesCmd = program.command('schedules').description('Manage scheduled tasks (cron jobs)');

--- a/src/lib/api/ai.test.ts
+++ b/src/lib/api/ai.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getOpenRouterApiKey } from './ai.js';
+
+vi.mock('./oss.js', () => ({
+  ossFetch: vi.fn(),
+}));
+
+describe('getOpenRouterApiKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the OpenRouter key from the AI backend endpoint', async () => {
+    const { ossFetch } = await import('./oss.js');
+    (ossFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({ apiKey: 'sk-or-test', maskedKey: 'sk-or-****test' }),
+    });
+
+    await expect(getOpenRouterApiKey()).resolves.toEqual({
+      apiKey: 'sk-or-test',
+      maskedKey: 'sk-or-****test',
+    });
+    expect(ossFetch).toHaveBeenCalledWith('/api/ai/openrouter/api-key');
+  });
+
+  it('throws a clear error when the backend returns no raw key', async () => {
+    const { ossFetch } = await import('./oss.js');
+    (ossFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({ maskedKey: 'sk-or-****test' }),
+    });
+
+    await expect(getOpenRouterApiKey()).rejects.toThrow(/returned no OpenRouter API key/);
+  });
+});

--- a/src/lib/api/ai.test.ts
+++ b/src/lib/api/ai.test.ts
@@ -13,7 +13,7 @@ describe('getOpenRouterApiKey', () => {
   it('fetches the OpenRouter key from the AI backend endpoint', async () => {
     const { ossFetch } = await import('./oss.js');
     (ossFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      json: async () => ({ apiKey: 'sk-or-test', maskedKey: 'sk-or-****test' }),
+      json: async () => ({ apiKey: ' sk-or-test ', maskedKey: ' sk-or-****test ' }),
     });
 
     await expect(getOpenRouterApiKey()).resolves.toEqual({
@@ -27,6 +27,15 @@ describe('getOpenRouterApiKey', () => {
     const { ossFetch } = await import('./oss.js');
     (ossFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       json: async () => ({ maskedKey: 'sk-or-****test' }),
+    });
+
+    await expect(getOpenRouterApiKey()).rejects.toThrow(/returned no OpenRouter API key/);
+  });
+
+  it('throws a clear error when the backend returns a whitespace-only key', async () => {
+    const { ossFetch } = await import('./oss.js');
+    (ossFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({ apiKey: '   ', maskedKey: 'sk-or-****test' }),
     });
 
     await expect(getOpenRouterApiKey()).rejects.toThrow(/returned no OpenRouter API key/);

--- a/src/lib/api/ai.ts
+++ b/src/lib/api/ai.ts
@@ -9,15 +9,17 @@ export interface OpenRouterKeyResponse {
 export async function getOpenRouterApiKey(): Promise<OpenRouterKeyResponse> {
   const res = await ossFetch('/api/ai/openrouter/api-key');
   const data = await res.json() as Partial<OpenRouterKeyResponse>;
+  const apiKey = typeof data.apiKey === 'string' ? data.apiKey.trim() : '';
+  const maskedKey = typeof data.maskedKey === 'string' ? data.maskedKey.trim() : undefined;
 
-  if (typeof data.apiKey !== 'string' || data.apiKey.length === 0) {
+  if (apiKey.length === 0) {
     throw new CLIError(
       'AI gateway returned no OpenRouter API key. Open the InsForge dashboard AI page and verify Model Gateway is configured.',
     );
   }
 
   return {
-    apiKey: data.apiKey,
-    maskedKey: typeof data.maskedKey === 'string' ? data.maskedKey : undefined,
+    apiKey,
+    maskedKey,
   };
 }

--- a/src/lib/api/ai.ts
+++ b/src/lib/api/ai.ts
@@ -1,0 +1,23 @@
+import { CLIError } from '../errors.js';
+import { ossFetch } from './oss.js';
+
+export interface OpenRouterKeyResponse {
+  apiKey: string;
+  maskedKey?: string;
+}
+
+export async function getOpenRouterApiKey(): Promise<OpenRouterKeyResponse> {
+  const res = await ossFetch('/api/ai/openrouter/api-key');
+  const data = await res.json() as Partial<OpenRouterKeyResponse>;
+
+  if (typeof data.apiKey !== 'string' || data.apiKey.length === 0) {
+    throw new CLIError(
+      'AI gateway returned no OpenRouter API key. Open the InsForge dashboard AI page and verify Model Gateway is configured.',
+    );
+  }
+
+  return {
+    apiKey: data.apiKey,
+    maskedKey: typeof data.maskedKey === 'string' ? data.maskedKey : undefined,
+  };
+}

--- a/src/lib/api/oss.test.ts
+++ b/src/lib/api/oss.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { isMaskedDatabasePassword, spliceDatabasePassword } from './oss.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as config from '../config.js';
+import { isMaskedDatabasePassword, ossFetch, spliceDatabasePassword } from './oss.js';
+import type { ProjectConfig } from '../../types.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('spliceDatabasePassword', () => {
   // Real shape from cloud `/api/metadata/database-connection-string`
@@ -45,5 +51,29 @@ describe('isMaskedDatabasePassword', () => {
   });
   it('does not flag empty string (caller checks emptiness separately)', () => {
     expect(isMaskedDatabasePassword('')).toBe(false);
+  });
+});
+
+describe('ossFetch', () => {
+  it('shows an AI-specific 404 message for backends without Model Gateway setup', async () => {
+    vi.spyOn(config, 'getProjectConfig').mockReturnValue({
+      project_id: 'p1',
+      project_name: 'demo',
+      org_id: 'o1',
+      appkey: 'app',
+      region: 'us-east',
+      api_key: 'ik_test',
+      oss_host: 'https://app.us-east.insforge.app',
+    } satisfies ProjectConfig);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'NOT_FOUND' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(ossFetch('/api/ai/openrouter/api-key')).rejects.toThrow(
+      /Upgrade your InsForge project to a version with Model Gateway support/,
+    );
   });
 });

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -154,6 +154,10 @@ export async function ossFetch(
       message = 'Database migrations are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin about database migration support.';
     }
 
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/ai')) {
+      message = 'AI Model Gateway setup is not available on this backend.\nUpgrade your InsForge project to a version with Model Gateway support, or keep using the legacy @insforge/sdk AI modules for projects that still rely on the older AI API surface.';
+    }
+
     throw new CLIError(message);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ai setup` to `@insforge/cli` to configure the InsForge Model Gateway by fetching the project’s OpenRouter key and writing `OPENROUTER_API_KEY` to an env file with safe defaults. Bumps the CLI to `0.1.78`.

- **New Features**
  - `npx @insforge/cli ai setup` writes `OPENROUTER_API_KEY` (defaults to `.env.local`).
  - Supports `--env-file <path>` and `--json`.
  - Adds `.env*.local` to `.gitignore` only for local env files inside the project.
  - Does not overwrite a different existing key; reports mismatches.
  - JSON output returns only `maskedKey`; the raw key is never returned.

- **Bug Fixes**
  - Clear, AI-specific 404 when the backend lacks Model Gateway support.
  - Clear error if the backend returns a missing or whitespace-only key.

<sup>Written for commit 922d7ef454397f51b630e112de84df5fa5bde5d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ai` command with `setup` subcommand to fetch and store an OpenRouter API key (supports custom env file and JSON output)

* **Documentation**
  * README updated with AI command usage, setup workflow, env-file options, and secure deployment guidance

* **Behavior**
  * Improved error messaging when AI-related backend routes are unavailable

* **Tests**
  * Added tests covering setup flow, key retrieval, env-file handling, and ignore-file updates

* **Chores**
  * Version bumped to 0.1.78

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/126)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ai setup` command to fetch and write OpenRouter API key to an env file
> - Adds a new `ai setup` CLI subcommand that fetches the project's `OPENROUTER_API_KEY` from the backend via [`getOpenRouterApiKey`](https://github.com/InsForge/CLI/pull/126/files#diff-b3ab88dd635a545dd2f0c4716a53a7b30c05ed9f23cbae5ee66dc7ecbb302a45) and writes it to an env file (default `.env.local`) using `upsertEnvFile`.
> - Skips overwriting if an existing key differs, and reports mismatched keys without exposing the raw value.
> - Automatically appends `.env*.local` to `.gitignore` when the target file is a local env file inside the project and no equivalent ignore rule exists.
> - Supports `--env-file` to target a custom env file and `--json` for machine-readable output; the JSON result includes a `maskedKey` but never the raw key.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #126 opened
>
> - Added `ai setup` command to configure `openrouter` API key [922d7ef]
> - Bumped package version from 0.1.77 to 0.1.78 [922d7ef]
> - Modified `.gitignore` update logic for non-default local environment files [e3e580e]
> - Added whitespace trimming and validation for OpenRouter API keys [e3e580e]
> - Added AI-specific error messaging for route-level 404 responses [e3e580e]
> - Added interactive progress spinner during OpenRouter API key fetching [e3e580e]
> - Removed description setting for top-level AI command [e3e580e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c0fa38.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->