### PR TITLE
feat(cli): add auth verification + password policy to insforge.toml

### DIFF
--- a/src/commands/config/apply.ts
+++ b/src/commands/config/apply.ts
@@ -8,35 +8,16 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { parseConfigToml } from '../../lib/config-toml.js';
-import { diffConfig, type DiffChange, type LiveConfig } from '../../lib/config-diff.js';
+import { diffConfig, type DiffChange } from '../../lib/config-diff.js';
 import { formatPlan } from '../../lib/config-format.js';
-import { metadataSupports, changePath } from '../../lib/config-capabilities.js';
+import {
+  metadataSupports,
+  changePath,
+  authPasswordWireKey,
+} from '../../lib/config-capabilities.js';
 import { resolveEnvRef } from '../../lib/config-secrets.js';
+import { liveFromMetadata, type RawMetadataResponse } from '../../lib/config-metadata.js';
 import { reportCliUsage } from '../../lib/skills.js';
-
-interface RawAuthMetadata {
-  allowedRedirectUrls?: string[];
-  smtpConfig?: {
-    enabled?: boolean;
-    host?: string;
-    port?: number;
-    username?: string;
-    hasPassword?: boolean;
-    senderEmail?: string;
-    senderName?: string;
-    minIntervalSeconds?: number;
-  };
-}
-
-interface RawMetadataResponse {
-  auth?: RawAuthMetadata;
-  // Cloud-only slice (InsForge#1259). Self-host or pre-#1259 backends omit
-  // the key entirely; the capability gate uses presence/absence to decide
-  // whether [deployments] writes are honored.
-  deployments?: {
-    customSlug?: string | null;
-  };
-}
 
 export function registerConfigApplyCommand(cfg: Command): void {
   cfg
@@ -146,35 +127,44 @@ export function registerConfigApplyCommand(cfg: Command): void {
     });
 }
 
-function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
-  const live: LiveConfig = { auth: {} };
-  if (raw.auth?.allowedRedirectUrls !== undefined) {
-    live.auth!.allowed_redirect_urls = raw.auth.allowedRedirectUrls;
-  }
-  if (raw.auth?.smtpConfig) {
-    const s = raw.auth.smtpConfig;
-    live.auth!.smtp = {
-      enabled: s.enabled ?? false,
-      host: s.host ?? '',
-      port: s.port ?? 587,
-      username: s.username ?? '',
-      hasPassword: s.hasPassword ?? false,
-      sender_email: s.senderEmail ?? '',
-      sender_name: s.senderName ?? '',
-      min_interval_seconds: s.minIntervalSeconds ?? 60,
-    };
-  }
-  if (raw.deployments) {
-    live.deployments = { subdomain: raw.deployments.customSlug ?? null };
-  }
-  return live;
-}
-
 async function applyChange(change: DiffChange): Promise<void> {
   if (change.section === 'auth' && change.key === 'allowed_redirect_urls') {
     await ossFetch('/api/auth/config', {
       method: 'PUT',
       body: JSON.stringify({ allowedRedirectUrls: change.to }),
+    });
+    return;
+  }
+  if (change.section === 'auth' && change.key === 'require_email_verification') {
+    await ossFetch('/api/auth/config', {
+      method: 'PUT',
+      body: JSON.stringify({ requireEmailVerification: change.to }),
+    });
+    return;
+  }
+  if (change.section === 'auth' && change.key === 'verify_email_method') {
+    await ossFetch('/api/auth/config', {
+      method: 'PUT',
+      body: JSON.stringify({ verifyEmailMethod: change.to }),
+    });
+    return;
+  }
+  if (change.section === 'auth' && change.key === 'reset_password_method') {
+    await ossFetch('/api/auth/config', {
+      method: 'PUT',
+      body: JSON.stringify({ resetPasswordMethod: change.to }),
+    });
+    return;
+  }
+  if (change.section === 'auth.password') {
+    // Each password policy field is independently dispatched — same endpoint,
+    // partial body. The capability gate already confirmed the field exists on
+    // this backend; the wire key is centralized in config-capabilities so a
+    // future rename touches one place.
+    const wireKey = authPasswordWireKey(change.key);
+    await ossFetch('/api/auth/config', {
+      method: 'PUT',
+      body: JSON.stringify({ [wireKey]: change.to }),
     });
     return;
   }

--- a/src/commands/config/export.test.ts
+++ b/src/commands/config/export.test.ts
@@ -107,9 +107,15 @@ describe('config export (capability probe)', () => {
       'https://b.com',
     ]);
     expect(result.config.auth?.smtp).toBeDefined();
-    // No deployments slice in this fixture — that section gets skipped, but
-    // the auth slice still produces a valid TOML.
-    expect(result.skipped).toEqual(['deployments.subdomain']);
+    // Only allowedRedirectUrls and smtpConfig are in the fixture; everything
+    // else (verification flags, password policy, deployments) gets skipped.
+    expect(result.skipped.sort()).toEqual([
+      'auth.password',
+      'auth.require_email_verification',
+      'auth.reset_password_method',
+      'auth.verify_email_method',
+      'deployments.subdomain',
+    ]);
 
     const written = readFileSync(target, 'utf8');
     expect(written).toContain('allowed_redirect_urls');
@@ -213,7 +219,11 @@ describe('config export (capability probe)', () => {
     expect(result.config.auth).toBeUndefined();
     expect(result.skipped.sort()).toEqual([
       'auth.allowed_redirect_urls',
+      'auth.password',
+      'auth.require_email_verification',
+      'auth.reset_password_method',
       'auth.smtp',
+      'auth.verify_email_method',
       'deployments.subdomain',
     ]);
     // File is still written so future apply cycles work — just empty.
@@ -243,9 +253,15 @@ describe('config export (capability probe)', () => {
       skipped: string[];
     };
     expect(result.config.deployments).toEqual({ subdomain: 'my-app' });
-    // No smtpConfig in fixture → that section gets skipped, but the
-    // deployments section still emits cleanly.
-    expect(result.skipped).toEqual(['auth.smtp']);
+    // No smtpConfig or auth.* fields in fixture → those sections get skipped,
+    // but the deployments section still emits cleanly.
+    expect(result.skipped.sort()).toEqual([
+      'auth.password',
+      'auth.require_email_verification',
+      'auth.reset_password_method',
+      'auth.smtp',
+      'auth.verify_email_method',
+    ]);
 
     const written = readFileSync(target, 'utf8');
     expect(written).toContain('[deployments]');
@@ -278,7 +294,13 @@ describe('config export (capability probe)', () => {
       skipped: string[];
     };
     expect(result.config.deployments).toBeUndefined();
-    expect(result.skipped).toEqual(['auth.smtp']);
+    expect(result.skipped.sort()).toEqual([
+      'auth.password',
+      'auth.require_email_verification',
+      'auth.reset_password_method',
+      'auth.smtp',
+      'auth.verify_email_method',
+    ]);
 
     const written = readFileSync(target, 'utf8');
     expect(written).not.toContain('[deployments]');

--- a/src/commands/config/export.ts
+++ b/src/commands/config/export.ts
@@ -8,8 +8,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { stringifyConfigToml } from '../../lib/config-toml.js';
-import type { InsforgeConfig } from '../../lib/config-schema.js';
-import type { RawMetadataResponse } from '../../lib/config-metadata.js';
+import { configFromMetadata, type RawMetadataResponse } from '../../lib/config-metadata.js';
 import { reportCliUsage } from '../../lib/skills.js';
 
 export function registerConfigExportCommand(cfg: Command): void {
@@ -47,121 +46,10 @@ export function registerConfigExportCommand(cfg: Command): void {
         const res = await ossFetch('/api/metadata');
         const raw = (await res.json()) as RawMetadataResponse;
 
-        // Only emit sections the backend actually exposes. The TOML file
-        // should describe what THIS backend can do — not aspirational fields
-        // that would break on apply. Probe presence in the raw response;
-        // an older backend without the field gets an empty config,
-        // not a TOML littered with defaults that pretend to work.
-        const config: InsforgeConfig = {};
-        const skipped: string[] = [];
-
-        const authSlice = raw?.auth;
-        const authObj =
-          authSlice && typeof authSlice === 'object' ? authSlice : undefined;
-
-        if (authObj && 'allowedRedirectUrls' in authObj) {
-          config.auth = config.auth ?? {};
-          config.auth.allowed_redirect_urls = authObj.allowedRedirectUrls ?? [];
-        } else {
-          skipped.push('auth.allowed_redirect_urls');
-        }
-
-        if (authObj && 'requireEmailVerification' in authObj) {
-          config.auth = config.auth ?? {};
-          config.auth.require_email_verification = authObj.requireEmailVerification ?? false;
-        } else {
-          skipped.push('auth.require_email_verification');
-        }
-
-        if (
-          authObj &&
-          'verifyEmailMethod' in authObj &&
-          (authObj.verifyEmailMethod === 'code' || authObj.verifyEmailMethod === 'link')
-        ) {
-          config.auth = config.auth ?? {};
-          config.auth.verify_email_method = authObj.verifyEmailMethod;
-        } else {
-          skipped.push('auth.verify_email_method');
-        }
-
-        if (
-          authObj &&
-          'resetPasswordMethod' in authObj &&
-          (authObj.resetPasswordMethod === 'code' || authObj.resetPasswordMethod === 'link')
-        ) {
-          config.auth = config.auth ?? {};
-          config.auth.reset_password_method = authObj.resetPasswordMethod;
-        } else {
-          skipped.push('auth.reset_password_method');
-        }
-
-        // Emit [auth.password] only when the backend exposes at least one
-        // policy field. Each present field copies through; missing ones stay
-        // out of the TOML so re-applying the export is a no-op (default-keep).
-        if (
-          authObj &&
-          ('passwordMinLength' in authObj ||
-            'requireNumber' in authObj ||
-            'requireLowercase' in authObj ||
-            'requireUppercase' in authObj ||
-            'requireSpecialChar' in authObj)
-        ) {
-          config.auth = config.auth ?? {};
-          config.auth.password = {};
-          if ('passwordMinLength' in authObj) {
-            config.auth.password.min_length = authObj.passwordMinLength ?? 8;
-          }
-          if ('requireNumber' in authObj) {
-            config.auth.password.require_number = authObj.requireNumber ?? false;
-          }
-          if ('requireLowercase' in authObj) {
-            config.auth.password.require_lowercase = authObj.requireLowercase ?? false;
-          }
-          if ('requireUppercase' in authObj) {
-            config.auth.password.require_uppercase = authObj.requireUppercase ?? false;
-          }
-          if ('requireSpecialChar' in authObj) {
-            config.auth.password.require_special_char = authObj.requireSpecialChar ?? false;
-          }
-        } else {
-          skipped.push('auth.password');
-        }
-
-        if (authObj && 'smtpConfig' in authObj && authObj.smtpConfig) {
-          const s = authObj.smtpConfig;
-          config.auth = config.auth ?? {};
-          config.auth.smtp = {
-            enabled: s.enabled ?? false,
-            host: s.host ?? '',
-            port: s.port ?? 587,
-            username: s.username ?? '',
-            // When backend has a password set, emit a deterministic env()
-            // placeholder so the user knows which secret to define. We do
-            // NOT round-trip the value (it never leaves the backend).
-            // Re-applying this TOML force-resends from the secrets store
-            // — see config-diff.ts for the force-resend rationale.
-            ...(s.hasPassword ? { password: 'env(SMTP_PASSWORD)' } : {}),
-            sender_email: s.senderEmail ?? '',
-            sender_name: s.senderName ?? '',
-            min_interval_seconds: s.minIntervalSeconds ?? 60,
-          };
-        } else {
-          skipped.push('auth.smtp');
-        }
-
-        const deploymentsSlice = raw?.deployments;
-        if (deploymentsSlice && typeof deploymentsSlice === 'object') {
-          // Cloud backend exposes the slice. Only emit a value when a slug
-          // is actually set — an unset slug means the project is on its
-          // default URL, and surfacing subdomain = "" in the TOML would
-          // imply "clear on apply" (and fail the backend's 3-char min).
-          if (typeof deploymentsSlice.customSlug === 'string' && deploymentsSlice.customSlug) {
-            config.deployments = { subdomain: deploymentsSlice.customSlug };
-          }
-        } else {
-          // Self-host or pre-#1259 backend — slice missing entirely.
-          skipped.push('deployments.subdomain');
-        }
+        // Field detection lives in config-metadata.ts alongside liveFromMetadata
+        // so apply/plan/export read the same response the same way. Adding a
+        // new field touches one place, not three.
+        const { config, skipped } = configFromMetadata(raw);
 
         const toml = stringifyConfigToml(config);
         writeFileSync(target, toml, 'utf8');

--- a/src/commands/config/export.ts
+++ b/src/commands/config/export.ts
@@ -9,31 +9,8 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { stringifyConfigToml } from '../../lib/config-toml.js';
 import type { InsforgeConfig } from '../../lib/config-schema.js';
+import type { RawMetadataResponse } from '../../lib/config-metadata.js';
 import { reportCliUsage } from '../../lib/skills.js';
-
-interface RawAuthMetadata {
-  allowedRedirectUrls?: string[];
-  smtpConfig?: {
-    enabled?: boolean;
-    host?: string;
-    port?: number;
-    username?: string;
-    hasPassword?: boolean;
-    senderEmail?: string;
-    senderName?: string;
-    minIntervalSeconds?: number;
-  };
-}
-
-interface RawMetadataResponse {
-  auth?: RawAuthMetadata;
-  // Cloud-only slice. Self-host or pre-#1259 backends omit the key
-  // entirely; presence is the signal the CLI uses to decide whether to
-  // emit a [deployments] section.
-  deployments?: {
-    customSlug?: string | null;
-  };
-}
 
 export function registerConfigExportCommand(cfg: Command): void {
   cfg
@@ -79,20 +56,79 @@ export function registerConfigExportCommand(cfg: Command): void {
         const skipped: string[] = [];
 
         const authSlice = raw?.auth;
-        if (authSlice && typeof authSlice === 'object' && 'allowedRedirectUrls' in authSlice) {
+        const authObj =
+          authSlice && typeof authSlice === 'object' ? authSlice : undefined;
+
+        if (authObj && 'allowedRedirectUrls' in authObj) {
           config.auth = config.auth ?? {};
-          config.auth.allowed_redirect_urls = authSlice.allowedRedirectUrls ?? [];
+          config.auth.allowed_redirect_urls = authObj.allowedRedirectUrls ?? [];
         } else {
           skipped.push('auth.allowed_redirect_urls');
         }
 
+        if (authObj && 'requireEmailVerification' in authObj) {
+          config.auth = config.auth ?? {};
+          config.auth.require_email_verification = authObj.requireEmailVerification ?? false;
+        } else {
+          skipped.push('auth.require_email_verification');
+        }
+
         if (
-          authSlice &&
-          typeof authSlice === 'object' &&
-          'smtpConfig' in authSlice &&
-          authSlice.smtpConfig
+          authObj &&
+          'verifyEmailMethod' in authObj &&
+          (authObj.verifyEmailMethod === 'code' || authObj.verifyEmailMethod === 'link')
         ) {
-          const s = authSlice.smtpConfig;
+          config.auth = config.auth ?? {};
+          config.auth.verify_email_method = authObj.verifyEmailMethod;
+        } else {
+          skipped.push('auth.verify_email_method');
+        }
+
+        if (
+          authObj &&
+          'resetPasswordMethod' in authObj &&
+          (authObj.resetPasswordMethod === 'code' || authObj.resetPasswordMethod === 'link')
+        ) {
+          config.auth = config.auth ?? {};
+          config.auth.reset_password_method = authObj.resetPasswordMethod;
+        } else {
+          skipped.push('auth.reset_password_method');
+        }
+
+        // Emit [auth.password] only when the backend exposes at least one
+        // policy field. Each present field copies through; missing ones stay
+        // out of the TOML so re-applying the export is a no-op (default-keep).
+        if (
+          authObj &&
+          ('passwordMinLength' in authObj ||
+            'requireNumber' in authObj ||
+            'requireLowercase' in authObj ||
+            'requireUppercase' in authObj ||
+            'requireSpecialChar' in authObj)
+        ) {
+          config.auth = config.auth ?? {};
+          config.auth.password = {};
+          if ('passwordMinLength' in authObj) {
+            config.auth.password.min_length = authObj.passwordMinLength ?? 8;
+          }
+          if ('requireNumber' in authObj) {
+            config.auth.password.require_number = authObj.requireNumber ?? false;
+          }
+          if ('requireLowercase' in authObj) {
+            config.auth.password.require_lowercase = authObj.requireLowercase ?? false;
+          }
+          if ('requireUppercase' in authObj) {
+            config.auth.password.require_uppercase = authObj.requireUppercase ?? false;
+          }
+          if ('requireSpecialChar' in authObj) {
+            config.auth.password.require_special_char = authObj.requireSpecialChar ?? false;
+          }
+        } else {
+          skipped.push('auth.password');
+        }
+
+        if (authObj && 'smtpConfig' in authObj && authObj.smtpConfig) {
+          const s = authObj.smtpConfig;
           config.auth = config.auth ?? {};
           config.auth.smtp = {
             enabled: s.enabled ?? false,

--- a/src/commands/config/plan.ts
+++ b/src/commands/config/plan.ts
@@ -10,7 +10,7 @@ import { parseConfigToml } from '../../lib/config-toml.js';
 import { diffConfig } from '../../lib/config-diff.js';
 import { formatPlan } from '../../lib/config-format.js';
 import { metadataSupports, changePath } from '../../lib/config-capabilities.js';
-import type { InsforgeConfig } from '../../lib/config-schema.js';
+import { liveFromMetadata, type RawMetadataResponse } from '../../lib/config-metadata.js';
 import { reportCliUsage } from '../../lib/skills.js';
 
 export function registerConfigPlanCommand(cfg: Command): void {
@@ -28,12 +28,8 @@ export function registerConfigPlanCommand(cfg: Command): void {
         const file = parseConfigToml(tomlSource);
 
         const res = await ossFetch('/api/metadata');
-        const raw = (await res.json()) as {
-          auth?: { allowedRedirectUrls?: string[] };
-        };
-        const live: InsforgeConfig = {
-          auth: { allowed_redirect_urls: raw.auth?.allowedRedirectUrls ?? [] },
-        };
+        const raw = (await res.json()) as RawMetadataResponse;
+        const live = liveFromMetadata(raw);
 
         const result = diffConfig({ live, file });
 

--- a/src/lib/config-capabilities.test.ts
+++ b/src/lib/config-capabilities.test.ts
@@ -87,8 +87,86 @@ describe('metadataSupports — deployments.subdomain', () => {
   });
 });
 
+describe('metadataSupports — auth verification flags', () => {
+  it('probes requireEmailVerification by presence', () => {
+    const ch: DiffChange = {
+      section: 'auth',
+      op: 'modify',
+      key: 'require_email_verification',
+      from: false,
+      to: true,
+    };
+    expect(metadataSupports({ auth: { requireEmailVerification: false } }, ch)).toBe(true);
+    expect(metadataSupports({ auth: {} }, ch)).toBe(false);
+  });
+
+  it('probes verifyEmailMethod and resetPasswordMethod by presence', () => {
+    const verify: DiffChange = {
+      section: 'auth',
+      op: 'modify',
+      key: 'verify_email_method',
+      from: 'code',
+      to: 'link',
+    };
+    const reset: DiffChange = {
+      section: 'auth',
+      op: 'modify',
+      key: 'reset_password_method',
+      from: 'code',
+      to: 'link',
+    };
+    const raw = { auth: { verifyEmailMethod: 'code', resetPasswordMethod: 'code' } };
+    expect(metadataSupports(raw, verify)).toBe(true);
+    expect(metadataSupports(raw, reset)).toBe(true);
+    expect(metadataSupports({ auth: {} }, verify)).toBe(false);
+    expect(metadataSupports({ auth: {} }, reset)).toBe(false);
+  });
+});
+
+describe('metadataSupports — [auth.password] per-field', () => {
+  const minLengthChange: DiffChange = {
+    section: 'auth.password',
+    op: 'modify',
+    key: 'min_length',
+    from: 8,
+    to: 12,
+  };
+  const requireNumberChange: DiffChange = {
+    section: 'auth.password',
+    op: 'modify',
+    key: 'require_number',
+    from: false,
+    to: true,
+  };
+
+  it('returns true when the matching flat camelCase key is present', () => {
+    expect(metadataSupports({ auth: { passwordMinLength: 8 } }, minLengthChange)).toBe(true);
+    expect(metadataSupports({ auth: { requireNumber: true } }, requireNumberChange)).toBe(true);
+  });
+
+  it('returns false when the matching key is absent', () => {
+    // Backend exposed min_length but not require_number — only the supported
+    // field passes the probe. Lets a future backend ship the policy fields
+    // piecemeal without breaking the CLI.
+    expect(metadataSupports({ auth: { passwordMinLength: 8 } }, requireNumberChange)).toBe(false);
+    expect(metadataSupports({ auth: {} }, minLengthChange)).toBe(false);
+  });
+});
+
 describe('changePath', () => {
   it('joins section and key with a dot', () => {
     expect(changePath(change)).toBe('auth.allowed_redirect_urls');
+  });
+
+  it('renders auth.password.* fields with the full path', () => {
+    expect(
+      changePath({
+        section: 'auth.password',
+        op: 'modify',
+        key: 'min_length',
+        from: 8,
+        to: 12,
+      }),
+    ).toBe('auth.password.min_length');
   });
 });

--- a/src/lib/config-capabilities.ts
+++ b/src/lib/config-capabilities.ts
@@ -25,11 +25,14 @@
 
 import type { DiffChange } from './config-diff.js';
 
+// The probe takes the metadata response loosely-typed: typed shapes from
+// callers (RawMetadataResponse) and Record<string, unknown> both satisfy
+// this. Runtime checks below verify the actual structure before reading.
 type RawMetadata = {
-  auth?: Record<string, unknown>;
+  auth?: unknown;
   // Cloud-only slice. Self-host backends omit the key entirely — that's the
   // signal we use to gate [deployments] writes (self-host can't honor them).
-  deployments?: Record<string, unknown>;
+  deployments?: unknown;
 };
 
 /**
@@ -39,22 +42,28 @@ type RawMetadata = {
  */
 export function metadataSupports(raw: RawMetadata, change: DiffChange): boolean {
   if (change.section === 'auth' && change.key === 'allowed_redirect_urls') {
-    return (
-      raw?.auth !== undefined &&
-      raw.auth !== null &&
-      typeof raw.auth === 'object' &&
-      'allowedRedirectUrls' in raw.auth
-    );
+    return hasAuthKey(raw, 'allowedRedirectUrls');
+  }
+  if (change.section === 'auth' && change.key === 'require_email_verification') {
+    return hasAuthKey(raw, 'requireEmailVerification');
+  }
+  if (change.section === 'auth' && change.key === 'verify_email_method') {
+    return hasAuthKey(raw, 'verifyEmailMethod');
+  }
+  if (change.section === 'auth' && change.key === 'reset_password_method') {
+    return hasAuthKey(raw, 'resetPasswordMethod');
+  }
+  if (change.section === 'auth.password') {
+    // Per-key probes. The backend exposes each password policy field as a
+    // flat key under `auth` (not a nested passwordPolicy object), so a
+    // legacy backend that only added e.g. passwordMinLength but not the
+    // require_* flags would still get partial support.
+    return hasAuthKey(raw, AUTH_PASSWORD_WIRE_KEY[change.key]);
   }
   if (change.section === 'auth.smtp') {
     // SMTP is whole-object: a backend either exposes `smtpConfig` in
     // /api/metadata (and accepts PUT /api/auth/smtp-config) or doesn't.
-    return (
-      raw?.auth !== undefined &&
-      raw.auth !== null &&
-      typeof raw.auth === 'object' &&
-      'smtpConfig' in raw.auth
-    );
+    return hasAuthKey(raw, 'smtpConfig');
   }
   if (change.section === 'deployments' && change.key === 'subdomain') {
     // Presence-only probe: cloud backends always carry `customSlug` in the
@@ -73,10 +82,41 @@ export function metadataSupports(raw: RawMetadata, change: DiffChange): boolean 
   return false;
 }
 
+function hasAuthKey(raw: RawMetadata, key: string): boolean {
+  const auth = raw?.auth;
+  return auth !== undefined && auth !== null && typeof auth === 'object' && key in auth;
+}
+
+// Maps TOML keys under [auth.password] to the flat camelCase fields the
+// backend emits on /api/metadata's auth slice. Single source of truth used
+// by both the capability probe and the apply dispatcher (via authPasswordWireKey).
+const AUTH_PASSWORD_WIRE_KEY: Record<
+  'min_length' | 'require_number' | 'require_lowercase' | 'require_uppercase' | 'require_special_char',
+  string
+> = {
+  min_length: 'passwordMinLength',
+  require_number: 'requireNumber',
+  require_lowercase: 'requireLowercase',
+  require_uppercase: 'requireUppercase',
+  require_special_char: 'requireSpecialChar',
+};
+
 /**
  * Human-readable path for a change, used in skipped/applied summaries.
  */
 export function changePath(change: DiffChange): string {
   if (change.section === 'auth.smtp') return 'auth.smtp';
   return `${change.section}.${change.key}`;
+}
+
+/**
+ * Wire-format key for an auth.password.* TOML field. Exposed so apply.ts can
+ * build the PUT body without duplicating the camelCase mapping. Keeping this
+ * here (next to the probe that uses the same table) means a future field add
+ * touches one place.
+ */
+export function authPasswordWireKey(
+  key: 'min_length' | 'require_number' | 'require_lowercase' | 'require_uppercase' | 'require_special_char',
+): string {
+  return AUTH_PASSWORD_WIRE_KEY[key];
 }

--- a/src/lib/config-diff.test.ts
+++ b/src/lib/config-diff.test.ts
@@ -223,3 +223,153 @@ describe('diffConfig — auth.smtp', () => {
     expect(sections).toEqual(['auth', 'auth.smtp']);
   });
 });
+
+describe('diffConfig — auth verification flags', () => {
+  it('emits a single change when require_email_verification flips', () => {
+    const result = diffConfig({
+      live: { auth: { require_email_verification: false } },
+      file: { auth: { require_email_verification: true } },
+    });
+    expect(result.changes).toEqual([
+      {
+        section: 'auth',
+        op: 'modify',
+        key: 'require_email_verification',
+        from: false,
+        to: true,
+      },
+    ]);
+  });
+
+  it('treats absent live as default false for require_email_verification', () => {
+    // Legacy backend that didn't expose the field — diff fills in the
+    // documented default so the change "shows up" sensibly on first apply.
+    const result = diffConfig({
+      live: { auth: {} },
+      file: { auth: { require_email_verification: true } },
+    });
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toMatchObject({
+      key: 'require_email_verification',
+      from: false,
+      to: true,
+    });
+  });
+
+  it('treats matching require_email_verification as no-op', () => {
+    expect(
+      diffConfig({
+        live: { auth: { require_email_verification: true } },
+        file: { auth: { require_email_verification: true } },
+      }).changes,
+    ).toEqual([]);
+  });
+
+  it('emits one change per verify/reset method swap', () => {
+    const result = diffConfig({
+      live: {
+        auth: { verify_email_method: 'code', reset_password_method: 'code' },
+      },
+      file: {
+        auth: { verify_email_method: 'link', reset_password_method: 'link' },
+      },
+    });
+    expect(result.changes.map((c) => c.key).sort()).toEqual([
+      'reset_password_method',
+      'verify_email_method',
+    ]);
+  });
+
+  it('treats absent live verify_email_method as default "code"', () => {
+    expect(
+      diffConfig({
+        live: { auth: {} },
+        file: { auth: { verify_email_method: 'code' } },
+      }).changes,
+    ).toEqual([]);
+  });
+});
+
+describe('diffConfig — [auth.password]', () => {
+  const LIVE_POLICY = {
+    min_length: 8,
+    require_number: false,
+    require_lowercase: false,
+    require_uppercase: false,
+    require_special_char: false,
+  };
+
+  it('emits per-field changes when policy fields differ', () => {
+    const result = diffConfig({
+      live: { auth: { password: LIVE_POLICY } },
+      file: {
+        auth: {
+          password: { min_length: 12, require_number: true },
+        },
+      },
+    });
+    expect(result.changes).toHaveLength(2);
+    expect(result.changes.map((c) => c.key).sort()).toEqual([
+      'min_length',
+      'require_number',
+    ]);
+    for (const c of result.changes) {
+      expect(c.section).toBe('auth.password');
+    }
+  });
+
+  it('treats matching policy fields as no-op', () => {
+    expect(
+      diffConfig({
+        live: { auth: { password: LIVE_POLICY } },
+        file: { auth: { password: { min_length: 8, require_number: false } } },
+      }).changes,
+    ).toEqual([]);
+  });
+
+  it('preserves unspecified password fields (default-keep)', () => {
+    // file changes min_length only; the require_* flags should not appear
+    // as diff entries even though their live values differ from the file's
+    // omitted defaults.
+    const result = diffConfig({
+      live: {
+        auth: {
+          password: {
+            min_length: 8,
+            require_number: true,
+            require_lowercase: true,
+            require_uppercase: true,
+            require_special_char: true,
+          },
+        },
+      },
+      file: { auth: { password: { min_length: 16 } } },
+    });
+    expect(result.changes).toEqual([
+      {
+        section: 'auth.password',
+        op: 'modify',
+        key: 'min_length',
+        from: 8,
+        to: 16,
+      },
+    ]);
+  });
+
+  it('falls back to backend defaults when live policy is missing', () => {
+    // Legacy backend that didn't expose any policy fields.
+    const result = diffConfig({
+      live: { auth: {} },
+      file: { auth: { password: { min_length: 12 } } },
+    });
+    expect(result.changes).toEqual([
+      {
+        section: 'auth.password',
+        op: 'modify',
+        key: 'min_length',
+        from: 8,
+        to: 12,
+      },
+    ]);
+  });
+});

--- a/src/lib/config-diff.ts
+++ b/src/lib/config-diff.ts
@@ -1,9 +1,20 @@
-import type { InsforgeConfig, SmtpConfig } from './config-schema.js';
+import type {
+  InsforgeConfig,
+  PasswordConfig,
+  SmtpConfig,
+  VerificationMethod,
+} from './config-schema.js';
 import { parseEnvRef } from './config-secrets.js';
 
 /**
  * A single declarative change the file would impose on live state. Discriminated
  * union: each variant maps to one backend endpoint at apply time.
+ *
+ * The auth flags and every auth.password.* field all hit the SAME endpoint
+ * (PUT /api/auth/config) but stay independent variants on purpose: each is
+ * capability-gated and applied separately, so a partial write succeeds on
+ * backends that only support a subset. Per-change PUTs are idempotent and
+ * preserve "default-keep" semantics for unspecified fields.
  */
 export type DiffChange =
   | {
@@ -12,6 +23,41 @@ export type DiffChange =
       key: 'allowed_redirect_urls';
       from: string[];
       to: string[];
+    }
+  | {
+      section: 'auth';
+      op: 'modify';
+      key: 'require_email_verification';
+      from: boolean;
+      to: boolean;
+    }
+  | {
+      section: 'auth';
+      op: 'modify';
+      key: 'verify_email_method';
+      from: VerificationMethod;
+      to: VerificationMethod;
+    }
+  | {
+      section: 'auth';
+      op: 'modify';
+      key: 'reset_password_method';
+      from: VerificationMethod;
+      to: VerificationMethod;
+    }
+  | {
+      section: 'auth.password';
+      op: 'modify';
+      key: 'min_length';
+      from: number;
+      to: number;
+    }
+  | {
+      section: 'auth.password';
+      op: 'modify';
+      key: 'require_number' | 'require_lowercase' | 'require_uppercase' | 'require_special_char';
+      from: boolean;
+      to: boolean;
     }
   | {
       section: 'auth.smtp';
@@ -98,11 +144,23 @@ export interface DiffInput {
 export interface LiveConfig {
   auth?: {
     allowed_redirect_urls?: string[];
+    require_email_verification?: boolean;
+    verify_email_method?: VerificationMethod;
+    reset_password_method?: VerificationMethod;
+    password?: LivePasswordPolicy;
     smtp?: LiveSmtpState;
   };
   deployments?: {
     subdomain?: string | null;
   };
+}
+
+export interface LivePasswordPolicy {
+  min_length: number;
+  require_number: boolean;
+  require_lowercase: boolean;
+  require_uppercase: boolean;
+  require_special_char: boolean;
 }
 
 /**
@@ -132,6 +190,54 @@ export function diffConfig({ live, file }: DiffInput): DiffResult {
     }
   }
 
+  if (fileAuth && 'require_email_verification' in fileAuth) {
+    const fromV = liveAuth.require_email_verification ?? false;
+    const toV = fileAuth.require_email_verification ?? false;
+    if (fromV !== toV) {
+      changes.push({
+        section: 'auth',
+        op: 'modify',
+        key: 'require_email_verification',
+        from: fromV,
+        to: toV,
+      });
+    }
+  }
+
+  if (fileAuth?.verify_email_method) {
+    // 'code' matches the backend default for an unset live row; treating
+    // absent live as 'code' avoids a spurious diff on fresh projects.
+    const fromV: VerificationMethod = liveAuth.verify_email_method ?? 'code';
+    const toV = fileAuth.verify_email_method;
+    if (fromV !== toV) {
+      changes.push({
+        section: 'auth',
+        op: 'modify',
+        key: 'verify_email_method',
+        from: fromV,
+        to: toV,
+      });
+    }
+  }
+
+  if (fileAuth?.reset_password_method) {
+    const fromV: VerificationMethod = liveAuth.reset_password_method ?? 'code';
+    const toV = fileAuth.reset_password_method;
+    if (fromV !== toV) {
+      changes.push({
+        section: 'auth',
+        op: 'modify',
+        key: 'reset_password_method',
+        from: fromV,
+        to: toV,
+      });
+    }
+  }
+
+  if (fileAuth?.password) {
+    diffPassword(liveAuth.password, fileAuth.password, changes);
+  }
+
   if (fileAuth?.smtp !== undefined) {
     const smtpChange = diffSmtp(liveAuth.smtp, fileAuth.smtp);
     if (smtpChange) changes.push(smtpChange);
@@ -146,7 +252,10 @@ export function diffConfig({ live, file }: DiffInput): DiffResult {
     // the line. The PUT body sends slug: null which the backend interprets
     // as clear.
     const rawTo = fileDeployments.subdomain;
-    const toV = rawTo === null || rawTo === '' ? null : rawTo;
+    // `subdomain?: string | null` widens to include undefined under exactOptionalPropertyTypes.
+    // Treat absent / null / empty-string all as "clear".
+    const toV: string | null =
+      rawTo === null || rawTo === undefined || rawTo === '' ? null : rawTo;
     if (fromV !== toV) {
       changes.push({
         section: 'deployments',
@@ -159,6 +268,52 @@ export function diffConfig({ live, file }: DiffInput): DiffResult {
   }
 
   return { changes, summary: summarize(changes) };
+}
+
+/**
+ * Per-key diff of the password policy. Unlike SMTP this is NOT whole-object:
+ * a partial [auth.password] block in TOML applies only the fields it names,
+ * preserving the rest of live state. Mirrors the existing per-key pattern of
+ * allowed_redirect_urls / require_email_verification.
+ *
+ * Empty-live (legacy backend that doesn't expose the policy) falls back to
+ * the documented backend defaults so the diff still shows the user what the
+ * file would impose.
+ */
+function diffPassword(
+  live: LivePasswordPolicy | undefined,
+  file: PasswordConfig,
+  changes: DiffChange[],
+): void {
+  const liveView = live ?? EMPTY_PASSWORD_POLICY;
+
+  if (file.min_length !== undefined && liveView.min_length !== file.min_length) {
+    changes.push({
+      section: 'auth.password',
+      op: 'modify',
+      key: 'min_length',
+      from: liveView.min_length,
+      to: file.min_length,
+    });
+  }
+  for (const key of [
+    'require_number',
+    'require_lowercase',
+    'require_uppercase',
+    'require_special_char',
+  ] as const) {
+    const fromV = liveView[key];
+    const toV = file[key];
+    if (toV !== undefined && fromV !== toV) {
+      changes.push({
+        section: 'auth.password',
+        op: 'modify',
+        key,
+        from: fromV,
+        to: toV,
+      });
+    }
+  }
 }
 
 /**
@@ -257,6 +412,18 @@ const EMPTY_SMTP_VIEW: SmtpDiffView = {
   sender_email: '',
   sender_name: '',
   min_interval_seconds: 60,
+};
+
+// Backend defaults for auth.password fields when the live row is missing
+// (legacy backend or fresh project). Mirrors `authConfigSchema` defaults in
+// shared-schemas: any drift here will surface as a spurious diff on first
+// apply against an older backend.
+const EMPTY_PASSWORD_POLICY: LivePasswordPolicy = {
+  min_length: 8,
+  require_number: false,
+  require_lowercase: false,
+  require_uppercase: false,
+  require_special_char: false,
 };
 
 function summarize(changes: DiffChange[]): DiffSummary {

--- a/src/lib/config-diff.ts
+++ b/src/lib/config-diff.ts
@@ -204,7 +204,11 @@ export function diffConfig({ live, file }: DiffInput): DiffResult {
     }
   }
 
-  if (fileAuth?.verify_email_method) {
+  // Match the `'key' in fileAuth` pattern used for require_email_verification.
+  // Truthy checks happen to work today (both enum values are truthy) but would
+  // silently misbehave if a future VerificationMethod value (e.g. literal "0")
+  // were added.
+  if (fileAuth && 'verify_email_method' in fileAuth && fileAuth.verify_email_method) {
     // 'code' matches the backend default for an unset live row; treating
     // absent live as 'code' avoids a spurious diff on fresh projects.
     const fromV: VerificationMethod = liveAuth.verify_email_method ?? 'code';
@@ -220,7 +224,7 @@ export function diffConfig({ live, file }: DiffInput): DiffResult {
     }
   }
 
-  if (fileAuth?.reset_password_method) {
+  if (fileAuth && 'reset_password_method' in fileAuth && fileAuth.reset_password_method) {
     const fromV: VerificationMethod = liveAuth.reset_password_method ?? 'code';
     const toV = fileAuth.reset_password_method;
     if (fromV !== toV) {

--- a/src/lib/config-metadata.test.ts
+++ b/src/lib/config-metadata.test.ts
@@ -91,6 +91,16 @@ describe('liveFromMetadata', () => {
   it('omits deployments when slice is absent (self-host)', () => {
     expect(liveFromMetadata({ auth: { allowedRedirectUrls: [] } }).deployments).toBeUndefined();
   });
+
+  it('treats a malformed auth slice as absent rather than crashing', () => {
+    // A server returning auth: "oops" or auth: 42 must not crash `config plan`
+    // — `'key' in primitive` throws a TypeError. Treat any non-object slice as
+    // "this backend exposes nothing" so the command degrades gracefully.
+    for (const bad of ['oops', 42, true, [], null] as unknown[]) {
+      const live = liveFromMetadata({ auth: bad as never });
+      expect(live).toEqual({ auth: {} });
+    }
+  });
 });
 
 describe('configFromMetadata', () => {
@@ -172,6 +182,15 @@ describe('configFromMetadata', () => {
       deployments: { customSlug: null },
     });
     expect(config.deployments).toBeUndefined();
+  });
+
+  it('treats a malformed auth slice as absent and reports every field skipped', () => {
+    for (const bad of ['oops', 42, true, [], null] as unknown[]) {
+      const { config, skipped } = configFromMetadata({ auth: bad as never });
+      expect(config.auth).toBeUndefined();
+      expect(skipped).toContain('auth.allowed_redirect_urls');
+      expect(skipped).toContain('auth.password');
+    }
   });
 
   it('emits env(SMTP_PASSWORD) placeholder when hasPassword is true', () => {

--- a/src/lib/config-metadata.test.ts
+++ b/src/lib/config-metadata.test.ts
@@ -112,6 +112,15 @@ describe('liveFromMetadata', () => {
     expect(live.auth?.allowed_redirect_urls).toEqual([]);
   });
 
+  it('coerces non-string customSlug to null instead of propagating an invalid live shape', () => {
+    // The diff layer compares subdomain as a string|null. A leaked number
+    // would produce nonsense changes; tighten the projection at the source.
+    const live = liveFromMetadata({
+      deployments: { customSlug: 123 as unknown as string },
+    });
+    expect(live.deployments?.subdomain).toBeNull();
+  });
+
   it('omits live.smtp when backend returns smtpConfig: null', () => {
     // null = "SMTP is supported but no row yet". The diff layer fills the
     // empty-state defaults; live.smtp stays undefined to signal that.

--- a/src/lib/config-metadata.test.ts
+++ b/src/lib/config-metadata.test.ts
@@ -101,6 +101,23 @@ describe('liveFromMetadata', () => {
       expect(live).toEqual({ auth: {} });
     }
   });
+
+  it('coerces non-array allowedRedirectUrls to [] rather than crashing diff/render', () => {
+    // Belt-and-braces: even with a typed RawAuthMetadata, a malformed
+    // payload could ship a string here. `normalizeUrlList` would throw on
+    // `.sort()` over a string, so coerce safely.
+    const live = liveFromMetadata({
+      auth: { allowedRedirectUrls: 'https://oops.com' as unknown as string[] },
+    });
+    expect(live.auth?.allowed_redirect_urls).toEqual([]);
+  });
+
+  it('omits live.smtp when backend returns smtpConfig: null', () => {
+    // null = "SMTP is supported but no row yet". The diff layer fills the
+    // empty-state defaults; live.smtp stays undefined to signal that.
+    const live = liveFromMetadata({ auth: { smtpConfig: null as never } });
+    expect(live.auth?.smtp).toBeUndefined();
+  });
 });
 
 describe('configFromMetadata', () => {
@@ -191,6 +208,28 @@ describe('configFromMetadata', () => {
       expect(skipped).toContain('auth.allowed_redirect_urls');
       expect(skipped).toContain('auth.password');
     }
+  });
+
+  it('falls back to [] when allowedRedirectUrls is wrong-shaped (still supported)', () => {
+    const { config, skipped } = configFromMetadata({
+      auth: { allowedRedirectUrls: 'https://oops.com' as unknown as string[] },
+    });
+    expect(config.auth?.allowed_redirect_urls).toEqual([]);
+    // Field is still considered supported — backend exposed the key, just
+    // with a malformed value. Skipping it would hide the bug from the user.
+    expect(skipped).not.toContain('auth.allowed_redirect_urls');
+  });
+
+  it('treats smtpConfig: null as supported-but-empty (no [auth.smtp] block, NOT in skipped)', () => {
+    // Presence-based capability gating: the key exists in the response, so
+    // the backend supports SMTP — there's just no row yet. Marking it as
+    // skipped would tell the user "your backend doesn't support SMTP" which
+    // is false. Matches metadataSupports() in config-capabilities.ts.
+    const { config, skipped } = configFromMetadata({
+      auth: { smtpConfig: null as never },
+    });
+    expect(config.auth?.smtp).toBeUndefined();
+    expect(skipped).not.toContain('auth.smtp');
   });
 
   it('emits env(SMTP_PASSWORD) placeholder when hasPassword is true', () => {

--- a/src/lib/config-metadata.test.ts
+++ b/src/lib/config-metadata.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { configFromMetadata, liveFromMetadata } from './config-metadata.js';
+
+describe('liveFromMetadata', () => {
+  it('projects a full backend response onto LiveConfig', () => {
+    const live = liveFromMetadata({
+      auth: {
+        allowedRedirectUrls: ['https://a.com'],
+        requireEmailVerification: true,
+        verifyEmailMethod: 'link',
+        resetPasswordMethod: 'code',
+        passwordMinLength: 12,
+        requireNumber: true,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireSpecialChar: false,
+        smtpConfig: {
+          enabled: true,
+          host: 'smtp.gmail.com',
+          port: 587,
+          username: 'u',
+          hasPassword: true,
+          senderEmail: 's@a.com',
+          senderName: 'A',
+          minIntervalSeconds: 60,
+        },
+      },
+      deployments: { customSlug: 'my-app' },
+    });
+    expect(live).toEqual({
+      auth: {
+        allowed_redirect_urls: ['https://a.com'],
+        require_email_verification: true,
+        verify_email_method: 'link',
+        reset_password_method: 'code',
+        password: {
+          min_length: 12,
+          require_number: true,
+          require_lowercase: true,
+          require_uppercase: true,
+          require_special_char: false,
+        },
+        smtp: {
+          enabled: true,
+          host: 'smtp.gmail.com',
+          port: 587,
+          username: 'u',
+          hasPassword: true,
+          sender_email: 's@a.com',
+          sender_name: 'A',
+          min_interval_seconds: 60,
+        },
+      },
+      deployments: { subdomain: 'my-app' },
+    });
+  });
+
+  it('returns an empty auth slice when backend exposes no auth fields', () => {
+    // Legacy backend / freshly-migrated project: presence-based detection
+    // must NOT invent fields. The diff layer fills in safe defaults for
+    // anything the file references; live stays empty.
+    expect(liveFromMetadata({ auth: {} })).toEqual({ auth: {} });
+    expect(liveFromMetadata({})).toEqual({ auth: {} });
+  });
+
+  it('builds a partial password block when backend exposes some but not all fields', () => {
+    const live = liveFromMetadata({
+      auth: { passwordMinLength: 16, requireNumber: true },
+    });
+    // Fields not exposed by the backend take the documented defaults so the
+    // diff layer can still compare against a coherent live view.
+    expect(live.auth?.password).toEqual({
+      min_length: 16,
+      require_number: true,
+      require_lowercase: false,
+      require_uppercase: false,
+      require_special_char: false,
+    });
+  });
+
+  it('drops unknown enum values silently', () => {
+    // A future backend value (e.g. 'otp') would fail the parser if echoed
+    // back into TOML, so we treat it as absent. The diff layer then
+    // defaults live to 'code' — see diffConfig for the rationale.
+    const live = liveFromMetadata({
+      auth: { verifyEmailMethod: 'otp' },
+    });
+    expect(live.auth?.verify_email_method).toBeUndefined();
+  });
+
+  it('omits deployments when slice is absent (self-host)', () => {
+    expect(liveFromMetadata({ auth: { allowedRedirectUrls: [] } }).deployments).toBeUndefined();
+  });
+});
+
+describe('configFromMetadata', () => {
+  it('projects a full backend response onto InsforgeConfig with no skipped entries', () => {
+    const { config, skipped } = configFromMetadata({
+      auth: {
+        allowedRedirectUrls: ['https://a.com'],
+        requireEmailVerification: true,
+        verifyEmailMethod: 'link',
+        resetPasswordMethod: 'code',
+        passwordMinLength: 12,
+        requireNumber: true,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireSpecialChar: false,
+        smtpConfig: {
+          enabled: false,
+          host: '',
+          port: 587,
+          username: '',
+          hasPassword: false,
+          senderEmail: '',
+          senderName: '',
+          minIntervalSeconds: 60,
+        },
+      },
+      deployments: { customSlug: 'my-app' },
+    });
+    expect(config.auth?.require_email_verification).toBe(true);
+    expect(config.auth?.verify_email_method).toBe('link');
+    expect(config.auth?.password).toEqual({
+      min_length: 12,
+      require_number: true,
+      require_lowercase: true,
+      require_uppercase: true,
+      require_special_char: false,
+    });
+    expect(config.auth?.smtp).toBeDefined();
+    expect(config.deployments).toEqual({ subdomain: 'my-app' });
+    expect(skipped).toEqual([]);
+  });
+
+  it('reports every unsupported field for a legacy backend', () => {
+    const { config, skipped } = configFromMetadata({ auth: {} });
+    expect(config.auth).toBeUndefined();
+    expect(skipped.sort()).toEqual([
+      'auth.allowed_redirect_urls',
+      'auth.password',
+      'auth.require_email_verification',
+      'auth.reset_password_method',
+      'auth.smtp',
+      'auth.verify_email_method',
+      'deployments.subdomain',
+    ]);
+  });
+
+  it('emits only the password fields the backend exposes', () => {
+    // Backend ships passwordMinLength but not the require_* flags — the TOML
+    // should show only min_length so re-applying is a no-op for the rest.
+    const { config } = configFromMetadata({
+      auth: { passwordMinLength: 16 },
+    });
+    expect(config.auth?.password).toEqual({ min_length: 16 });
+  });
+
+  it('drops unknown enum values and lists them as skipped', () => {
+    const { config, skipped } = configFromMetadata({
+      auth: { verifyEmailMethod: 'otp' },
+    });
+    expect(config.auth?.verify_email_method).toBeUndefined();
+    expect(skipped).toContain('auth.verify_email_method');
+  });
+
+  it('omits [deployments] when slug is unset on cloud backend', () => {
+    // customSlug: null means "default URL" — emitting subdomain = "" would
+    // mean "clear on apply" which fails the 3-char min on the backend.
+    const { config } = configFromMetadata({
+      auth: { allowedRedirectUrls: [] },
+      deployments: { customSlug: null },
+    });
+    expect(config.deployments).toBeUndefined();
+  });
+
+  it('emits env(SMTP_PASSWORD) placeholder when hasPassword is true', () => {
+    const { config } = configFromMetadata({
+      auth: {
+        smtpConfig: {
+          enabled: true,
+          host: 'smtp.gmail.com',
+          port: 587,
+          username: 'u',
+          hasPassword: true,
+          senderEmail: 's@a.com',
+          senderName: 'A',
+          minIntervalSeconds: 60,
+        },
+      },
+    });
+    expect(config.auth?.smtp?.password).toBe('env(SMTP_PASSWORD)');
+  });
+});

--- a/src/lib/config-metadata.ts
+++ b/src/lib/config-metadata.ts
@@ -57,7 +57,10 @@ export interface RawMetadataResponse {
  */
 export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
   const live: LiveConfig = { auth: {} };
-  const a = raw.auth;
+  // Guard against a malformed response (auth: "string" / number / null) —
+  // the `in` operator throws a TypeError on non-objects, so refuse to read
+  // anything from a wrong-shaped slice instead of crashing the command.
+  const a = isPlainObject(raw.auth) ? raw.auth : undefined;
 
   if (a?.allowedRedirectUrls !== undefined) {
     live.auth!.allowed_redirect_urls = a.allowedRedirectUrls;
@@ -112,10 +115,14 @@ export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
       min_interval_seconds: s.minIntervalSeconds ?? 60,
     };
   }
-  if (raw.deployments) {
+  if (isPlainObject(raw.deployments)) {
     live.deployments = { subdomain: raw.deployments.customSlug ?? null };
   }
   return live;
+}
+
+function isPlainObject<T>(v: T | unknown): v is T {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
 /**
@@ -134,7 +141,9 @@ export function configFromMetadata(raw: RawMetadataResponse): {
 } {
   const config: InsforgeConfig = {};
   const skipped: string[] = [];
-  const a = raw.auth;
+  // Same defensive narrowing as liveFromMetadata — a non-object auth slice
+  // means "this backend exposes nothing", not "crash on `in`".
+  const a = isPlainObject(raw.auth) ? raw.auth : undefined;
 
   if (a && 'allowedRedirectUrls' in a) {
     config.auth = config.auth ?? {};
@@ -222,8 +231,8 @@ export function configFromMetadata(raw: RawMetadataResponse): {
     skipped.push('auth.smtp');
   }
 
-  const d = raw.deployments;
-  if (d && typeof d === 'object') {
+  const d = isPlainObject(raw.deployments) ? raw.deployments : undefined;
+  if (d) {
     // Cloud backend exposes the slice. Only emit a value when a slug is
     // actually set — an unset slug means the project is on its default URL,
     // and surfacing subdomain = "" in the TOML would imply "clear on apply"

--- a/src/lib/config-metadata.ts
+++ b/src/lib/config-metadata.ts
@@ -62,8 +62,13 @@ export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
   // anything from a wrong-shaped slice instead of crashing the command.
   const a = isPlainObject(raw.auth) ? raw.auth : undefined;
 
-  if (a?.allowedRedirectUrls !== undefined) {
-    live.auth!.allowed_redirect_urls = a.allowedRedirectUrls;
+  if (a && 'allowedRedirectUrls' in a) {
+    // Belt-and-braces: even after the auth-slice typeof guard, a malformed
+    // payload could ship `allowedRedirectUrls: "https://..."` (string) or
+    // `null` and crash `normalizeUrlList` / TOML rendering downstream. Coerce
+    // a wrong-shaped value to `[]` so the diff layer just shows the user
+    // their TOML's URLs as additions.
+    live.auth!.allowed_redirect_urls = asStringArray(a.allowedRedirectUrls) ?? [];
   }
   if (a && 'requireEmailVerification' in a) {
     live.auth!.require_email_verification = a.requireEmailVerification ?? false;
@@ -102,7 +107,10 @@ export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
       require_special_char: a.requireSpecialChar ?? false,
     };
   }
-  if (a?.smtpConfig) {
+  // Build live.smtp only when the backend has actual data. `smtpConfig: null`
+  // means the backend supports SMTP but no row exists yet — the diff layer's
+  // empty-state defaults already cover that case.
+  if (isPlainObject(a?.smtpConfig)) {
     const s = a.smtpConfig;
     live.auth!.smtp = {
       enabled: s.enabled ?? false,
@@ -126,6 +134,10 @@ function isPlainObject<T extends object>(v: T | undefined | null | unknown): v i
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
+function asStringArray(v: unknown): string[] | null {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string') ? v : null;
+}
+
 /**
  * Project the raw metadata response onto an InsforgeConfig suitable for
  * writing back as `insforge.toml`. Mirrors liveFromMetadata's presence
@@ -147,8 +159,10 @@ export function configFromMetadata(raw: RawMetadataResponse): {
   const a = isPlainObject(raw.auth) ? raw.auth : undefined;
 
   if (a && 'allowedRedirectUrls' in a) {
+    // Wrong-shaped value (non-array) still counts as "supported" — fall back
+    // to [] for the TOML rather than crashing the export.
     config.auth = config.auth ?? {};
-    config.auth.allowed_redirect_urls = a.allowedRedirectUrls ?? [];
+    config.auth.allowed_redirect_urls = asStringArray(a.allowedRedirectUrls) ?? [];
   } else {
     skipped.push('auth.allowed_redirect_urls');
   }
@@ -211,23 +225,30 @@ export function configFromMetadata(raw: RawMetadataResponse): {
     skipped.push('auth.password');
   }
 
-  if (a && 'smtpConfig' in a && a.smtpConfig) {
+  // Presence-based gating to match the rest of the file: `smtpConfig` key
+  // exists ⇒ backend supports SMTP, even when its value is null (no row yet).
+  // Only emit the [auth.smtp] block when there's actual data to render.
+  if (a && 'smtpConfig' in a) {
     const s = a.smtpConfig;
-    config.auth = config.auth ?? {};
-    config.auth.smtp = {
-      enabled: s.enabled ?? false,
-      host: s.host ?? '',
-      port: s.port ?? 587,
-      username: s.username ?? '',
-      // When backend has a password set, emit a deterministic env() placeholder
-      // so the user knows which secret to define. We do NOT round-trip the
-      // value (it never leaves the backend). Re-applying this TOML force-resends
-      // from the secrets store — see config-diff.ts for the force-resend rationale.
-      ...(s.hasPassword ? { password: 'env(SMTP_PASSWORD)' } : {}),
-      sender_email: s.senderEmail ?? '',
-      sender_name: s.senderName ?? '',
-      min_interval_seconds: s.minIntervalSeconds ?? 60,
-    };
+    if (isPlainObject(s)) {
+      config.auth = config.auth ?? {};
+      config.auth.smtp = {
+        enabled: s.enabled ?? false,
+        host: s.host ?? '',
+        port: s.port ?? 587,
+        username: s.username ?? '',
+        // When backend has a password set, emit a deterministic env() placeholder
+        // so the user knows which secret to define. We do NOT round-trip the
+        // value (it never leaves the backend). Re-applying this TOML force-resends
+        // from the secrets store — see config-diff.ts for the force-resend rationale.
+        ...(s.hasPassword ? { password: 'env(SMTP_PASSWORD)' } : {}),
+        sender_email: s.senderEmail ?? '',
+        sender_name: s.senderName ?? '',
+        min_interval_seconds: s.minIntervalSeconds ?? 60,
+      };
+    }
+    // smtpConfig: null is "supported but blank" — don't emit a block, don't
+    // mark as skipped. Matches capability-probe semantics.
   } else {
     skipped.push('auth.smtp');
   }

--- a/src/lib/config-metadata.ts
+++ b/src/lib/config-metadata.ts
@@ -123,9 +123,15 @@ export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
       min_interval_seconds: s.minIntervalSeconds ?? 60,
     };
   }
-  const d = raw.deployments;
-  if (isPlainObject(d)) {
-    live.deployments = { subdomain: d.customSlug ?? null };
+  const d = isPlainObject(raw.deployments) ? raw.deployments : undefined;
+  if (d) {
+    // Match the string-shape guard in configFromMetadata: a wrong-typed
+    // customSlug (e.g. `123`) degrades to null rather than leaking into
+    // live.deployments.subdomain — the diff layer would otherwise compare
+    // numbers to strings and produce nonsense changes.
+    live.deployments = {
+      subdomain: typeof d.customSlug === 'string' && d.customSlug ? d.customSlug : null,
+    };
   }
   return live;
 }

--- a/src/lib/config-metadata.ts
+++ b/src/lib/config-metadata.ts
@@ -1,0 +1,114 @@
+// CLI/src/lib/config-metadata.ts
+//
+// Single source of truth for converting /api/metadata's raw JSON response
+// into the LiveConfig shape the diff layer consumes. apply/plan/export all
+// route through this to ensure they agree on what "live" looks like —
+// otherwise plan vs apply could disagree on whether a field is a change.
+
+import type { LiveConfig } from './config-diff.js';
+
+/**
+ * Raw shape of the backend's /api/metadata response. Only the keys this CLI
+ * reads are listed; absent keys mean "backend doesn't yet support this
+ * field" — used by capability probes and export's emission decision.
+ */
+export interface RawAuthMetadata {
+  allowedRedirectUrls?: string[];
+  requireEmailVerification?: boolean;
+  verifyEmailMethod?: string;
+  resetPasswordMethod?: string;
+  passwordMinLength?: number;
+  requireNumber?: boolean;
+  requireLowercase?: boolean;
+  requireUppercase?: boolean;
+  requireSpecialChar?: boolean;
+  smtpConfig?: {
+    enabled?: boolean;
+    host?: string;
+    port?: number;
+    username?: string;
+    hasPassword?: boolean;
+    senderEmail?: string;
+    senderName?: string;
+    minIntervalSeconds?: number;
+  };
+}
+
+export interface RawMetadataResponse {
+  auth?: RawAuthMetadata;
+  // Cloud-only slice. Self-host or pre-#1259 backends omit the key
+  // entirely; presence is the signal used to decide whether [deployments]
+  // writes are honored.
+  deployments?: {
+    customSlug?: string | null;
+  };
+}
+
+/**
+ * Project the raw metadata response onto the shape diffConfig accepts.
+ * Missing fields stay undefined — the diff layer interprets that as
+ * "field not yet supported on this backend" and uses its own fallback
+ * defaults when the file references a missing-on-live field.
+ */
+export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
+  const live: LiveConfig = { auth: {} };
+  const a = raw.auth;
+
+  if (a?.allowedRedirectUrls !== undefined) {
+    live.auth!.allowed_redirect_urls = a.allowedRedirectUrls;
+  }
+  if (a && 'requireEmailVerification' in a) {
+    live.auth!.require_email_verification = a.requireEmailVerification ?? false;
+  }
+  if (
+    a &&
+    'verifyEmailMethod' in a &&
+    (a.verifyEmailMethod === 'code' || a.verifyEmailMethod === 'link')
+  ) {
+    live.auth!.verify_email_method = a.verifyEmailMethod;
+  }
+  if (
+    a &&
+    'resetPasswordMethod' in a &&
+    (a.resetPasswordMethod === 'code' || a.resetPasswordMethod === 'link')
+  ) {
+    live.auth!.reset_password_method = a.resetPasswordMethod;
+  }
+  // Build the password slice only if the backend exposed at least one field
+  // (legacy backends omit the lot). Missing individual fields fall back to
+  // the same defaults the diff layer uses, so a backend that adds them
+  // piecemeal still produces a coherent live view.
+  if (
+    a &&
+    ('passwordMinLength' in a ||
+      'requireNumber' in a ||
+      'requireLowercase' in a ||
+      'requireUppercase' in a ||
+      'requireSpecialChar' in a)
+  ) {
+    live.auth!.password = {
+      min_length: a.passwordMinLength ?? 8,
+      require_number: a.requireNumber ?? false,
+      require_lowercase: a.requireLowercase ?? false,
+      require_uppercase: a.requireUppercase ?? false,
+      require_special_char: a.requireSpecialChar ?? false,
+    };
+  }
+  if (a?.smtpConfig) {
+    const s = a.smtpConfig;
+    live.auth!.smtp = {
+      enabled: s.enabled ?? false,
+      host: s.host ?? '',
+      port: s.port ?? 587,
+      username: s.username ?? '',
+      hasPassword: s.hasPassword ?? false,
+      sender_email: s.senderEmail ?? '',
+      sender_name: s.senderName ?? '',
+      min_interval_seconds: s.minIntervalSeconds ?? 60,
+    };
+  }
+  if (raw.deployments) {
+    live.deployments = { subdomain: raw.deployments.customSlug ?? null };
+  }
+  return live;
+}

--- a/src/lib/config-metadata.ts
+++ b/src/lib/config-metadata.ts
@@ -115,13 +115,14 @@ export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
       min_interval_seconds: s.minIntervalSeconds ?? 60,
     };
   }
-  if (isPlainObject(raw.deployments)) {
-    live.deployments = { subdomain: raw.deployments.customSlug ?? null };
+  const d = raw.deployments;
+  if (isPlainObject(d)) {
+    live.deployments = { subdomain: d.customSlug ?? null };
   }
   return live;
 }
 
-function isPlainObject<T>(v: T | unknown): v is T {
+function isPlainObject<T extends object>(v: T | undefined | null | unknown): v is T {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 

--- a/src/lib/config-metadata.ts
+++ b/src/lib/config-metadata.ts
@@ -1,10 +1,15 @@
 // CLI/src/lib/config-metadata.ts
 //
 // Single source of truth for converting /api/metadata's raw JSON response
-// into the LiveConfig shape the diff layer consumes. apply/plan/export all
-// route through this to ensure they agree on what "live" looks like —
-// otherwise plan vs apply could disagree on whether a field is a change.
+// into the shapes the rest of the CLI consumes:
+//   - liveFromMetadata → LiveConfig for the diff layer (apply, plan)
+//   - configFromMetadata → InsforgeConfig + skipped[] for export
+//
+// All field-presence detection lives here. apply / plan / export route
+// through these two functions so a future field-mapping fix lands in one
+// place rather than diverging across commands.
 
+import type { InsforgeConfig } from './config-schema.js';
 import type { LiveConfig } from './config-diff.js';
 
 /**
@@ -111,4 +116,124 @@ export function liveFromMetadata(raw: RawMetadataResponse): LiveConfig {
     live.deployments = { subdomain: raw.deployments.customSlug ?? null };
   }
   return live;
+}
+
+/**
+ * Project the raw metadata response onto an InsforgeConfig suitable for
+ * writing back as `insforge.toml`. Mirrors liveFromMetadata's presence
+ * detection but emits the schema shape (optional everything) and tracks
+ * sections the backend doesn't yet expose so export can warn the user.
+ *
+ * Diverges from `liveFromMetadata` only in output shape, not in WHICH
+ * fields are considered present — the two MUST agree, otherwise re-applying
+ * an export wouldn't round-trip cleanly. Update both together.
+ */
+export function configFromMetadata(raw: RawMetadataResponse): {
+  config: InsforgeConfig;
+  skipped: string[];
+} {
+  const config: InsforgeConfig = {};
+  const skipped: string[] = [];
+  const a = raw.auth;
+
+  if (a && 'allowedRedirectUrls' in a) {
+    config.auth = config.auth ?? {};
+    config.auth.allowed_redirect_urls = a.allowedRedirectUrls ?? [];
+  } else {
+    skipped.push('auth.allowed_redirect_urls');
+  }
+
+  if (a && 'requireEmailVerification' in a) {
+    config.auth = config.auth ?? {};
+    config.auth.require_email_verification = a.requireEmailVerification ?? false;
+  } else {
+    skipped.push('auth.require_email_verification');
+  }
+
+  // Unknown enum values (anything other than 'code'/'link') fall back to
+  // "skipped" rather than passing through. Reason: the parser would reject
+  // an unknown literal at the next `config apply`, so emitting it would
+  // produce a TOML the CLI can't read back. If the backend ever introduces
+  // a new method, the CLI must teach the validator about it first.
+  if (
+    a &&
+    'verifyEmailMethod' in a &&
+    (a.verifyEmailMethod === 'code' || a.verifyEmailMethod === 'link')
+  ) {
+    config.auth = config.auth ?? {};
+    config.auth.verify_email_method = a.verifyEmailMethod;
+  } else {
+    skipped.push('auth.verify_email_method');
+  }
+
+  if (
+    a &&
+    'resetPasswordMethod' in a &&
+    (a.resetPasswordMethod === 'code' || a.resetPasswordMethod === 'link')
+  ) {
+    config.auth = config.auth ?? {};
+    config.auth.reset_password_method = a.resetPasswordMethod;
+  } else {
+    skipped.push('auth.reset_password_method');
+  }
+
+  // Emit [auth.password] only when the backend exposes at least one policy
+  // field. Each present field copies through; missing fields stay out of
+  // the TOML so re-applying the export is a no-op (default-keep).
+  if (
+    a &&
+    ('passwordMinLength' in a ||
+      'requireNumber' in a ||
+      'requireLowercase' in a ||
+      'requireUppercase' in a ||
+      'requireSpecialChar' in a)
+  ) {
+    config.auth = config.auth ?? {};
+    config.auth.password = {};
+    if ('passwordMinLength' in a) config.auth.password.min_length = a.passwordMinLength ?? 8;
+    if ('requireNumber' in a) config.auth.password.require_number = a.requireNumber ?? false;
+    if ('requireLowercase' in a) config.auth.password.require_lowercase = a.requireLowercase ?? false;
+    if ('requireUppercase' in a) config.auth.password.require_uppercase = a.requireUppercase ?? false;
+    if ('requireSpecialChar' in a) {
+      config.auth.password.require_special_char = a.requireSpecialChar ?? false;
+    }
+  } else {
+    skipped.push('auth.password');
+  }
+
+  if (a && 'smtpConfig' in a && a.smtpConfig) {
+    const s = a.smtpConfig;
+    config.auth = config.auth ?? {};
+    config.auth.smtp = {
+      enabled: s.enabled ?? false,
+      host: s.host ?? '',
+      port: s.port ?? 587,
+      username: s.username ?? '',
+      // When backend has a password set, emit a deterministic env() placeholder
+      // so the user knows which secret to define. We do NOT round-trip the
+      // value (it never leaves the backend). Re-applying this TOML force-resends
+      // from the secrets store — see config-diff.ts for the force-resend rationale.
+      ...(s.hasPassword ? { password: 'env(SMTP_PASSWORD)' } : {}),
+      sender_email: s.senderEmail ?? '',
+      sender_name: s.senderName ?? '',
+      min_interval_seconds: s.minIntervalSeconds ?? 60,
+    };
+  } else {
+    skipped.push('auth.smtp');
+  }
+
+  const d = raw.deployments;
+  if (d && typeof d === 'object') {
+    // Cloud backend exposes the slice. Only emit a value when a slug is
+    // actually set — an unset slug means the project is on its default URL,
+    // and surfacing subdomain = "" in the TOML would imply "clear on apply"
+    // (and fail the backend's 3-char min).
+    if (typeof d.customSlug === 'string' && d.customSlug) {
+      config.deployments = { subdomain: d.customSlug };
+    }
+  } else {
+    skipped.push('deployments.subdomain');
+  }
+
+  return { config, skipped };
 }

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -14,9 +14,30 @@ export interface InsforgeConfig {
   deployments?: DeploymentsConfig;
 }
 
+export type VerificationMethod = 'code' | 'link';
+
 export interface AuthConfig {
   allowed_redirect_urls?: string[];
+  require_email_verification?: boolean;
+  verify_email_method?: VerificationMethod;
+  reset_password_method?: VerificationMethod;
+  password?: PasswordConfig;
   smtp?: SmtpConfig;
+}
+
+/**
+ * Password policy enforced at signup / reset. All fields are independent —
+ * a partial [auth.password] block in TOML applies only the fields it names,
+ * preserving the rest (default-keep). Mirrors the flat camelCase fields the
+ * backend exposes on `authConfig` (passwordMinLength, requireNumber, etc.);
+ * the nested table is a CLI-side ergonomic — the wire still sends them flat.
+ */
+export interface PasswordConfig {
+  min_length?: number;
+  require_number?: boolean;
+  require_lowercase?: boolean;
+  require_uppercase?: boolean;
+  require_special_char?: boolean;
 }
 
 /**
@@ -115,7 +136,78 @@ function validateAuth(input: unknown): AuthConfig {
     out.allowed_redirect_urls = v;
   }
 
+  if ('require_email_verification' in obj) {
+    if (typeof obj.require_email_verification !== 'boolean') {
+      throw new ConfigValidationError(
+        'auth.require_email_verification',
+        'must be a boolean',
+      );
+    }
+    out.require_email_verification = obj.require_email_verification;
+  }
+
+  if ('verify_email_method' in obj) {
+    out.verify_email_method = validateVerificationMethod(
+      'auth.verify_email_method',
+      obj.verify_email_method,
+    );
+  }
+
+  if ('reset_password_method' in obj) {
+    out.reset_password_method = validateVerificationMethod(
+      'auth.reset_password_method',
+      obj.reset_password_method,
+    );
+  }
+
+  if ('password' in obj) out.password = validatePassword(obj.password);
   if ('smtp' in obj) out.smtp = validateSmtp(obj.smtp);
+
+  return out;
+}
+
+function validateVerificationMethod(path: string, value: unknown): VerificationMethod {
+  if (value !== 'code' && value !== 'link') {
+    throw new ConfigValidationError(path, 'must be "code" or "link"');
+  }
+  return value;
+}
+
+function validatePassword(input: unknown): PasswordConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ConfigValidationError('auth.password', 'must be a table');
+  }
+  const obj = input as Record<string, unknown>;
+  const out: PasswordConfig = {};
+
+  if ('min_length' in obj) {
+    if (
+      typeof obj.min_length !== 'number' ||
+      !Number.isInteger(obj.min_length) ||
+      obj.min_length < 4 ||
+      obj.min_length > 128
+    ) {
+      throw new ConfigValidationError(
+        'auth.password.min_length',
+        'must be an integer between 4 and 128',
+      );
+    }
+    out.min_length = obj.min_length;
+  }
+
+  for (const key of [
+    'require_number',
+    'require_lowercase',
+    'require_uppercase',
+    'require_special_char',
+  ] as const) {
+    if (key in obj) {
+      if (typeof obj[key] !== 'boolean') {
+        throw new ConfigValidationError(`auth.password.${key}`, 'must be a boolean');
+      }
+      out[key] = obj[key] as boolean;
+    }
+  }
 
   return out;
 }

--- a/src/lib/config-toml.test.ts
+++ b/src/lib/config-toml.test.ts
@@ -197,6 +197,161 @@ describe('stringifyConfigToml — auth.smtp', () => {
   });
 });
 
+describe('parseConfigToml — auth verification flags', () => {
+  it('parses require_email_verification as a boolean', () => {
+    const toml = `
+[auth]
+require_email_verification = true
+`;
+    expect(parseConfigToml(toml)).toEqual({
+      auth: { require_email_verification: true },
+    });
+  });
+
+  it('rejects non-boolean require_email_verification', () => {
+    expect(() =>
+      parseConfigToml('[auth]\nrequire_email_verification = "yes"\n'),
+    ).toThrow(/require_email_verification.*boolean/);
+  });
+
+  it('parses verify_email_method as "code" or "link"', () => {
+    expect(parseConfigToml('[auth]\nverify_email_method = "code"\n')).toEqual({
+      auth: { verify_email_method: 'code' },
+    });
+    expect(parseConfigToml('[auth]\nverify_email_method = "link"\n')).toEqual({
+      auth: { verify_email_method: 'link' },
+    });
+  });
+
+  it('rejects unknown verify_email_method value', () => {
+    expect(() =>
+      parseConfigToml('[auth]\nverify_email_method = "magic"\n'),
+    ).toThrow(/verify_email_method.*code.*link/);
+  });
+
+  it('parses reset_password_method as "code" or "link"', () => {
+    expect(
+      parseConfigToml('[auth]\nreset_password_method = "link"\n'),
+    ).toEqual({ auth: { reset_password_method: 'link' } });
+  });
+});
+
+describe('parseConfigToml — [auth.password]', () => {
+  it('parses a full password policy', () => {
+    const toml = `
+[auth.password]
+min_length = 12
+require_number = true
+require_lowercase = true
+require_uppercase = false
+require_special_char = true
+`;
+    expect(parseConfigToml(toml)).toEqual({
+      auth: {
+        password: {
+          min_length: 12,
+          require_number: true,
+          require_lowercase: true,
+          require_uppercase: false,
+          require_special_char: true,
+        },
+      },
+    });
+  });
+
+  it('accepts a partial policy (default-keep semantics)', () => {
+    expect(parseConfigToml('[auth.password]\nmin_length = 16\n')).toEqual({
+      auth: { password: { min_length: 16 } },
+    });
+  });
+
+  it('rejects min_length below 4', () => {
+    expect(() =>
+      parseConfigToml('[auth.password]\nmin_length = 3\n'),
+    ).toThrow(/min_length.*4 and 128/);
+  });
+
+  it('rejects min_length above 128', () => {
+    expect(() =>
+      parseConfigToml('[auth.password]\nmin_length = 200\n'),
+    ).toThrow(/min_length.*4 and 128/);
+  });
+
+  it('rejects non-integer min_length', () => {
+    expect(() =>
+      parseConfigToml('[auth.password]\nmin_length = 8.5\n'),
+    ).toThrow(/min_length.*4 and 128/);
+  });
+
+  it('rejects non-boolean require_* field', () => {
+    expect(() =>
+      parseConfigToml('[auth.password]\nrequire_number = "yes"\n'),
+    ).toThrow(/auth\.password\.require_number.*boolean/);
+  });
+});
+
+describe('stringifyConfigToml — auth flags + password', () => {
+  it('emits the three auth flags directly under [auth]', () => {
+    const out = stringifyConfigToml({
+      auth: {
+        require_email_verification: true,
+        verify_email_method: 'link',
+        reset_password_method: 'code',
+      },
+    });
+    expect(out).toContain('[auth]');
+    expect(out).toContain('require_email_verification = true');
+    expect(out).toContain('verify_email_method = "link"');
+    expect(out).toContain('reset_password_method = "code"');
+  });
+
+  it('emits [auth.password] as a sub-table after [auth]', () => {
+    const out = stringifyConfigToml({
+      auth: {
+        require_email_verification: true,
+        password: {
+          min_length: 12,
+          require_number: true,
+        },
+      },
+    });
+    const authIdx = out.indexOf('[auth]');
+    const pwIdx = out.indexOf('[auth.password]');
+    expect(authIdx).toBeGreaterThanOrEqual(0);
+    expect(pwIdx).toBeGreaterThan(authIdx);
+    expect(out).toContain('min_length = 12');
+    expect(out).toContain('require_number = true');
+  });
+
+  it('omits unspecified password fields (preserves partial policy)', () => {
+    const out = stringifyConfigToml({
+      auth: { password: { min_length: 8 } },
+    });
+    expect(out).toContain('[auth.password]');
+    expect(out).toContain('min_length = 8');
+    expect(out).not.toContain('require_number');
+  });
+
+  it('round-trips a full auth + password config', () => {
+    const original = {
+      auth: {
+        allowed_redirect_urls: ['https://a.com'],
+        require_email_verification: true,
+        verify_email_method: 'link' as const,
+        reset_password_method: 'code' as const,
+        password: {
+          min_length: 12,
+          require_number: true,
+          require_lowercase: true,
+          require_uppercase: true,
+          require_special_char: true,
+        },
+      },
+    };
+    expect(parseConfigToml(stringifyConfigToml(original))).toEqual(original);
+  });
+});
+
 describe('parseConfigToml — [deployments]', () => {
   it('parses subdomain as a string', () => {
     expect(parseConfigToml('[deployments]\nsubdomain = "my-app"\n')).toEqual({

--- a/src/lib/config-toml.ts
+++ b/src/lib/config-toml.ts
@@ -1,5 +1,11 @@
 import * as smolToml from 'smol-toml';
-import { validateConfig, type InsforgeConfig, type SmtpConfig } from './config-schema.js';
+import {
+  validateConfig,
+  type AuthConfig,
+  type InsforgeConfig,
+  type PasswordConfig,
+  type SmtpConfig,
+} from './config-schema.js';
 import { parseEnvRef } from './config-secrets.js';
 
 export function parseConfigToml(input: string): InsforgeConfig {
@@ -14,8 +20,8 @@ export function parseConfigToml(input: string): InsforgeConfig {
 
 /**
  * Render a normalized config back to TOML. Section ordering is deterministic
- * (project_id → auth → auth.smtp) so diffs are stable across runs of
- * `insforge config export`.
+ * (project_id → auth → auth.password → auth.smtp → deployments) so diffs
+ * are stable across runs of `insforge config export`.
  *
  * The renderer is intentionally hand-rolled rather than using smol-toml's
  * stringify: smol-toml doesn't preserve field order, and we want a stable
@@ -31,13 +37,16 @@ export function stringifyConfigToml(config: InsforgeConfig): string {
 
   if (config.auth) {
     lines.push('[auth]');
-    if (config.auth.allowed_redirect_urls !== undefined) {
-      const urls = config.auth.allowed_redirect_urls
-        .map((u) => JSON.stringify(u))
-        .join(', ');
-      lines.push(`allowed_redirect_urls = [${urls}]`);
-    }
+    renderAuthFlatFields(config.auth, lines);
     lines.push('');
+
+    // Sub-tables emit in fixed order so exported TOML is stable across runs;
+    // smol-toml's stringify would reorder these without our guarantee.
+    if (config.auth.password !== undefined) {
+      lines.push('[auth.password]');
+      renderPasswordFields(config.auth.password, lines);
+      lines.push('');
+    }
 
     if (config.auth.smtp !== undefined) {
       lines.push('[auth.smtp]');
@@ -59,6 +68,36 @@ export function stringifyConfigToml(config: InsforgeConfig): string {
   }
 
   return lines.join('\n').replace(/\n+$/, '\n');
+}
+
+function renderAuthFlatFields(auth: AuthConfig, lines: string[]): void {
+  if (auth.allowed_redirect_urls !== undefined) {
+    const urls = auth.allowed_redirect_urls.map((u) => JSON.stringify(u)).join(', ');
+    lines.push(`allowed_redirect_urls = [${urls}]`);
+  }
+  if (auth.require_email_verification !== undefined) {
+    lines.push(`require_email_verification = ${auth.require_email_verification}`);
+  }
+  if (auth.verify_email_method !== undefined) {
+    lines.push(`verify_email_method = ${JSON.stringify(auth.verify_email_method)}`);
+  }
+  if (auth.reset_password_method !== undefined) {
+    lines.push(`reset_password_method = ${JSON.stringify(auth.reset_password_method)}`);
+  }
+}
+
+function renderPasswordFields(pw: PasswordConfig, lines: string[]): void {
+  if (pw.min_length !== undefined) lines.push(`min_length = ${pw.min_length}`);
+  if (pw.require_number !== undefined) lines.push(`require_number = ${pw.require_number}`);
+  if (pw.require_lowercase !== undefined) {
+    lines.push(`require_lowercase = ${pw.require_lowercase}`);
+  }
+  if (pw.require_uppercase !== undefined) {
+    lines.push(`require_uppercase = ${pw.require_uppercase}`);
+  }
+  if (pw.require_special_char !== undefined) {
+    lines.push(`require_special_char = ${pw.require_special_char}`);
+  }
 }
 
 function renderSmtpFields(smtp: SmtpConfig, lines: string[]): void {


### PR DESCRIPTION
## Summary

Extends config-as-code to cover the rest of the auth.config row that the SMTP work depends on — declaratively configure verification flows + password policy.

**Stacked on top of #123** (the SMTP / deployments PR). Merge that first; this is a clean fast-forward after.

### New TOML surface

\`\`\`toml
[auth]
require_email_verification = true
verify_email_method = "link"     # "code" | "link"
reset_password_method = "code"

[auth.password]
min_length = 12
require_number = true
require_lowercase = true
require_uppercase = true
require_special_char = true
\`\`\`

### Design notes

- **Per-key DiffChange variants** (not whole-object like SMTP) — a partial \`[auth.password]\` block only touches the fields it names, preserving the rest of live state. True default-keep semantics.
- **Per-field capability gating** — each field probes its own \`/api/metadata\` key, so a backend that exposes the policy piecemeal still applies the supported subset rather than failing the whole batch.
- **Single endpoint, per-key PUTs** — all eight new fields route through \`PUT /api/auth/config\`. Idempotent and fast; keeps each change independently capability-gated.
- **No OSS backend work needed** — \`authConfigAdminResponseSchema\` already spreads every field on \`/api/metadata\`, and \`updateAuthConfigRequestSchema = authConfigSchema.omit(...).partial()\` already accepts them on the PUT side.

### Drive-by fix

Extracted \`liveFromMetadata\` into \`src/lib/config-metadata.ts\` so apply/plan/export agree on the live shape. Fixes a latent bug where \`plan.ts\` only read \`allowedRedirectUrls\` from metadata — SMTP/deployments/new-field diffs in the plan output would have shown false positives.

## Test plan

- [x] \`vitest run\` — 343/343 pass (~30 new tests across config-diff, config-toml, config-capabilities, export)
- [x] \`tsc --noEmit\` — clean on every touched file (one pre-existing prompts.ts error remains, unrelated)
- [x] \`eslint src/lib/config-*.ts src/commands/config/*.ts src/lib/config-metadata.ts\` — clean
- [x] \`tsup\` build — clean
- [ ] Manual: \`insforge config export\` against a real backend, hand-edit \`[auth.password]\`, \`insforge config plan\`, \`apply\` — verify per-key apply semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds auth verification flags and password policy to `insforge.toml` with per-field diffs and applies. Centralizes metadata handling and hardens parsing to prevent crashes, bogus diffs, and false skips.

- New Features
  - [auth]: `require_email_verification`, `verify_email_method` ("code" | "link"), `reset_password_method` ("code" | "link").
  - [auth.password]: `min_length`, `require_number`, `require_lowercase`, `require_uppercase`, `require_special_char`; per-key diffs and idempotent per-field `PUT /api/auth/config` using a centralized wire-key map; capability-gated via flat `/api/metadata` keys.
  - Export uses shared `config-metadata` to emit only supported fields; unknown enum values are dropped.

- Bug Fixes
  - Shared `liveFromMetadata` + `configFromMetadata` keep plan/export/apply in sync and fix plan false positives.
  - Defensive parsing: coerce wrong-shaped `allowedRedirectUrls` to `[]`; treat `smtpConfig: null` as supported-but-empty; shape-guard `deployments.customSlug` (non-strings → `null`) to avoid bogus diffs.
  - Explicit key-existence checks for `verify_email_method` and `reset_password_method` avoid silent mismatches when live is missing.

<sup>Written for commit c4e086ea1f9f76340c08001a01351da16427621c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auth verification flags and password policy support to `insforge.toml`
> - Extends the `insforge.toml` schema with `require_email_verification`, `verify_email_method`, `reset_password_method`, and an `[auth.password]` sub-table (with `min_length` and `require_*` boolean fields).
> - Updates `config plan`, `config apply`, and `config export` to diff, apply, and emit these new fields by issuing `PUT /api/auth/config` with the relevant fields.
> - Centralizes live-state projection and export logic into new `liveFromMetadata` and `configFromMetadata` helpers in [config-metadata.ts](https://github.com/InsForge/CLI/pull/127/files#diff-ab1ba1ec7e873b4ac33f4b601ecf0b51d632739cdaf7eebec4727952d4b83c02), removing duplicated inline implementations from each command.
> - Adds capability probing in [config-capabilities.ts](https://github.com/InsForge/CLI/pull/127/files#diff-b0f4c0c8748e98a29c8ca1d4d6280c02a560a03bcc38a9649cc98a490373cc4e) so unsupported fields are skipped when the backend lacks them.
> - Behavioral Change: `config plan` now diffs additional live fields; backends missing these fields default to `false` (verification flag) or `'code'` (method fields) rather than being ignored.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #127 opened
>
> - Added `asStringArray` utility function and updated `liveFromMetadata` and `configFromMetadata` functions to coerce wrong-shaped `allowedRedirectUrls` values to empty arrays [78325f8]
> - Updated `liveFromMetadata` and `configFromMetadata` functions to only populate SMTP configuration blocks when `smtpConfig` is a plain object, treating null values as absent [78325f8]
> - Added test coverage for `allowedRedirectUrls` coercion and `smtpConfig` null-handling in both `liveFromMetadata` and `configFromMetadata` functions [78325f8]
> - Modified `liveFromMetadata` function in `config-metadata` to validate `deployments.customSlug` type and value, ensuring `deployments.subdomain` is set to null unless `customSlug` is a non-empty string, and added corresponding test coverage for non-string input scenarios [c4e086e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b22aa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email verification controls (require flag, selection of verification/reset method)
  * Password policy customization (min length and per-character requirements) and dedicated password subtable in exports
  * Exports/plans/applies now use richer backend metadata to show supported/unsupported fields and emit deterministic TOML (SMTP password exported as env placeholder)

* **Tests**
  * Expanded coverage for auth fields, password-policy diffs, metadata projections, capability probing, and TOML parse/stringify

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/127)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->