### PR TITLE
refactor(posthog): always defer wizard to user

### DIFF
--- a/src/commands/posthog/setup.test.ts
+++ b/src/commands/posthog/setup.test.ts
@@ -29,14 +29,13 @@ vi.mock('@clack/prompts', async (orig) => {
     intro: vi.fn(),
     outro: vi.fn(),
     note: clackNoteMock,
-    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn() },
     spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
   };
 });
 
 const outputMock = vi.hoisted(() => ({
   outputJson: vi.fn(),
-  outputInfo: vi.fn(),
   outputSuccess: vi.fn(),
 }));
 vi.mock('../../lib/output.js', () => outputMock);
@@ -80,7 +79,6 @@ beforeEach(() => {
   apiMock.pollPosthogConnection.mockReset();
   apiMock.fetchPosthogConnection.mockReset();
   outputMock.outputJson.mockReset();
-  outputMock.outputInfo.mockReset();
   outputMock.outputSuccess.mockReset();
   clackNoteMock.mockReset();
   configMock.getProjectConfig.mockReturnValue({ project_id: 'p1', project_name: 'Test Project' });

--- a/src/commands/posthog/setup.test.ts
+++ b/src/commands/posthog/setup.test.ts
@@ -1,13 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
-import type { SpawnSyncReturns } from 'node:child_process';
-
-// Hoisted mocks — vi.mock factories are hoisted above ordinary top-level
-// statements, so any const they reference must be hoisted via vi.hoisted.
-const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
-vi.mock('node:child_process', () => ({
-  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
-}));
 
 const apiMock = vi.hoisted(() => ({
   startPosthogCliFlow: vi.fn(),
@@ -24,17 +16,19 @@ vi.mock('../../lib/config.js', () => configMock);
 
 vi.mock('../../lib/prompts.js', () => ({ isInteractive: false }));
 
-// `open` is loaded dynamically inside runConnectFlow; mock the module so the
-// real browser launch doesn't fire during tests.
+// `open` is loaded dynamically inside runConnectFlow; mock so the real browser
+// launch doesn't fire during tests.
 vi.mock('open', () => ({ default: vi.fn() }));
 
 // Silence interactive UI noise from clack — tests assert on mocks, not stdout.
+const clackNoteMock = vi.hoisted(() => vi.fn());
 vi.mock('@clack/prompts', async (orig) => {
   const actual = (await orig()) as Record<string, unknown>;
   return {
     ...actual,
     intro: vi.fn(),
     outro: vi.fn(),
+    note: clackNoteMock,
     log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
   };
@@ -50,38 +44,6 @@ vi.mock('../../lib/output.js', () => outputMock);
 // Imports must come AFTER the vi.mock calls because Vitest hoists the mocks
 // but ESM module evaluation order still matters.
 import { registerPosthogSetupCommand } from './setup.js';
-
-function spawnOk(): SpawnSyncReturns<string> {
-  return { pid: 1, output: ['', '', ''], stdout: '', stderr: '', status: 0, signal: null };
-}
-
-function spawnExit(code: number): SpawnSyncReturns<string> {
-  return { pid: 1, output: ['', '', ''], stdout: '', stderr: '', status: code, signal: null };
-}
-
-function spawnSignal(signal: NodeJS.Signals): SpawnSyncReturns<string> {
-  // When killed by signal, Node sets status: null and exposes the signal name.
-  return {
-    pid: 1,
-    output: ['', '', ''],
-    stdout: '',
-    stderr: '',
-    status: null as unknown as number,
-    signal,
-  };
-}
-
-function spawnSpawnError(err: Error): SpawnSyncReturns<string> {
-  return {
-    pid: 0,
-    output: ['', '', ''],
-    stdout: '',
-    stderr: '',
-    status: null as unknown as number,
-    signal: null,
-    error: err,
-  };
-}
 
 interface RunResult {
   exitCode?: number;
@@ -114,19 +76,15 @@ async function runSetup(argv: string[]): Promise<RunResult> {
 }
 
 beforeEach(() => {
-  spawnSyncMock.mockReset();
   apiMock.startPosthogCliFlow.mockReset();
   apiMock.pollPosthogConnection.mockReset();
   apiMock.fetchPosthogConnection.mockReset();
   outputMock.outputJson.mockReset();
   outputMock.outputInfo.mockReset();
   outputMock.outputSuccess.mockReset();
+  clackNoteMock.mockReset();
   configMock.getProjectConfig.mockReturnValue({ project_id: 'p1', project_name: 'Test Project' });
   configMock.getAccessToken.mockReturnValue('tok');
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
 });
 
 describe('posthog setup', () => {
@@ -137,7 +95,6 @@ describe('posthog setup', () => {
         kind: 'connected',
         connection: { apiKey: 'phc_', host: 'h', posthogProjectId: '1' },
       });
-      spawnSyncMock.mockReturnValue(spawnOk());
 
       await runSetup(['--skip-browser']);
 
@@ -156,7 +113,6 @@ describe('posthog setup', () => {
         host: 'h',
         posthogProjectId: '1',
       });
-      spawnSyncMock.mockReturnValue(spawnOk());
 
       await runSetup(['--skip-browser']);
 
@@ -164,18 +120,18 @@ describe('posthog setup', () => {
       expect(apiMock.fetchPosthogConnection).not.toHaveBeenCalled();
     });
 
-    it('fast-path data-drift: cli-start says connected but /connection says no → exits, wizard never spawns', async () => {
+    it('fast-path data-drift: cli-start says connected but /connection says no → exits non-zero', async () => {
       apiMock.startPosthogCliFlow.mockResolvedValue({ type: 'connected' });
       apiMock.fetchPosthogConnection.mockResolvedValue({ kind: 'not-connected' });
 
       const r = await runSetup(['--skip-browser']);
 
       expect(r.exitCode).toBeGreaterThan(0);
-      expect(spawnSyncMock).not.toHaveBeenCalled();
+      expect(clackNoteMock).not.toHaveBeenCalled();
     });
   });
 
-  describe('wizard step', () => {
+  describe('wizard handoff', () => {
     beforeEach(() => {
       apiMock.startPosthogCliFlow.mockResolvedValue({ type: 'connected' });
       apiMock.fetchPosthogConnection.mockResolvedValue({
@@ -184,72 +140,32 @@ describe('posthog setup', () => {
       });
     });
 
-    it('spawn error (ENOENT) → exits non-zero', async () => {
-      const enoent = Object.assign(new Error('spawn npx ENOENT'), { code: 'ENOENT' });
-      spawnSyncMock.mockReturnValue(spawnSpawnError(enoent));
-
-      const r = await runSetup(['--skip-browser']);
-
-      expect(spawnSyncMock).toHaveBeenCalledOnce();
-      expect(r.exitCode).toBeGreaterThan(0);
-    });
-
-    it('non-zero exit → exits non-zero', async () => {
-      spawnSyncMock.mockReturnValue(spawnExit(1));
-
-      const r = await runSetup(['--skip-browser']);
-
-      expect(r.exitCode).toBeGreaterThan(0);
-    });
-
-    it('SIGINT (exit 130) → clean exit, no error thrown', async () => {
-      spawnSyncMock.mockReturnValue(spawnExit(130));
-
-      const r = await runSetup(['--skip-browser']);
-
-      // Cancellation is graceful — runSetup returns normally, no handleError
-      // path, so process.exit was never called by the CLI.
-      expect(r.exitCode).toBeUndefined();
-    });
-
-    it('SIGINT signal (status=null, signal=SIGINT) → clean exit', async () => {
-      spawnSyncMock.mockReturnValue(spawnSignal('SIGINT'));
-
-      const r = await runSetup(['--skip-browser']);
-
-      expect(r.exitCode).toBeUndefined();
-    });
-
-    it('uses platform-aware npx binary', async () => {
-      spawnSyncMock.mockReturnValue(spawnOk());
-
+    it('always prints the wizard command in a Next step note (no spawn, no TTY check)', async () => {
       await runSetup(['--skip-browser']);
 
-      const [bin, args] = spawnSyncMock.mock.calls[0];
-      expect(bin).toMatch(/^npx(\.cmd)?$/);
-      expect(args).toEqual(['-y', '@posthog/wizard@latest']);
+      expect(clackNoteMock).toHaveBeenCalledOnce();
+      const [body, title] = clackNoteMock.mock.calls[0];
+      expect(title).toBe('Next step');
+      expect(body).toMatch(/npx(\.cmd)? -y @posthog\/wizard@latest/);
     });
   });
 
   describe('--json mode', () => {
-    it('skips wizard, emits JSON with wizardCommand', async () => {
+    it('emits JSON with wizardSkipped=true and wizardCommand', async () => {
       apiMock.startPosthogCliFlow.mockResolvedValue({ type: 'connected' });
       apiMock.fetchPosthogConnection.mockResolvedValue({
         kind: 'connected',
         connection: { apiKey: 'phc_', host: 'h', posthogProjectId: '1' },
       });
 
-      await runSetup(['--skip-browser']);
-      spawnSyncMock.mockClear();
-
-      // re-run in JSON mode
       const program = new Command();
       program.option('--json').option('--api-url <url>').option('-y, --yes');
       const posthog = program.command('posthog');
       registerPosthogSetupCommand(posthog);
       await program.parseAsync(['node', 'test', '--json', 'posthog', 'setup', '--skip-browser']);
 
-      expect(spawnSyncMock).not.toHaveBeenCalled();
+      // No clack note in JSON mode (stdout stays clean for piped consumers).
+      expect(clackNoteMock).not.toHaveBeenCalled();
       expect(outputMock.outputJson).toHaveBeenCalledOnce();
       const payload = outputMock.outputJson.mock.calls[0][0] as {
         success: boolean;

--- a/src/commands/posthog/setup.ts
+++ b/src/commands/posthog/setup.ts
@@ -1,5 +1,4 @@
 import type { Command } from 'commander';
-import { spawnSync } from 'node:child_process';
 import * as clack from '@clack/prompts';
 import pc from 'picocolors';
 import { getProjectConfig, getAccessToken } from '../../lib/config.js';
@@ -16,7 +15,7 @@ import {
   pollPosthogConnection,
   startPosthogCliFlow,
 } from '../../lib/api/posthog.js';
-import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
+import { outputJson, outputSuccess } from '../../lib/output.js';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 15 * 60 * 1000;
@@ -25,16 +24,13 @@ const MAX_TRANSIENT_RETRIES = 5;
 interface SetupResult {
   /** Whether the dashboard connection already existed (skipped OAuth) or was just established. */
   dashboardConnection: 'already-connected' | 'newly-connected';
-  /** True when JSON mode skipped the wizard step (wizard is interactive and incompatible with piped stdio). */
-  wizardSkipped: boolean;
-  /** Wizard process exit code; only set when wizardSkipped is false. */
-  wizardExitCode?: number;
-  /** Command the caller should run to complete the wizard step; only set when wizardSkipped is true. */
-  wizardCommand?: string;
+  /** Always true — CLI defers SDK install to the user-run `@posthog/wizard`. */
+  wizardSkipped: true;
+  /** The command the user should run themselves to complete the SDK install. */
+  wizardCommand: string;
 }
 
-// `npx` is installed as `npx.cmd` on Windows; passing the bare name to spawn
-// without a shell results in ENOENT. Use the platform-specific binary.
+// `npx` is installed as `npx.cmd` on Windows.
 const NPX_COMMAND = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 const WIZARD_COMMAND = `${NPX_COMMAND} -y @posthog/wizard@latest`;
 
@@ -70,13 +66,10 @@ interface RunSetupOpts {
 //   1. Ensure the InsForge dashboard has a PostHog connection (cli-start /
 //      OAuth). This is what populates `posthog_connections` in cloud-backend
 //      and makes the in-product Analytics page renderable.
-//   2. Spawn `npx @posthog/wizard` — it runs its own OAuth, lets the user pick
-//      a PostHog project, and installs + wires up the SDK in the app code.
-//
-// The two OAuths are independent and may even land on different PostHog
-// projects (rare in practice — same user account usually means same project).
-// We don't pass anything to the wizard; per its docs it discovers the project
-// interactively.
+//   2. Print the `npx @posthog/wizard` command and exit. The wizard is
+//      interactive (browser OAuth + framework picker) and we always defer it
+//      to the user's own terminal — agent shells and CI runners can't drive
+//      it, and detecting "are we really attended?" is too fragile.
 async function runSetup(opts: RunSetupOpts): Promise<SetupResult> {
   // 1. Linked project
   const proj = getProjectConfig();
@@ -98,54 +91,25 @@ async function runSetup(opts: RunSetupOpts): Promise<SetupResult> {
   // 3. Ensure dashboard connection exists
   const dashboardConnection = await ensureDashboardConnection(proj.project_id, token, opts);
 
-  // 4. Run the official PostHog wizard for app-code wiring.
-  //
-  // JSON mode is for scripted / headless callers, but the wizard is interactive
-  // (terminal TUI for framework + project selection, browser OAuth). Skip it
-  // and surface the command so the caller can run it themselves under a real
-  // TTY; piping its stdio would either hang or swallow the prompts.
-  if (opts.json) {
-    return {
-      dashboardConnection,
-      wizardSkipped: true,
-      wizardCommand: WIZARD_COMMAND,
-    };
+  // 4. Print the wizard command and exit. The wizard is interactive (browser
+  // OAuth + framework picker) and reliably detecting "do we have a real,
+  // attended TTY?" is fragile — agent shells allocate a PTY but never type
+  // into it; CI runners vary. Rather than try to autodetect, we always defer
+  // the wizard step to the user; they paste-and-run one command in their own
+  // terminal. CLI's job ends here.
+  if (!opts.json) {
+    clack.note(
+      `Run this in your terminal to wire PostHog into your app code:\n\n` +
+        `  ${WIZARD_COMMAND}\n\n` +
+        `Once it completes, open the Analytics page in your InsForge dashboard.`,
+      'Next step',
+    );
   }
-
-  outputInfo('Running the official PostHog setup wizard to wire PostHog into your app...');
-  outputInfo(
-    pc.dim('(it will open a browser for OAuth and let you pick a PostHog project)'),
-  );
-
-  const wizardResult = spawnSync(NPX_COMMAND, ['-y', '@posthog/wizard@latest'], {
-    stdio: 'inherit',
-    env: process.env,
-  });
-
-  if (wizardResult.error) {
-    throw new CLIError(`Failed to launch PostHog wizard: ${wizardResult.error.message}`);
-  }
-  const exitCode = wizardResult.status ?? 1;
-  // Treat user-initiated cancellation (Ctrl+C → 130 / SIGINT) as a clean exit
-  // rather than an error; the user just chose to abort the wizard step.
-  if (wizardResult.signal === 'SIGINT' || exitCode === 130) {
-    clack.outro('Setup cancelled.');
-    return {
-      dashboardConnection,
-      wizardSkipped: false,
-      wizardExitCode: exitCode,
-    };
-  }
-  if (exitCode !== 0) {
-    throw new CLIError(`PostHog wizard exited with code ${exitCode}.`);
-  }
-
-  clack.outro('Done. Open the Analytics page in your InsForge dashboard to view data.');
 
   return {
     dashboardConnection,
-    wizardSkipped: false,
-    wizardExitCode: exitCode,
+    wizardSkipped: true,
+    wizardCommand: WIZARD_COMMAND,
   };
 }
 
@@ -191,9 +155,12 @@ async function runConnectFlow(
     process.stderr.write('Your browser should open automatically. If not, copy the URL above.\n');
   } else {
     clack.log.info('PostHog is not yet connected to your InsForge dashboard.');
-    outputInfo('');
-    outputInfo(`Open this URL to authorize PostHog:\n  ${pc.cyan(pc.underline(authorizeUrl))}`);
-    outputInfo('');
+    if (opts.skipBrowser) {
+      clack.log.info(`Open this URL to authorize PostHog:\n${pc.cyan(pc.underline(authorizeUrl))}`);
+    } else {
+      clack.log.info('Opening browser to authorize PostHog...');
+      clack.log.info(`If browser doesn't open, visit:\n${pc.cyan(pc.underline(authorizeUrl))}`);
+    }
   }
 
   if (!opts.skipBrowser) {
@@ -206,7 +173,13 @@ async function runConnectFlow(
   }
 
   const spinner = !opts.json && isInteractive ? clack.spinner() : null;
-  spinner?.start('Waiting for InsForge dashboard connection... (timeout: 15 minutes)');
+  if (spinner) {
+    spinner.start('Waiting for InsForge dashboard connection... (timeout: 15 minutes)');
+  } else if (!opts.json) {
+    // Non-interactive (agent / CI / non-TTY): spinner can't animate, but the
+    // user still needs to know we're polling and how long we'll wait.
+    clack.log.info('Waiting for InsForge dashboard connection (up to 15 minutes)...');
+  }
 
   try {
     await pollPosthogConnection(
@@ -227,9 +200,19 @@ async function runConnectFlow(
       },
       opts.apiUrl,
     );
-    spinner?.stop('InsForge dashboard connection received.');
+    // Always print success — spinner.stop only renders in TTY, but the agent /
+    // non-interactive user needs to see the outcome of the wait.
+    if (spinner) {
+      spinner.stop('InsForge dashboard connection received.');
+    } else if (!opts.json) {
+      clack.log.success('InsForge dashboard connection received.');
+    }
   } catch (err) {
-    spinner?.stop('InsForge dashboard connection wait failed.');
+    if (spinner) {
+      spinner.stop('InsForge dashboard connection wait failed.');
+    } else if (!opts.json) {
+      clack.log.error('InsForge dashboard connection wait failed.');
+    }
     throw err;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors posthog setup to always defer the SDK install to the user. After verifying the dashboard connection, the CLI prints a “Next step” with `npx -y @posthog/wizard@latest` and exits; clearer non-interactive logs during OAuth and polling.

- **Refactors**
  - No longer spawns the wizard; removes `npx`/`spawnSync` logic and related tests.
  - When not using `--json`, shows a “Next step” note with the exact, platform-aware command; suppressed in `--json`.
  - JSON output now includes `wizardSkipped: true` and `wizardCommand`; `wizardExitCode` is removed.
  - Clearer connect flow messaging: consistent browser-open text, spinner fallback for non-TTY, and explicit success/error logs.

- **Migration**
  - Users: run `npx -y @posthog/wizard@latest` to wire the SDK.
  - Scripts/parsers: read `wizardSkipped` and `wizardCommand`; stop relying on `wizardExitCode` or the CLI launching the wizard.

<sup>Written for commit 06d93c7ab4713edc311727b76ba91382e573df61. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/132?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer PostHog wizard launch to the user in the `posthog setup` command
> - The `posthog setup` command no longer spawns the PostHog wizard via `spawnSync`. Instead, it always defers that step to the user.
> - In TTY mode, a `clack.note` titled 'Next step' prints the exact wizard command to run. In JSON mode, the response includes `wizardSkipped: true` and `wizardCommand`.
> - `SetupResult` is simplified: `wizardSkipped` is always `true` and `wizardCommand` is always present; `wizardExitCode` is removed.
> - The authorization/polling phase in `runConnectFlow` now uses `clack.log` for status messages in both interactive and non-interactive contexts, replacing `outputInfo`.
> - Behavioral Change: callers relying on the wizard being auto-launched or on `wizardExitCode` in the result will need to update their handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06d93c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified `posthog setup` command to display the PostHog wizard command instead of automatically launching it.
  * Improved handling of the `--skip-browser` flag during authorization.
  * Enhanced output messaging in non-interactive and JSON modes with clearer success and failure feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->