### PR TITLE
feat(cli)!: require --file for functions deploy

### DIFF
--- a/src/commands/functions/deploy.ts
+++ b/src/commands/functions/deploy.ts
@@ -1,5 +1,4 @@
 import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
 import type { Command } from 'commander';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
@@ -7,6 +6,16 @@ import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
 import type { FunctionResponse } from '../../types.js';
+
+export function resolveDeployFilePath(opts: { file?: string }): string {
+  if (!opts.file) {
+    throw new CLIError('Missing required option: --file <path>');
+  }
+  if (!existsSync(opts.file)) {
+    throw new CLIError(`Source file not found: ${opts.file}`);
+  }
+  return opts.file;
+}
 
 export function registerFunctionsDeployCommand(functionsCmd: Command): void {
   functionsCmd
@@ -20,14 +29,7 @@ export function registerFunctionsDeployCommand(functionsCmd: Command): void {
       try {
         await requireAuth();
 
-        // Resolve source file
-        const filePath = opts.file ?? join(process.cwd(), 'insforge', 'functions', slug, 'index.ts');
-        if (!existsSync(filePath)) {
-          throw new CLIError(
-            `Source file not found: ${filePath}\n` +
-            `Specify --file <path> or create ${join('insforge', 'functions', slug, 'index.ts')}`,
-          );
-        }
+        const filePath = resolveDeployFilePath(opts);
 
         const code = readFileSync(filePath, 'utf-8');
         const name = opts.name ?? slug;


### PR DESCRIPTION
## What

`insforge functions deploy <slug>` now **requires `--file <path>`**. The implicit fallback to `insforge/functions/<slug>/index.ts` is removed, and `resolveDeployFilePath()` centralizes the missing-flag / missing-file checks.

## Why

The CLI shouldn't dictate where function source lives. Developers keep their own layout and point `--file` at it. This also aligns the CLI with the MCP `create-function` tool, which already takes an explicit code file with no default path.

## Breaking change

Previously `deploy <slug>` fell back to `insforge/functions/<slug>/index.ts` when `--file` was omitted. That fallback is gone — omitting `--file` now errors with `Missing required option: --file <path>`.

## Test plan

- `npm run build` — passes
- `npm test` — 371 unit tests pass (the 3 errors are pre-existing vitest worker-startup timeouts in the `INTEGRATION_TEST_ENABLED`-gated suite, which doesn't run in CI/local without that env var)
- Manual: `deploy <slug>` with no `--file` → clear error; with `--file <missing>` → "Source file not found"; with `--file <existing>` → deploys

> Note: a dedicated unit test for `resolveDeployFilePath` is a worthwhile follow-up (the helper is currently covered by build + review only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`insforge functions deploy <slug>` now requires `--file <path>` and no longer falls back to `insforge/functions/<slug>/index.ts`. This makes the source path explicit and avoids imposing a project layout.

- **Migration**
  - Always pass `--file <path>` when deploying.
  - Omission errors with `Missing required option: --file <path>`; missing files error with `Source file not found: <path>`.

- **Refactors**
  - Added `resolveDeployFilePath()` to centralize missing-flag and missing-file checks.

<sup>Written for commit d7b55b7b2612f71986c9656b0f72f9f6d1b25b32. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/134?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy command now requires the `--file` parameter to be explicitly specified when deploying functions.
  * Added validation to ensure the specified file path exists before attempting deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require `--file` option for `functions deploy` command
> Previously, `functions deploy` fell back to an inferred default path when `--file` was omitted. Now `--file` is mandatory — omitting it immediately throws `Missing required option: --file <path>`, and specifying a non-existent path throws `Source file not found: <path>` without suggesting a default location. The logic is centralized in a new `resolveDeployFilePath` helper in [deploy.ts](https://github.com/InsForge/CLI/pull/134/files#diff-17fd5c7baacb3efd8bf75a507456d6f0185cbede1c7bbd409cc4fecd4c38ee9c). Behavioral Change: any existing usage of `functions deploy <slug>` without `--file` will now fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7b55b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->