### PR TITLE
feat(cli): add --marketplace flag to create

### DIFF
--- a/src/commands/create.marketplace.test.ts
+++ b/src/commands/create.marketplace.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { reportMarketplaceDownload } from './create';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const createSource: string = readFileSync(join(here, 'create.ts'), 'utf8');
+
+describe('reportMarketplaceDownload', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs to /templates/v1/<slug>/downloads on the given apiUrl', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ count: 1 }) });
+
+    await reportMarketplaceDownload('chatbot', 'https://api.insforge.dev');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.insforge.dev/templates/v1/chatbot/downloads');
+    expect(init).toMatchObject({ method: 'POST' });
+  });
+
+  it('URL-encodes the slug', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ count: 1 }) });
+
+    await reportMarketplaceDownload('weird slug', 'https://api.insforge.dev');
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('weird%20slug');
+  });
+
+  it('swallows network errors (does not throw)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(
+      reportMarketplaceDownload('chatbot', 'https://api.insforge.dev'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows non-2xx responses (does not throw)', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
+
+    await expect(
+      reportMarketplaceDownload('chatbot', 'https://api.insforge.dev'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('--marketplace flag wiring', () => {
+  // These tests read the source of create.ts and assert structural invariants
+  // (presence of mutual-exclusion check, branch ordering, absence of PostHog
+  // payload changes). The full command involves auth + network and isn't unit-
+  // testable without heavy mocking; this layer guards against silent refactors
+  // that would drop the wiring.
+
+  it('asserts the flag is mutually exclusive with --template at action entry', () => {
+    expect(createSource).toContain('--marketplace and --template are mutually exclusive');
+    expect(createSource).toMatch(/if \(opts\.marketplace && opts\.template\)/);
+  });
+
+  it('exposes the marketplace branch ahead of the githubTemplates branch in the download switch', () => {
+    const marketplaceIdx = createSource.indexOf('if (opts.marketplace) {');
+    const githubIdx = createSource.indexOf('githubTemplates.includes');
+    expect(marketplaceIdx).toBeGreaterThan(0);
+    expect(githubIdx).toBeGreaterThan(marketplaceIdx);
+  });
+
+  it('does NOT emit a PostHog template_selected event with a marketplace property', () => {
+    // template_selected still fires for the marketplace path (with template='empty'
+    // from the picker bypass) but its payload must not carry a 'marketplace' key.
+    expect(createSource).toMatch(/captureEvent\(orgId, 'template_selected'/);
+    const callIdx = createSource.indexOf("captureEvent(orgId, 'template_selected'");
+    const closingParen = createSource.indexOf(');', callIdx);
+    const callText = createSource.slice(callIdx, closingParen);
+    expect(callText).not.toMatch(/marketplace/);
+  });
+});

--- a/src/commands/create.marketplace.test.ts
+++ b/src/commands/create.marketplace.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { reportMarketplaceDownload } from './create';
+import { downloadMarketplaceTemplate, reportMarketplaceDownload } from './create';
+import type { ProjectConfig } from '../types';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const createSource: string = readFileSync(join(here, 'create.ts'), 'utf8');
+
+const dummyProjectConfig = {} as ProjectConfig;
 
 describe('reportMarketplaceDownload', () => {
   const fetchMock = vi.fn();
@@ -52,6 +55,38 @@ describe('reportMarketplaceDownload', () => {
     await expect(
       reportMarketplaceDownload('chatbot', 'https://api.insforge.dev'),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('downloadMarketplaceTemplate slug validation', () => {
+  // Slug must shape-match the registry regex before we touch the filesystem.
+  // This blocks path traversal (../, /abs, etc.) before path.join can be abused.
+
+  it('rejects parent-directory traversal', async () => {
+    await expect(
+      downloadMarketplaceTemplate('../etc', dummyProjectConfig, true),
+    ).rejects.toThrow(/Invalid --marketplace slug/);
+  });
+
+  it('rejects absolute path slugs', async () => {
+    await expect(
+      downloadMarketplaceTemplate('/etc/passwd', dummyProjectConfig, true),
+    ).rejects.toThrow(/Invalid --marketplace slug/);
+  });
+
+  it('rejects slugs with uppercase or special chars', async () => {
+    await expect(
+      downloadMarketplaceTemplate('FooBar', dummyProjectConfig, true),
+    ).rejects.toThrow(/Invalid --marketplace slug/);
+    await expect(
+      downloadMarketplaceTemplate('foo bar', dummyProjectConfig, true),
+    ).rejects.toThrow(/Invalid --marketplace slug/);
+  });
+
+  it('rejects empty slug', async () => {
+    await expect(
+      downloadMarketplaceTemplate('', dummyProjectConfig, true),
+    ).rejects.toThrow(/Invalid --marketplace slug/);
   });
 });
 

--- a/src/commands/create.marketplace.test.ts
+++ b/src/commands/create.marketplace.test.ts
@@ -102,11 +102,32 @@ describe('--marketplace flag wiring', () => {
     expect(createSource).toMatch(/if \(opts\.marketplace && opts\.template\)/);
   });
 
+  it('validates the slug at action entry before requireAuth (no orphaned project)', () => {
+    // The action handler must reject a bad slug BEFORE auth + project creation.
+    // Verify the regex check appears before the `await requireAuth(` call so
+    // the defense-in-depth check inside downloadMarketplaceTemplate is not the
+    // only line of defense.
+    const slugCheckIdx = createSource.indexOf(
+      'SAFE_MARKETPLACE_SLUG.test(opts.marketplace',
+    );
+    const requireAuthIdx = createSource.indexOf('await requireAuth(');
+    expect(slugCheckIdx).toBeGreaterThan(0);
+    expect(slugCheckIdx).toBeLessThan(requireAuthIdx);
+  });
+
   it('exposes the marketplace branch ahead of the githubTemplates branch in the download switch', () => {
     const marketplaceIdx = createSource.indexOf('if (opts.marketplace) {');
     const githubIdx = createSource.indexOf('githubTemplates.includes');
     expect(marketplaceIdx).toBeGreaterThan(0);
     expect(githubIdx).toBeGreaterThan(marketplaceIdx);
+  });
+
+  it('gates reportMarketplaceDownload on the downloaded boolean', () => {
+    // The counter ping must only fire when downloadMarketplaceTemplate returns
+    // true — a swallowed network/clone failure (return false) must NOT bump
+    // the marketplace's install count.
+    expect(createSource).toMatch(/const downloaded = await downloadMarketplaceTemplate/);
+    expect(createSource).toMatch(/if \(downloaded\)[\s\S]{0,80}reportMarketplaceDownload/);
   });
 
   it('does NOT emit a PostHog template_selected event with a marketplace property', () => {

--- a/src/commands/create.marketplace.test.ts
+++ b/src/commands/create.marketplace.test.ts
@@ -2,13 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { downloadMarketplaceTemplate, reportMarketplaceDownload } from './create';
-import type { ProjectConfig } from '../types';
+import { reportMarketplaceDownload } from './create';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const createSource: string = readFileSync(join(here, 'create.ts'), 'utf8');
-
-const dummyProjectConfig = {} as ProjectConfig;
 
 describe('reportMarketplaceDownload', () => {
   const fetchMock = vi.fn();
@@ -58,38 +55,6 @@ describe('reportMarketplaceDownload', () => {
   });
 });
 
-describe('downloadMarketplaceTemplate slug validation', () => {
-  // Slug must shape-match the registry regex before we touch the filesystem.
-  // This blocks path traversal (../, /abs, etc.) before path.join can be abused.
-
-  it('rejects parent-directory traversal', async () => {
-    await expect(
-      downloadMarketplaceTemplate('../etc', dummyProjectConfig, true),
-    ).rejects.toThrow(/Invalid --marketplace slug/);
-  });
-
-  it('rejects absolute path slugs', async () => {
-    await expect(
-      downloadMarketplaceTemplate('/etc/passwd', dummyProjectConfig, true),
-    ).rejects.toThrow(/Invalid --marketplace slug/);
-  });
-
-  it('rejects slugs with uppercase or special chars', async () => {
-    await expect(
-      downloadMarketplaceTemplate('FooBar', dummyProjectConfig, true),
-    ).rejects.toThrow(/Invalid --marketplace slug/);
-    await expect(
-      downloadMarketplaceTemplate('foo bar', dummyProjectConfig, true),
-    ).rejects.toThrow(/Invalid --marketplace slug/);
-  });
-
-  it('rejects empty slug', async () => {
-    await expect(
-      downloadMarketplaceTemplate('', dummyProjectConfig, true),
-    ).rejects.toThrow(/Invalid --marketplace slug/);
-  });
-});
-
 describe('--marketplace flag wiring', () => {
   // These tests read the source of create.ts and assert structural invariants
   // (presence of mutual-exclusion check, branch ordering, absence of PostHog
@@ -103,10 +68,11 @@ describe('--marketplace flag wiring', () => {
   });
 
   it('validates the slug at action entry before requireAuth (no orphaned project)', () => {
-    // The action handler must reject a bad slug BEFORE auth + project creation.
-    // Verify the regex check appears before the `await requireAuth(` call so
-    // the defense-in-depth check inside downloadMarketplaceTemplate is not the
-    // only line of defense.
+    // Slug regex MUST run before auth + project creation, otherwise a bad
+    // slug throws after the platform project already exists. With the
+    // standalone downloadMarketplaceTemplate function gone (marketplace now
+    // reuses downloadGitHubTemplate), the action-level check is the only
+    // line of defense — its position is load-bearing.
     const slugCheckIdx = createSource.indexOf(
       'SAFE_MARKETPLACE_SLUG.test(opts.marketplace',
     );
@@ -122,11 +88,11 @@ describe('--marketplace flag wiring', () => {
     expect(githubIdx).toBeGreaterThan(marketplaceIdx);
   });
 
-  it('gates reportMarketplaceDownload on the downloaded boolean', () => {
-    // The counter ping must only fire when downloadMarketplaceTemplate returns
+  it('gates reportMarketplaceDownload on the downloaded boolean from downloadGitHubTemplate', () => {
+    // The counter ping must only fire when downloadGitHubTemplate returns
     // true — a swallowed network/clone failure (return false) must NOT bump
     // the marketplace's install count.
-    expect(createSource).toMatch(/const downloaded = await downloadMarketplaceTemplate/);
+    expect(createSource).toMatch(/const downloaded = await downloadGitHubTemplate/);
     expect(createSource).toMatch(/if \(downloaded\)[\s\S]{0,80}reportMarketplaceDownload/);
   });
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -163,10 +163,14 @@ export function registerCreateCommand(program: Command): void {
     .option('--org-id <id>', 'Organization ID')
     .option('--region <region>', 'Deployment region (us-east, us-west, eu-central, ap-southeast)')
     .option('--template <template>', 'Template to use: react, nextjs, chatbot, crm, e-commerce, todo, or empty')
+    .option('--marketplace <slug>', 'Install a marketplace template by slug (browse: https://insforge.dev/templates)')
     .option('--auth <provider>', 'Wire a third-party auth provider into the chosen template (currently: better-auth)')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
+        if (opts.marketplace && opts.template) {
+          throw new CLIError('--marketplace and --template are mutually exclusive');
+        }
         await requireAuth(apiUrl, false);
 
         if (!json) {
@@ -238,6 +242,13 @@ export function registerCreateCommand(program: Command): void {
 
         if (template && !validTemplates.includes(template)) {
           throw new CLIError(`Invalid template "${template}". Valid options: ${validTemplates.join(', ')}`);
+        }
+        // Marketplace skips the interactive picker — discovery is web-only — but otherwise
+        // behaves like a regular template install (creates ./<projectName>/ subdir). Setting
+        // `template` to the slug makes `hasTemplate` true downstream; the download switch
+        // below short-circuits to the marketplace branch ahead of the githubTemplates check.
+        if (opts.marketplace) {
+          template = opts.marketplace as string;
         }
         if (!template) {
           if (json) {
@@ -348,7 +359,10 @@ export function registerCreateCommand(program: Command): void {
 
         // 7. Download template or seed env for blank projects
         const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
-        if (githubTemplates.includes(template!)) {
+        if (opts.marketplace) {
+          await downloadMarketplaceTemplate(opts.marketplace as string, projectConfig, json);
+          void reportMarketplaceDownload(opts.marketplace as string, apiUrl ?? 'https://api.insforge.dev');
+        } else if (githubTemplates.includes(template!)) {
           await downloadGitHubTemplate(template!, projectConfig, json);
         } else if (hasTemplate) {
           await downloadTemplate(template as Framework, projectConfig, projectName, json, apiUrl);
@@ -691,3 +705,126 @@ export async function downloadGitHubTemplate(
   }
 }
 
+export async function downloadMarketplaceTemplate(
+  slug: string,
+  projectConfig: ProjectConfig,
+  json: boolean,
+): Promise<void> {
+  const s = !json ? clack.spinner() : null;
+  s?.start(`Downloading marketplace template "${slug}"...`);
+
+  const tempDir = path.join(tmpdir(), `insforge-marketplace-${Date.now()}`);
+
+  try {
+    await fs.mkdir(tempDir, { recursive: true });
+
+    const templatesRepo =
+      process.env.INSFORGE_TEMPLATES_REPO ?? 'https://github.com/InsForge/insforge-templates.git';
+    if (!SAFE_REPO_PATTERN.test(templatesRepo)) {
+      throw new Error(`INSFORGE_TEMPLATES_REPO has unsupported characters: ${templatesRepo}`);
+    }
+    const templatesBranch = process.env.INSFORGE_TEMPLATES_BRANCH;
+    if (templatesBranch !== undefined && !SAFE_BRANCH_PATTERN.test(templatesBranch)) {
+      throw new Error(`INSFORGE_TEMPLATES_BRANCH has unsupported characters: ${templatesBranch}`);
+    }
+    const cloneArgs = ['clone', '--depth', '1'];
+    if (templatesBranch) cloneArgs.push('-b', templatesBranch);
+    cloneArgs.push('--', templatesRepo, '.');
+    await execFileAsync('git', cloneArgs, {
+      cwd: tempDir,
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+
+    const templateDir = path.join(tempDir, slug);
+    const stat = await fs.stat(templateDir).catch(() => null);
+    if (!stat?.isDirectory()) {
+      throw new Error(
+        `Template "${slug}" not found.\nBrowse available templates: https://insforge.dev/templates`,
+      );
+    }
+
+    s?.message('Copying template files...');
+    const cwd = process.cwd();
+    await copyDir(templateDir, cwd);
+
+    // Seed .env.local from .env.example (same logic as downloadGitHubTemplate).
+    const envExamplePath = path.join(cwd, '.env.example');
+    const envExampleExists = await fs.stat(envExamplePath).catch(() => null);
+    if (envExampleExists) {
+      const anonKey = await getAnonKey();
+      const envExample = await fs.readFile(envExamplePath, 'utf-8');
+      const envFinal = envExample.replace(
+        /^([A-Z][A-Z0-9_]*=)(.*)$/gm,
+        (_, prefix: string, _value: string) => {
+          const key = prefix.slice(0, -1);
+          if (/INSFORGE.*(URL|BASE_URL)$/.test(key)) return `${prefix}${projectConfig.oss_host}`;
+          if (/INSFORGE.*ANON_KEY$/.test(key)) return `${prefix}${anonKey}`;
+          if (key === 'NEXT_PUBLIC_APP_URL') {
+            return `${prefix}https://${projectConfig.appkey}.insforge.site`;
+          }
+          return `${prefix}${_value}`;
+        },
+      );
+      const envLocalPath = path.join(cwd, '.env.local');
+      try {
+        await fs.writeFile(envLocalPath, envFinal, { flag: 'wx' });
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
+          if (!json) clack.log.warn('.env.local already exists; skipping env seeding.');
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    s?.stop(`Marketplace template "${slug}" downloaded`);
+
+    // Auto-run db_init.sql if present (parity with downloadGitHubTemplate).
+    const migrationPath = path.join(cwd, 'migrations', 'db_init.sql');
+    const migrationExists = await fs.stat(migrationPath).catch(() => null);
+    if (migrationExists) {
+      const dbSpinner = !json ? clack.spinner() : null;
+      dbSpinner?.start('Running database migrations...');
+      try {
+        const sql = await fs.readFile(migrationPath, 'utf-8');
+        await runRawSql(sql, true);
+        dbSpinner?.stop('Database migrations applied');
+      } catch (err) {
+        dbSpinner?.stop('Database migration failed');
+        if (!json) {
+          clack.log.warn(`Migration failed: ${(err as Error).message}`);
+        } else {
+          throw err;
+        }
+      }
+    }
+  } catch (err) {
+    s?.stop(`Marketplace template "${slug}" download failed`);
+    throw err;
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Fire-and-forget POST to the marketplace download counter.
+ * Network errors and non-2xx responses are swallowed — a transient
+ * counter blip must not kill the install. The DB counter is the source
+ * of truth; PostHog is intentionally not used (per spec §6.3).
+ */
+export async function reportMarketplaceDownload(slug: string, apiUrl: string): Promise<void> {
+  try {
+    const res = await fetch(`${apiUrl}/templates/v1/${encodeURIComponent(slug)}/downloads`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    if (!res.ok) {
+      // Swallow — best-effort counter ping.
+      return;
+    }
+  } catch {
+    // Swallow — best-effort counter ping.
+  }
+}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -33,6 +33,7 @@ const execFileAsync = promisify(execFile);
 // validate the values so a hostile env var can't slip in extra git options.
 const SAFE_REPO_PATTERN = /^(https?:\/\/|git@)[A-Za-z0-9._:/@~+-]+(\.git)?$/;
 const SAFE_BRANCH_PATTERN = /^[A-Za-z0-9._/-]+$/;
+const SAFE_MARKETPLACE_SLUG = /^[a-z0-9][a-z0-9-]{0,99}$/;
 
 export type Framework = 'react' | 'nextjs';
 
@@ -710,6 +711,13 @@ export async function downloadMarketplaceTemplate(
   projectConfig: ProjectConfig,
   json: boolean,
 ): Promise<void> {
+  if (!SAFE_MARKETPLACE_SLUG.test(slug)) {
+    throw new CLIError(
+      `Invalid --marketplace slug "${slug}". Slugs must match ${SAFE_MARKETPLACE_SLUG}.\n` +
+        `Browse available templates: https://insforge.dev/templates`,
+    );
+  }
+
   const s = !json ? clack.spinner() : null;
   s?.start(`Downloading marketplace template "${slug}"...`);
 
@@ -801,7 +809,18 @@ export async function downloadMarketplaceTemplate(
     }
   } catch (err) {
     s?.stop(`Marketplace template "${slug}" download failed`);
-    throw err;
+    if (err instanceof CLIError) {
+      throw err;
+    }
+    const msg = `Failed to download marketplace template "${slug}": ${(err as Error).message}`;
+    if (json) {
+      console.error(JSON.stringify({ warning: msg }));
+    } else {
+      clack.log.warn(msg);
+      clack.log.info(
+        `You can manually clone from: https://github.com/InsForge/insforge-templates/tree/main/${slug}`,
+      );
+    }
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -172,6 +172,17 @@ export function registerCreateCommand(program: Command): void {
         if (opts.marketplace && opts.template) {
           throw new CLIError('--marketplace and --template are mutually exclusive');
         }
+        // Validate the marketplace slug up front, BEFORE we authenticate or
+        // create the platform project. The defense-in-depth check inside
+        // downloadMarketplaceTemplate also fires, but by the time that runs
+        // the project is already linked — a bad slug here would otherwise
+        // leave an orphaned project on the user's account.
+        if (opts.marketplace && !SAFE_MARKETPLACE_SLUG.test(opts.marketplace as string)) {
+          throw new CLIError(
+            `Invalid --marketplace slug "${opts.marketplace}". Slugs must match ${SAFE_MARKETPLACE_SLUG}.\n` +
+              `Browse available templates: https://insforge.dev/templates`,
+          );
+        }
         await requireAuth(apiUrl, false);
 
         if (!json) {
@@ -361,8 +372,20 @@ export function registerCreateCommand(program: Command): void {
         // 7. Download template or seed env for blank projects
         const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
         if (opts.marketplace) {
-          await downloadMarketplaceTemplate(opts.marketplace as string, projectConfig, json);
-          void reportMarketplaceDownload(opts.marketplace as string, apiUrl ?? 'https://api.insforge.dev');
+          // Counter only fires if the template actually landed on disk —
+          // a swallowed network/clone failure returns false so we don't
+          // record phantom installs in the marketplace's download stats.
+          const downloaded = await downloadMarketplaceTemplate(
+            opts.marketplace as string,
+            projectConfig,
+            json,
+          );
+          if (downloaded) {
+            void reportMarketplaceDownload(
+              opts.marketplace as string,
+              apiUrl ?? 'https://api.insforge.dev',
+            );
+          }
         } else if (githubTemplates.includes(template!)) {
           await downloadGitHubTemplate(template!, projectConfig, json);
         } else if (hasTemplate) {
@@ -710,7 +733,7 @@ export async function downloadMarketplaceTemplate(
   slug: string,
   projectConfig: ProjectConfig,
   json: boolean,
-): Promise<void> {
+): Promise<boolean> {
   if (!SAFE_MARKETPLACE_SLUG.test(slug)) {
     throw new CLIError(
       `Invalid --marketplace slug "${slug}". Slugs must match ${SAFE_MARKETPLACE_SLUG}.\n` +
@@ -807,6 +830,12 @@ export async function downloadMarketplaceTemplate(
         }
       }
     }
+
+    // Reached only after clone + copy + (optional) env seeding + (optional)
+    // db_init.sql all completed without throwing. Returning true here lets
+    // the call site decide whether to fire the download counter; a swallowed
+    // failure below returns false so we don't record phantom installs.
+    return true;
   } catch (err) {
     s?.stop(`Marketplace template "${slug}" download failed`);
     if (err instanceof CLIError) {
@@ -821,6 +850,7 @@ export async function downloadMarketplaceTemplate(
         `You can manually clone from: https://github.com/InsForge/insforge-templates/tree/main/${slug}`,
       );
     }
+    return false;
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -372,10 +372,11 @@ export function registerCreateCommand(program: Command): void {
         // 7. Download template or seed env for blank projects
         const githubTemplates = ['chatbot', 'crm', 'e-commerce', 'nextjs', 'react', 'todo'];
         if (opts.marketplace) {
-          // Counter only fires if the template actually landed on disk —
-          // a swallowed network/clone failure returns false so we don't
-          // record phantom installs in the marketplace's download stats.
-          const downloaded = await downloadMarketplaceTemplate(
+          // Marketplace reuses downloadGitHubTemplate — same git-clone + copy +
+          // env-seed + db_init flow. Slug was already validated at action
+          // entry; counter only fires when the boolean comes back true so a
+          // swallowed clone failure doesn't record a phantom install.
+          const downloaded = await downloadGitHubTemplate(
             opts.marketplace as string,
             projectConfig,
             json,
@@ -623,7 +624,7 @@ export async function downloadGitHubTemplate(
   templateName: string,
   projectConfig: ProjectConfig,
   json: boolean,
-): Promise<void> {
+): Promise<boolean> {
   const s = !json ? clack.spinner() : null;
   s?.start(`Downloading ${templateName} template...`);
 
@@ -715,6 +716,12 @@ export async function downloadGitHubTemplate(
         }
       }
     }
+
+    // Reached only after clone + copy + (optional) env seeding + (optional)
+    // db_init.sql all completed without throwing. Callers (currently the
+    // --marketplace path) gate the marketplace download counter on this
+    // boolean so swallowed failures below don't count as installs.
+    return true;
   } catch (err) {
     s?.stop(`${templateName} template download failed`);
     const msg = `Failed to download ${templateName} template: ${(err as Error).message}`;
@@ -723,129 +730,6 @@ export async function downloadGitHubTemplate(
     } else {
       clack.log.warn(msg);
       clack.log.info('You can manually clone from: https://github.com/InsForge/insforge-templates');
-    }
-  } finally {
-    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-  }
-}
-
-export async function downloadMarketplaceTemplate(
-  slug: string,
-  projectConfig: ProjectConfig,
-  json: boolean,
-): Promise<boolean> {
-  if (!SAFE_MARKETPLACE_SLUG.test(slug)) {
-    throw new CLIError(
-      `Invalid --marketplace slug "${slug}". Slugs must match ${SAFE_MARKETPLACE_SLUG}.\n` +
-        `Browse available templates: https://insforge.dev/templates`,
-    );
-  }
-
-  const s = !json ? clack.spinner() : null;
-  s?.start(`Downloading marketplace template "${slug}"...`);
-
-  const tempDir = path.join(tmpdir(), `insforge-marketplace-${Date.now()}`);
-
-  try {
-    await fs.mkdir(tempDir, { recursive: true });
-
-    // Marketplace always pulls from main of the canonical InsForge templates
-    // repo. No env-var override — contributors testing an unmerged template
-    // should validate locally (`npx @insforge/cli create --template <name>`
-    // still honours INSFORGE_TEMPLATES_BRANCH for that workflow) rather than
-    // route through the public marketplace command.
-    await execFileAsync(
-      'git',
-      ['clone', '--depth', '1', '--', 'https://github.com/InsForge/insforge-templates.git', '.'],
-      {
-        cwd: tempDir,
-        maxBuffer: 10 * 1024 * 1024,
-        timeout: 60_000,
-      },
-    );
-
-    const templateDir = path.join(tempDir, slug);
-    const stat = await fs.stat(templateDir).catch(() => null);
-    if (!stat?.isDirectory()) {
-      throw new Error(
-        `Template "${slug}" not found.\nBrowse available templates: https://insforge.dev/templates`,
-      );
-    }
-
-    s?.message('Copying template files...');
-    const cwd = process.cwd();
-    await copyDir(templateDir, cwd);
-
-    // Seed .env.local from .env.example (same logic as downloadGitHubTemplate).
-    const envExamplePath = path.join(cwd, '.env.example');
-    const envExampleExists = await fs.stat(envExamplePath).catch(() => null);
-    if (envExampleExists) {
-      const anonKey = await getAnonKey();
-      const envExample = await fs.readFile(envExamplePath, 'utf-8');
-      const envFinal = envExample.replace(
-        /^([A-Z][A-Z0-9_]*=)(.*)$/gm,
-        (_, prefix: string, _value: string) => {
-          const key = prefix.slice(0, -1);
-          if (/INSFORGE.*(URL|BASE_URL)$/.test(key)) return `${prefix}${projectConfig.oss_host}`;
-          if (/INSFORGE.*ANON_KEY$/.test(key)) return `${prefix}${anonKey}`;
-          if (key === 'NEXT_PUBLIC_APP_URL') {
-            return `${prefix}https://${projectConfig.appkey}.insforge.site`;
-          }
-          return `${prefix}${_value}`;
-        },
-      );
-      const envLocalPath = path.join(cwd, '.env.local');
-      try {
-        await fs.writeFile(envLocalPath, envFinal, { flag: 'wx' });
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
-          if (!json) clack.log.warn('.env.local already exists; skipping env seeding.');
-        } else {
-          throw e;
-        }
-      }
-    }
-
-    s?.stop(`Marketplace template "${slug}" downloaded`);
-
-    // Auto-run db_init.sql if present (parity with downloadGitHubTemplate).
-    const migrationPath = path.join(cwd, 'migrations', 'db_init.sql');
-    const migrationExists = await fs.stat(migrationPath).catch(() => null);
-    if (migrationExists) {
-      const dbSpinner = !json ? clack.spinner() : null;
-      dbSpinner?.start('Running database migrations...');
-      try {
-        const sql = await fs.readFile(migrationPath, 'utf-8');
-        await runRawSql(sql, true);
-        dbSpinner?.stop('Database migrations applied');
-      } catch (err) {
-        dbSpinner?.stop('Database migration failed');
-        if (!json) {
-          clack.log.warn(`Migration failed: ${(err as Error).message}`);
-        } else {
-          throw err;
-        }
-      }
-    }
-
-    // Reached only after clone + copy + (optional) env seeding + (optional)
-    // db_init.sql all completed without throwing. Returning true here lets
-    // the call site decide whether to fire the download counter; a swallowed
-    // failure below returns false so we don't record phantom installs.
-    return true;
-  } catch (err) {
-    s?.stop(`Marketplace template "${slug}" download failed`);
-    if (err instanceof CLIError) {
-      throw err;
-    }
-    const msg = `Failed to download marketplace template "${slug}": ${(err as Error).message}`;
-    if (json) {
-      console.error(JSON.stringify({ warning: msg }));
-    } else {
-      clack.log.warn(msg);
-      clack.log.info(
-        `You can manually clone from: https://github.com/InsForge/insforge-templates/tree/main/${slug}`,
-      );
     }
     return false;
   } finally {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -749,23 +749,20 @@ export async function downloadMarketplaceTemplate(
   try {
     await fs.mkdir(tempDir, { recursive: true });
 
-    const templatesRepo =
-      process.env.INSFORGE_TEMPLATES_REPO ?? 'https://github.com/InsForge/insforge-templates.git';
-    if (!SAFE_REPO_PATTERN.test(templatesRepo)) {
-      throw new Error(`INSFORGE_TEMPLATES_REPO has unsupported characters: ${templatesRepo}`);
-    }
-    const templatesBranch = process.env.INSFORGE_TEMPLATES_BRANCH;
-    if (templatesBranch !== undefined && !SAFE_BRANCH_PATTERN.test(templatesBranch)) {
-      throw new Error(`INSFORGE_TEMPLATES_BRANCH has unsupported characters: ${templatesBranch}`);
-    }
-    const cloneArgs = ['clone', '--depth', '1'];
-    if (templatesBranch) cloneArgs.push('-b', templatesBranch);
-    cloneArgs.push('--', templatesRepo, '.');
-    await execFileAsync('git', cloneArgs, {
-      cwd: tempDir,
-      maxBuffer: 10 * 1024 * 1024,
-      timeout: 60_000,
-    });
+    // Marketplace always pulls from main of the canonical InsForge templates
+    // repo. No env-var override — contributors testing an unmerged template
+    // should validate locally (`npx @insforge/cli create --template <name>`
+    // still honours INSFORGE_TEMPLATES_BRANCH for that workflow) rather than
+    // route through the public marketplace command.
+    await execFileAsync(
+      'git',
+      ['clone', '--depth', '1', '--', 'https://github.com/InsForge/insforge-templates.git', '.'],
+      {
+        cwd: tempDir,
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 60_000,
+      },
+    );
 
     const templateDir = path.join(tempDir, slug);
     const stat = await fs.stat(templateDir).catch(() => null);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--marketplace <slug>` to `create` to install marketplace templates by slug with early validation and a success-gated download counter. The marketplace path now reuses the GitHub template workflow and only reports a download on successful installs.

- **New Features**
  - `--marketplace <slug>` installs a template without the picker; mutually exclusive with `--template`.
  - Validates slugs (lowercase letters, numbers, hyphens) at action entry before auth/project creation.
  - Reuses `downloadGitHubTemplate` to clone from the canonical InsForge templates repo on `main` (no env-var overrides), copy files, seed `.env.local`, and run `migrations/db_init.sql` if present; returns a boolean for success.
  - Sends a POST to `${apiUrl}/templates/v1/<slug>/downloads` only when the download succeeds (slug URL-encoded); network/non-2xx errors are ignored. PostHog payload remains unchanged.

- **Migration**
  - Example: `insforge create my-app --marketplace chatbot`

<sup>Written for commit 150bb96ab6396856a41a5855689279ec069cafab. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/137?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--marketplace` flag to the `create` command for installing marketplace templates
> - Adds `--marketplace <slug>` to the `create` CLI command, which validates the slug against `SAFE_MARKETPLACE_SLUG` (`^[a-z0-9][a-z0-9-]{0,99}$`) before authentication or project creation.
> - Mutually excludes `--marketplace` and `--template`; providing both throws a `CLIError`.
> - On successful download, fires a best-effort POST to `/templates/v1/<slug>/downloads` via the new `reportMarketplaceDownload` function, which swallows all errors.
> - Changes `downloadGitHubTemplate` to return `Promise<boolean>` (true on success, false on failure) to gate the download counter ping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 150bb96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scaffold projects from the marketplace using a new --marketplace flag
  * Marketplace scaffolding downloads templates, configures environment files without overwriting existing local env, and runs database initialization when present
  * --marketplace and --template are mutually exclusive; marketplace selection skips interactive picker

* **Tests**
  * Added comprehensive tests covering marketplace download/validation, error handling, and telemetry/reporting behavior (fire-and-forget reporting)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->