### PR TITLE
chore: bump version to 0.1.82

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `@insforge/cli` version from 0.1.81 to 0.1.82 to publish the next patch release and keep `package.json` and `package-lock.json` in sync.

<sup>Written for commit a108871b25ee4e1d29c335411a676560dbdaffd5. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/138?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version released for `@insforge/cli`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to 0.1.82
> Updates the version field in [package.json](https://github.com/InsForge/CLI/pull/138/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from 0.1.81 to 0.1.82.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a108871.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->