### PR TITLE
feat(cli): write AGENTS.md into project root for bare agent harnesses (INS-187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,8 @@ It also installs [`find-skills`](https://github.com/vercel-labs/skills) so agent
 
 Skill files are written to per-agent directories (e.g. `.claude/`, `.cursor/`, `.windsurf/`) and are automatically added to your `.gitignore`. You can re-run `npx @insforge/cli link` at any time to reinstall or update skills.
 
+For bare agent harnesses that follow the open [agents.md](https://agents.md) standard (a single `AGENTS.md` at the project root) rather than the per-agent skill directories, the CLI also writes an `AGENTS.md` into your project. It contains a delimited `<!-- INSFORGE:START -->…<!-- INSFORGE:END -->` block with InsForge context (where credentials live, when to reach for the SDK vs. the CLI, and a few correctness patterns). If you already have an `AGENTS.md`, the block is appended once and refreshed in place on subsequent runs, leaving your own content untouched. Unlike the per-agent skill files, `AGENTS.md` is **not** gitignored, so you can commit and share it.
+
 ## Analytics
 
 The CLI reports anonymous usage events to [PostHog](https://posthog.com) so we can understand which features are being used and prioritize improvements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/lib/agents-md.test.ts
+++ b/src/lib/agents-md.test.ts
@@ -40,6 +40,23 @@ describe('buildInsforgeBlock', () => {
     expect(block.toLowerCase()).toContain('before implementing');
   });
 
+  it('names the specific skills the CLI installs', () => {
+    const block = buildInsforgeBlock(null);
+    for (const skill of [
+      '`insforge`',
+      '`insforge-cli`',
+      '`insforge-debug`',
+      '`insforge-integrations`',
+      '`find-skills`',
+    ]) {
+      expect(block).toContain(skill);
+    }
+  });
+
+  it('does not recommend the `insforge docs` command', () => {
+    expect(buildInsforgeBlock(null)).not.toContain('insforge docs');
+  });
+
   it('includes the high-leverage correctness patterns', () => {
     const block = buildInsforgeBlock(null);
     expect(block).toContain('insert([{');

--- a/src/lib/agents-md.test.ts
+++ b/src/lib/agents-md.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ProjectConfig } from '../types.js';
+import {
+  AGENTS_MD_END,
+  AGENTS_MD_START,
+  buildInsforgeBlock,
+  mergeAgentsMd,
+  writeLocalAgentsMd,
+} from './agents-md.js';
+
+const config: ProjectConfig = {
+  project_id: 'p1',
+  project_name: 'My App',
+  org_id: 'o1',
+  appkey: 'abc',
+  region: 'us-east',
+  api_key: 'super-secret-key-xyz',
+  oss_host: 'https://abc.us-east.insforge.app',
+};
+
+describe('buildInsforgeBlock', () => {
+  it('wraps content in the InsForge markers', () => {
+    const block = buildInsforgeBlock(null);
+    expect(block.startsWith(AGENTS_MD_START)).toBe(true);
+    expect(block.trimEnd().endsWith(AGENTS_MD_END)).toBe(true);
+  });
+
+  it('explains what InsForge is', () => {
+    const block = buildInsforgeBlock(null);
+    expect(block).toContain('InsForge');
+    expect(block.toLowerCase()).toContain('backend');
+  });
+
+  it('tells the agent when to use the installed skills', () => {
+    const block = buildInsforgeBlock(null);
+    expect(block.toLowerCase()).toContain('skill');
+    expect(block.toLowerCase()).toContain('before implementing');
+  });
+
+  it('includes the high-leverage correctness patterns', () => {
+    const block = buildInsforgeBlock(null);
+    expect(block).toContain('insert([{');
+    expect(block).toContain('auth.users(id)');
+    expect(block).toContain('auth.uid()');
+  });
+
+  it('includes project name and API host when config is present', () => {
+    const block = buildInsforgeBlock(config);
+    expect(block).toContain('My App');
+    expect(block).toContain('https://abc.us-east.insforge.app');
+  });
+
+  it('never leaks the api_key (the file is committed)', () => {
+    expect(buildInsforgeBlock(config)).not.toContain('super-secret-key-xyz');
+  });
+});
+
+describe('mergeAgentsMd', () => {
+  it('creates a fresh file with a heading when none exists', () => {
+    const out = mergeAgentsMd(null, config);
+    expect(out).toContain('# AGENTS.md');
+    expect(out).toContain(AGENTS_MD_START);
+    expect(out).toContain(AGENTS_MD_END);
+  });
+
+  it('appends the block to an existing file, preserving user content', () => {
+    const existing = '# My rules\n\nAlways write tests.\n';
+    const out = mergeAgentsMd(existing, config);
+    expect(out).toContain('Always write tests.');
+    expect(out.indexOf('Always write tests.')).toBeLessThan(out.indexOf(AGENTS_MD_START));
+  });
+
+  it('replaces an existing InsForge block in place (no duplication)', () => {
+    const first = mergeAgentsMd('# My rules\n\nKeep it.\n', config);
+    const second = mergeAgentsMd(first, config);
+    expect(second).toBe(first); // idempotent
+    expect(second.match(/INSFORGE:START/g)).toHaveLength(1);
+    expect(second).toContain('Keep it.');
+  });
+
+  it('refreshes the block when config changes without growing the file', () => {
+    const first = mergeAgentsMd(null, null);
+    const refreshed = mergeAgentsMd(first, config);
+    expect(refreshed.match(/INSFORGE:START/g)).toHaveLength(1);
+    expect(refreshed).toContain('My App');
+  });
+
+  it('treats an empty existing file as fresh', () => {
+    const out = mergeAgentsMd('   \n', config);
+    expect(out).toContain('# AGENTS.md');
+  });
+});
+
+describe('writeLocalAgentsMd', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cli-agents-md-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates AGENTS.md in the target directory', () => {
+    writeLocalAgentsMd(true, { cwd: dir, config });
+    const content = readFileSync(join(dir, 'AGENTS.md'), 'utf-8');
+    expect(content).toContain(AGENTS_MD_START);
+    expect(content).toContain('My App');
+  });
+
+  it('is idempotent: a second run leaves the file byte-identical', () => {
+    writeLocalAgentsMd(true, { cwd: dir, config });
+    const first = readFileSync(join(dir, 'AGENTS.md'), 'utf-8');
+    writeLocalAgentsMd(true, { cwd: dir, config });
+    const second = readFileSync(join(dir, 'AGENTS.md'), 'utf-8');
+    expect(second).toBe(first);
+  });
+
+  it('preserves a pre-existing AGENTS.md and appends the InsForge block', () => {
+    const p = join(dir, 'AGENTS.md');
+    writeFileSync(p, '# Existing\n\nUser instructions here.\n');
+    writeLocalAgentsMd(true, { cwd: dir, config });
+    const content = readFileSync(p, 'utf-8');
+    expect(content).toContain('User instructions here.');
+    expect(content).toContain(AGENTS_MD_START);
+  });
+});

--- a/src/lib/agents-md.test.ts
+++ b/src/lib/agents-md.test.ts
@@ -110,6 +110,26 @@ describe('mergeAgentsMd', () => {
     expect(out).toContain('# AGENTS.md');
   });
 
+  it('recovers in place (no duplicate) when the END marker was deleted', () => {
+    // User corrupts the managed block by removing only its END marker, leaving
+    // an orphaned START. A rerun must replace from START to EOF, not append a
+    // second block (which a later run could use to eat content between blocks).
+    const corrupted = `# Mine\n\n${AGENTS_MD_START}\nstale insforge block, end marker gone\n`;
+    const first = mergeAgentsMd(corrupted, config);
+    const second = mergeAgentsMd(first, config);
+    expect(first.match(/INSFORGE:START/g)).toHaveLength(1);
+    expect(first).toContain(AGENTS_MD_END);
+    expect(first).toContain('# Mine');
+    expect(second).toBe(first); // idempotent after recovery
+  });
+
+  it('inserts a newline when user content directly precedes the block', () => {
+    const existing = `Title ${AGENTS_MD_START}old${AGENTS_MD_END}\n`;
+    const out = mergeAgentsMd(existing, config);
+    expect(out).toContain(`Title \n${AGENTS_MD_START}`);
+    expect(out).not.toContain(`Title ${AGENTS_MD_START}`);
+  });
+
   it('stays idempotent when user content above the block mentions the END marker', () => {
     // A stray END marker in the user's own prose must not be mistaken for the
     // block's terminator, which would skip in-place replacement and duplicate.

--- a/src/lib/agents-md.test.ts
+++ b/src/lib/agents-md.test.ts
@@ -109,6 +109,17 @@ describe('mergeAgentsMd', () => {
     const out = mergeAgentsMd('   \n', config);
     expect(out).toContain('# AGENTS.md');
   });
+
+  it('stays idempotent when user content above the block mentions the END marker', () => {
+    // A stray END marker in the user's own prose must not be mistaken for the
+    // block's terminator, which would skip in-place replacement and duplicate.
+    const userPrefix = `# Notes\n\nDo not edit \`${AGENTS_MD_END}\` in my docs.\n\n`;
+    const first = mergeAgentsMd(`${userPrefix}placeholder\n`, config);
+    const second = mergeAgentsMd(first, config);
+    expect(second).toBe(first); // idempotent
+    expect(second.match(/INSFORGE:START/g)).toHaveLength(1);
+    expect(second).toContain('Do not edit');
+  });
 });
 
 describe('writeLocalAgentsMd', () => {

--- a/src/lib/agents-md.ts
+++ b/src/lib/agents-md.ts
@@ -69,7 +69,11 @@ export function mergeAgentsMd(existing: string | null, config: ProjectConfig | n
   }
 
   const startIdx = existing.indexOf(AGENTS_MD_START);
-  const endIdx = existing.indexOf(AGENTS_MD_END);
+  // Search for the END marker after the matched START so a stray END marker in
+  // the user's own content above the block can't break in-place replacement
+  // (which would append a duplicate block on the next run).
+  const endIdx =
+    startIdx === -1 ? -1 : existing.indexOf(AGENTS_MD_END, startIdx + AGENTS_MD_START.length);
   if (startIdx !== -1 && endIdx > startIdx) {
     const before = existing.slice(0, startIdx);
     const after = existing.slice(endIdx + AGENTS_MD_END.length);

--- a/src/lib/agents-md.ts
+++ b/src/lib/agents-md.ts
@@ -1,0 +1,108 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as clack from '@clack/prompts';
+import type { ProjectConfig } from '../types.js';
+import { getProjectConfig } from './config.js';
+
+// HTML-comment markers delimit the InsForge-managed section so we can refresh it
+// in place on re-link instead of appending a duplicate every run. Anything
+// outside the markers is the user's own content and is never touched.
+export const AGENTS_MD_START = '<!-- INSFORGE:START -->';
+export const AGENTS_MD_END = '<!-- INSFORGE:END -->';
+
+/**
+ * Builds the InsForge-managed block for AGENTS.md (markers included).
+ *
+ * Contains no secrets: AGENTS.md follows the open agents.md standard and is
+ * meant to be committed and shared, so only the project name and the (already
+ * public) API host are embedded, never the api_key.
+ */
+export function buildInsforgeBlock(config: ProjectConfig | null): string {
+  const lines: string[] = [
+    AGENTS_MD_START,
+    '## InsForge backend',
+    '',
+    'This project uses [InsForge](https://insforge.dev): an all-in-one, open-source Postgres-based backend (BaaS) that gives this app a database, authentication, file storage, edge functions, realtime, an AI model gateway, and payments through one platform.',
+    '',
+  ];
+
+  if (config?.project_name || config?.oss_host) {
+    const name = config.project_name ? `**${config.project_name}**` : 'This project';
+    const host = config.oss_host ? ` (API base \`${config.oss_host}\`)` : '';
+    lines.push(`- **Project:** ${name}${host}`);
+  }
+
+  lines.push(
+    '- **Skills:** detailed InsForge skills are installed for supported coding agents. Before implementing any InsForge feature (database queries, auth, storage, edge functions, realtime, AI, or payments), consult the `insforge` skill or run `insforge docs <feature>` so you generate correct code instead of guessing the API.',
+    '- **Credentials:** app code reads keys from `.env.local`; the CLI reads `.insforge/project.json`. Never hardcode or commit keys.',
+    '- **App code:** use the `@insforge/sdk` client for database, auth, storage, realtime, and AI calls.',
+    '- **Infrastructure:** use the `insforge` CLI (`npx @insforge/cli`) for SQL, migrations, RLS policies, storage buckets, functions, secrets, payments, and deploys.',
+    '',
+    'Key patterns:',
+    '',
+    '- Database inserts take an array: `insert([{ ... }])`.',
+    '- Reference users with `auth.users(id)`; use `auth.uid()` in RLS policies.',
+    '- For storage uploads, persist both the returned `url` and `key`.',
+    AGENTS_MD_END,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Pure merge of the InsForge block into AGENTS.md content.
+ *
+ * - No existing file (or blank): create one with a top-level heading.
+ * - Existing file with our markers: replace the block in place (idempotent,
+ *   the file never grows on repeated runs).
+ * - Existing file without our markers: append the block, preserving the user's
+ *   own content above it.
+ */
+export function mergeAgentsMd(existing: string | null, config: ProjectConfig | null): string {
+  const block = buildInsforgeBlock(config);
+
+  if (existing === null || existing.trim() === '') {
+    return `# AGENTS.md\n\n${block}\n`;
+  }
+
+  const startIdx = existing.indexOf(AGENTS_MD_START);
+  const endIdx = existing.indexOf(AGENTS_MD_END);
+  if (startIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx);
+    const after = existing.slice(endIdx + AGENTS_MD_END.length);
+    return `${before}${block}${after}`;
+  }
+
+  return `${existing.replace(/\s+$/, '')}\n\n${block}\n`;
+}
+
+/**
+ * Writes (or refreshes) the InsForge section of `AGENTS.md` in the project
+ * directory so bare agent harnesses that read `./AGENTS.md` get InsForge
+ * context. Unlike the per-agent skill directories, AGENTS.md is left out of
+ * .gitignore so it can be committed and shared with the team.
+ *
+ * Best-effort: callers wrap this so a write failure never aborts create/link.
+ */
+export function writeLocalAgentsMd(
+  json: boolean,
+  opts?: { cwd?: string; config?: ProjectConfig | null },
+): void {
+  const cwd = opts?.cwd ?? process.cwd();
+  const config = opts?.config !== undefined ? opts.config : getProjectConfig();
+  const path = join(cwd, 'AGENTS.md');
+
+  const existed = existsSync(path);
+  const existing = existed ? readFileSync(path, 'utf-8') : null;
+  const next = mergeAgentsMd(existing, config);
+  if (existing === next) return; // already up to date
+
+  writeFileSync(path, next);
+  if (!json) {
+    clack.log.success(
+      existed
+        ? 'Updated AGENTS.md with InsForge guidance.'
+        : 'Created AGENTS.md with InsForge guidance.',
+    );
+  }
+}

--- a/src/lib/agents-md.ts
+++ b/src/lib/agents-md.ts
@@ -69,17 +69,20 @@ export function mergeAgentsMd(existing: string | null, config: ProjectConfig | n
   }
 
   const startIdx = existing.indexOf(AGENTS_MD_START);
-  // Search for the END marker after the matched START so a stray END marker in
-  // the user's own content above the block can't break in-place replacement
-  // (which would append a duplicate block on the next run).
-  const endIdx =
-    startIdx === -1 ? -1 : existing.indexOf(AGENTS_MD_END, startIdx + AGENTS_MD_START.length);
-  if (startIdx !== -1 && endIdx > startIdx) {
-    const before = existing.slice(0, startIdx);
-    const after = existing.slice(endIdx + AGENTS_MD_END.length);
+  if (startIdx !== -1) {
+    // Close the block at the END marker that follows this START (not the first
+    // END in the file, which could be a stray marker in the user's own content
+    // above the block). If the block was corrupted by removing its END marker,
+    // replace from START through end-of-file so we recover in place instead of
+    // appending a duplicate block on the next run.
+    const endMarkerIdx = existing.indexOf(AGENTS_MD_END, startIdx + AGENTS_MD_START.length);
+    let before = existing.slice(0, startIdx);
+    if (before.length > 0 && !before.endsWith('\n')) before += '\n';
+    const after = endMarkerIdx === -1 ? '\n' : existing.slice(endMarkerIdx + AGENTS_MD_END.length);
     return `${before}${block}${after}`;
   }
 
+  // No InsForge block yet — append it, separated by a blank line.
   return `${existing.replace(/\s+$/, '')}\n\n${block}\n`;
 }
 

--- a/src/lib/agents-md.ts
+++ b/src/lib/agents-md.ts
@@ -33,10 +33,13 @@ export function buildInsforgeBlock(config: ProjectConfig | null): string {
   }
 
   lines.push(
-    '- **Skills:** detailed InsForge skills are installed for supported coding agents. Before implementing any InsForge feature (database queries, auth, storage, edge functions, realtime, AI, or payments), consult the `insforge` skill or run `insforge docs <feature>` so you generate correct code instead of guessing the API.',
+    '- **Skills:** these InsForge skills are installed for supported coding agents. Reach for them before implementing any InsForge feature instead of guessing the API:',
+    '  - `insforge`: app code with the `@insforge/sdk` client (database CRUD, auth, storage, edge functions, realtime, AI, email, and Stripe payments).',
+    '  - `insforge-cli`: backend and infrastructure via the `insforge` CLI (projects, SQL, migrations, RLS policies, storage buckets, functions, secrets, payment setup, schedules, deploys).',
+    '  - `insforge-debug`: diagnosing failures (SDK/HTTP errors, RLS denials, auth and OAuth issues) and running security or performance audits.',
+    '  - `insforge-integrations`: wiring external auth providers (Clerk, Auth0, WorkOS, Better Auth, etc.) for JWT-based RLS, or the OKX x402 payment facilitator.',
+    '  - `find-skills`: discovering additional skills on demand.',
     '- **Credentials:** app code reads keys from `.env.local`; the CLI reads `.insforge/project.json`. Never hardcode or commit keys.',
-    '- **App code:** use the `@insforge/sdk` client for database, auth, storage, realtime, and AI calls.',
-    '- **Infrastructure:** use the `insforge` CLI (`npx @insforge/cli`) for SQL, migrations, RLS policies, storage buckets, functions, secrets, payments, and deploys.',
     '',
     'Key patterns:',
     '',

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, appendFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import * as clack from '@clack/prompts';
+import { writeLocalAgentsMd } from './agents-md.js';
 import { getProjectConfig } from './config.js';
 
 const execAsync = promisify(exec);
@@ -137,6 +138,16 @@ export async function installSkills(json: boolean, authProvider?: string): Promi
 
   try {
     updateGitignore();
+  } catch {
+    // non-critical, silently ignore
+  }
+
+  // Drop an AGENTS.md in the project root so bare "true harness" agents that
+  // follow the open agents.md standard (and don't read the per-agent skill
+  // dirs) still get InsForge context. Left out of .gitignore on purpose so it
+  // can be committed and shared. Best-effort — never block create/link.
+  try {
+    writeLocalAgentsMd(json);
   } catch {
     // non-critical, silently ignore
   }


### PR DESCRIPTION
## What & why

`insforge create` / `insforge link` already install per-agent skills into per-agent directories (`.claude/`, `.cursor/`, `.windsurf/`, …) **globally** via `npx skills add`. But a bare "true harness" agent that follows the open [agents.md](https://agents.md) standard reads a single `./AGENTS.md` at the project root, and never looks at those per-agent dirs.

This PR makes the CLI also write an `AGENTS.md` into the **local project directory** during the same install step, so those harnesses get InsForge context. Resolves **INS-187**.

## What the AGENTS.md says
- **What InsForge is** (all-in-one Postgres BaaS).
- **When to use the installed skills** — consult the `insforge` skill / `insforge docs <feature>` before implementing any InsForge feature, instead of guessing the API.
- Where credentials live (`.env.local` / `.insforge/project.json`), `@insforge/sdk` for app code vs. the `insforge` CLI for infra, and a few high-leverage correctness patterns (array inserts, `auth.users(id)`/`auth.uid()`, storage `url`+`key`).

## Behavior / design decisions
- **Idempotent merge.** Content sits inside `<!-- INSFORGE:START -->…<!-- INSFORGE:END -->` markers. No file → create it; existing file without our markers → append the block once; existing file with our markers → refresh in place. The file never grows on repeated `link` runs, and a user's own `AGENTS.md` content is preserved.
- **Committed, not gitignored.** Unlike the per-agent skill dirs, `AGENTS.md` is deliberately left out of the `.gitignore` block so it can be committed and shared (the whole point of the standard).
- **No secrets.** Only the project name and the (already public) API host are embedded — never the `api_key` — because this file is committed.
- **Best-effort.** Wired into `installSkills()` in its own try/catch so a write failure never aborts `create`/`link`.

## Files
- `src/lib/agents-md.ts` (new) — `buildInsforgeBlock`, pure `mergeAgentsMd`, `writeLocalAgentsMd`.
- `src/lib/agents-md.test.ts` (new) — 14 unit tests (markers, idempotency, append-preserve, no-secret, content checks).
- `src/lib/skills.ts` — call `writeLocalAgentsMd(json)` after `updateGitignore()`.
- `README.md` — Agent Skills section note.
- `package.json` — version bump `0.1.82` → `0.1.83`.

## Verification
- `npm run lint` (full vitest suite + eslint): **383 passed / 13 skipped, 0 errors**.
- `npm run build`: success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Write AGENTS.md into project root when installing skills
> - Adds [`agents-md.ts`](https://github.com/InsForge/CLI/pull/139/files#diff-013a496ab155cbc0a89b4948f2a370265d985178b90e6e1619722b9d8276f3f9) with three utilities: `buildInsforgeBlock` generates a secret-free InsForge guidance block; `mergeAgentsMd` idempotently inserts or replaces the block in existing file content without touching user-written sections; `writeLocalAgentsMd` reads, merges, and writes AGENTS.md only when content changes.
> - Calls `writeLocalAgentsMd` at the end of `installSkills` in [`skills.ts`](https://github.com/InsForge/CLI/pull/139/files#diff-c9007d25f494c224c301e8731d5b57f357f48a38150b2950cf1e2d310ae34288) inside a best-effort try/catch so failures are silently ignored.
> - The generated block includes installed skills, credential locations, and correctness patterns, but never embeds `api_key`.
> - AGENTS.md is committed (not gitignored) and updated in-place on repeated installs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c444a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now generates and maintains an AGENTS.md at the project root to document agent skills and public project config; the generated block is idempotent, refreshable, and preserves existing user content.

* **Documentation**
  * README updated to describe AGENTS.md generation and behavior.

* **Tests**
  * Added test coverage validating AGENTS.md creation, idempotency, merging, and preservation of user content.

* **Chores**
  * Package version bumped to 0.1.83.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->