### PR TITLE
feat(cli): add PostHog tracking for compute commands

### DIFF
--- a/src/commands/compute/delete.ts
+++ b/src/commands/compute/delete.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 
 export function registerComputeDeleteCommand(computeCmd: Command): void {
   computeCmd
@@ -25,8 +26,10 @@ export function registerComputeDeleteCommand(computeCmd: Command): void {
           outputSuccess('Service deleted.');
         }
         await reportCliUsage('cli.compute.delete', true);
+        await trackComputeUsage('delete', true);
       } catch (err) {
         await reportCliUsage('cli.compute.delete', false);
+        await trackComputeUsage('delete', false);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/deploy.test.ts
+++ b/src/commands/compute/deploy.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../../lib/api/oss.js', () => ({
+  ossFetch: vi.fn(),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ access_token: 'tok', user: { id: 'u1' } })),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  getProjectConfig: vi.fn(() => ({
+    project_id: 'p1',
+    project_name: 'proj',
+    org_id: 'o1',
+    region: 'iad',
+    appkey: 'k',
+    api_key: 'key',
+  })),
+  getCredentials: vi.fn(() => ({ user: { id: 'u1' } })),
+}));
+
+vi.mock('../../lib/analytics.js', () => ({
+  trackCompute: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/skills.js', () => ({
+  reportCliUsage: vi.fn(async () => {}),
+}));
+
+import { registerComputeDeployCommand } from './deploy.js';
+import { ossFetch } from '../../lib/api/oss.js';
+import { trackCompute } from '../../lib/analytics.js';
+
+const mockOssFetch = ossFetch as ReturnType<typeof vi.fn>;
+const mockTrackCompute = trackCompute as ReturnType<typeof vi.fn>;
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>').option('-y, --yes');
+  const computeCmd = program.command('compute');
+  registerComputeDeployCommand(computeCmd);
+  return program;
+}
+
+describe('compute deploy analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Image mode makes two calls in order: list (→ [] = no existing service),
+    // then POST (→ the created service).
+    mockOssFetch
+      .mockResolvedValueOnce({ json: async () => [] })
+      .mockResolvedValueOnce({
+        json: async () => ({ name: 'api', status: 'creating', port: 8080 }),
+      });
+  });
+
+  it('tracks deploy with safe metadata only — no image url or env values leak', async () => {
+    const program = makeProgram();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await program.parseAsync(
+        [
+          'compute', 'deploy',
+          '--name', 'api',
+          '--image', 'registry.example.com/secret/api:1.2.3',
+          '--cpu', 'shared-1x',
+          '--memory', '512',
+          '--region', 'iad',
+          '--port', '8080',
+          '--env', '{"SECRET_TOKEN":"hunter2"}',
+          '--json',
+        ],
+        { from: 'user' },
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(mockTrackCompute).toHaveBeenCalledTimes(1);
+    const [subcommand, config, props] = mockTrackCompute.mock.calls[0];
+    expect(subcommand).toBe('deploy');
+    expect(config).toMatchObject({ project_id: 'p1' });
+    expect(props).toMatchObject({
+      success: true,
+      user_id: 'u1',
+      mode: 'image',
+      cpu: 'shared-1x',
+      memory: 512,
+      region: 'iad',
+      port: 8080,
+      has_env: true,
+    });
+    // Never ship the image URL or env var values/contents.
+    expect(props).not.toHaveProperty('image');
+    expect(props).not.toHaveProperty('imageUrl');
+    expect(props).not.toHaveProperty('env');
+    expect(props).not.toHaveProperty('envVars');
+    expect(JSON.stringify(props)).not.toContain('hunter2');
+    expect(JSON.stringify(props)).not.toContain('registry.example.com');
+  });
+});

--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -6,6 +6,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 import { parseEnvFile } from '../../lib/env-file.js';
 import {
   ensureFlyctlAvailable,
@@ -145,6 +146,14 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
             if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
           }
           await reportCliUsage('cli.compute.deploy', true);
+          await trackComputeUsage('deploy', true, {
+            mode: 'image',
+            cpu: opts.cpu,
+            memory,
+            region: opts.region,
+            port,
+            has_env: Boolean(envVars),
+          });
           return;
         }
 
@@ -275,8 +284,17 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
         }
 
         await reportCliUsage('cli.compute.deploy', true);
+        await trackComputeUsage('deploy', true, {
+          mode: 'source',
+          cpu: opts.cpu,
+          memory,
+          region: opts.region,
+          port,
+          has_env: Boolean(envVars),
+        });
       } catch (err) {
         await reportCliUsage('cli.compute.deploy', false);
+        await trackComputeUsage('deploy', false, { mode: dir ? 'source' : 'image' });
         handleError(err, json);
       }
     });

--- a/src/commands/compute/events.ts
+++ b/src/commands/compute/events.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 
 // `compute events <id>` returns Fly machine lifecycle events (start/stop/exit/
 // restart) — not container stdout/stderr. The previous name `compute logs`
@@ -31,6 +32,7 @@ export function registerComputeEventsCommand(computeCmd: Command): void {
           if (!Array.isArray(events) || events.length === 0) {
             console.log('No events found.');
             await reportCliUsage('cli.compute.events', true);
+            await trackComputeUsage('events', true);
             return;
           }
           for (const entry of events) {
@@ -39,8 +41,10 @@ export function registerComputeEventsCommand(computeCmd: Command): void {
           }
         }
         await reportCliUsage('cli.compute.events', true);
+        await trackComputeUsage('events', true);
       } catch (err) {
         await reportCliUsage('cli.compute.events', false);
+        await trackComputeUsage('events', false);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/get.ts
+++ b/src/commands/compute/get.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputInfo } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 
 export function registerComputeGetCommand(computeCmd: Command): void {
   computeCmd
@@ -31,8 +32,10 @@ export function registerComputeGetCommand(computeCmd: Command): void {
           outputInfo(`Created:   ${service.createdAt}`);
         }
         await reportCliUsage('cli.compute.get', true);
+        await trackComputeUsage('get', true);
       } catch (err) {
         await reportCliUsage('cli.compute.get', false);
+        await trackComputeUsage('get', false);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/list.ts
+++ b/src/commands/compute/list.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 
 export function registerComputeListCommand(computeCmd: Command): void {
   computeCmd
@@ -24,6 +25,7 @@ export function registerComputeListCommand(computeCmd: Command): void {
           if (services.length === 0) {
             console.log('No compute services found.');
             await reportCliUsage('cli.compute.list', true);
+            await trackComputeUsage('list', true);
             return;
           }
           outputTable(
@@ -39,8 +41,10 @@ export function registerComputeListCommand(computeCmd: Command): void {
           );
         }
         await reportCliUsage('cli.compute.list', true);
+        await trackComputeUsage('list', true);
       } catch (err) {
         await reportCliUsage('cli.compute.list', false);
+        await trackComputeUsage('list', false);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/start.ts
+++ b/src/commands/compute/start.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 
 export function registerComputeStartCommand(computeCmd: Command): void {
   computeCmd
@@ -28,8 +29,10 @@ export function registerComputeStartCommand(computeCmd: Command): void {
           }
         }
         await reportCliUsage('cli.compute.start', true);
+        await trackComputeUsage('start', true);
       } catch (err) {
         await reportCliUsage('cli.compute.start', false);
+        await trackComputeUsage('start', false);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/stop.test.ts
+++ b/src/commands/compute/stop.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../../lib/api/oss.js', () => ({
+  ossFetch: vi.fn(async () => ({ json: async () => ({ name: 'svc', status: 'stopped' }) })),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ access_token: 'tok', user: { id: 'u1' } })),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  getProjectConfig: vi.fn(() => ({
+    project_id: 'p1',
+    project_name: 'proj',
+    org_id: 'o1',
+    region: 'iad',
+    appkey: 'k',
+    api_key: 'key',
+  })),
+  getCredentials: vi.fn(() => ({ user: { id: 'u1' } })),
+}));
+
+vi.mock('../../lib/analytics.js', () => ({
+  trackCompute: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/skills.js', () => ({
+  reportCliUsage: vi.fn(async () => {}),
+}));
+
+import { registerComputeStopCommand } from './stop.js';
+import { ossFetch } from '../../lib/api/oss.js';
+import { trackCompute } from '../../lib/analytics.js';
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>').option('-y, --yes');
+  const computeCmd = program.command('compute');
+  registerComputeStopCommand(computeCmd);
+  return program;
+}
+
+describe('compute stop analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('tracks cli_compute stop with success and the user id on the happy path', async () => {
+    const program = makeProgram();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await program.parseAsync(['compute', 'stop', 'svc-1', '--json'], { from: 'user' });
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(ossFetch).toHaveBeenCalled();
+    expect(trackCompute).toHaveBeenCalledWith(
+      'stop',
+      expect.objectContaining({ project_id: 'p1' }),
+      expect.objectContaining({ success: true, user_id: 'u1' }),
+    );
+  });
+});

--- a/src/commands/compute/stop.ts
+++ b/src/commands/compute/stop.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 
 export function registerComputeStopCommand(computeCmd: Command): void {
   computeCmd
@@ -25,8 +26,10 @@ export function registerComputeStopCommand(computeCmd: Command): void {
           outputSuccess(`Service "${service.name}" stopped.`);
         }
         await reportCliUsage('cli.compute.stop', true);
+        await trackComputeUsage('stop', true);
       } catch (err) {
         await reportCliUsage('cli.compute.stop', false);
+        await trackComputeUsage('stop', false);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/update.ts
+++ b/src/commands/compute/update.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackComputeUsage } from './utils.js';
 
 const ENV_KEY_REGEX = /^[A-Z_][A-Z0-9_]*$/;
 
@@ -135,8 +136,10 @@ export function registerComputeUpdateCommand(computeCmd: Command): void {
           if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
         }
         await reportCliUsage('cli.compute.update', true);
+        await trackComputeUsage('update', true);
       } catch (err) {
         await reportCliUsage('cli.compute.update', false);
+        await trackComputeUsage('update', false);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/utils.test.ts
+++ b/src/commands/compute/utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/config.js', () => ({
+  getProjectConfig: vi.fn(),
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../lib/analytics.js', () => ({
+  trackCompute: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+import { trackComputeUsage } from './utils.js';
+import { getProjectConfig, getCredentials } from '../../lib/config.js';
+import { trackCompute, shutdownAnalytics } from '../../lib/analytics.js';
+
+const CONFIG = {
+  project_id: 'p1',
+  project_name: 'proj',
+  org_id: 'o1',
+  region: 'iad',
+  appkey: 'k',
+  api_key: 'key',
+};
+
+const mockProjectConfig = getProjectConfig as ReturnType<typeof vi.fn>;
+const mockCredentials = getCredentials as ReturnType<typeof vi.fn>;
+
+describe('trackComputeUsage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('tracks the subcommand with success, user_id and extra props when a project is linked', async () => {
+    mockProjectConfig.mockReturnValue(CONFIG);
+    mockCredentials.mockReturnValue({ user: { id: 'u1' } });
+
+    await trackComputeUsage('deploy', true, { cpu: 'shared-1x', memory: 512 });
+
+    expect(trackCompute).toHaveBeenCalledWith('deploy', CONFIG, {
+      success: true,
+      user_id: 'u1',
+      cpu: 'shared-1x',
+      memory: 512,
+    });
+    expect(shutdownAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards success:false', async () => {
+    mockProjectConfig.mockReturnValue(CONFIG);
+    mockCredentials.mockReturnValue({ user: { id: 'u1' } });
+
+    await trackComputeUsage('stop', false);
+
+    expect(trackCompute).toHaveBeenCalledWith(
+      'stop',
+      CONFIG,
+      expect.objectContaining({ success: false, user_id: 'u1' }),
+    );
+  });
+
+  it('still tracks with user_id undefined when no credentials are present', async () => {
+    mockProjectConfig.mockReturnValue(CONFIG);
+    mockCredentials.mockReturnValue(null);
+
+    await trackComputeUsage('list', true);
+
+    expect(trackCompute).toHaveBeenCalledWith(
+      'list',
+      CONFIG,
+      expect.objectContaining({ success: true, user_id: undefined }),
+    );
+  });
+
+  it('does not track when no project is linked but still flushes analytics', async () => {
+    mockProjectConfig.mockReturnValue(null);
+
+    await trackComputeUsage('get', true);
+
+    expect(trackCompute).not.toHaveBeenCalled();
+    expect(shutdownAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws and always flushes even if config lookup fails', async () => {
+    mockProjectConfig.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    await expect(trackComputeUsage('delete', true)).resolves.toBeUndefined();
+    expect(trackCompute).not.toHaveBeenCalled();
+    expect(shutdownAnalytics).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/compute/utils.ts
+++ b/src/commands/compute/utils.ts
@@ -1,0 +1,42 @@
+import { getCredentials, getProjectConfig } from '../../lib/config.js';
+import { shutdownAnalytics, trackCompute } from '../../lib/analytics.js';
+
+export type ComputeCommandTelemetry = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+// Fire a `cli_compute_invoked` PostHog event for a compute subcommand.
+// Mirrors `trackPaymentUsage` in ../payments/utils.ts: the event is keyed on
+// the linked project (distinct id) and also carries the acting user's id so
+// usage can be broken down per user. Telemetry must never change command
+// behavior, so everything here is best-effort and swallowed on failure, and
+// analytics are always flushed in the `finally` before the process exits.
+export async function trackComputeUsage(
+  subcommand: string,
+  success: boolean,
+  properties: ComputeCommandTelemetry = {},
+): Promise<void> {
+  try {
+    try {
+      const config = getProjectConfig();
+      if (config) {
+        let userId: string | undefined;
+        try {
+          userId = getCredentials()?.user?.id;
+        } catch {
+          // User id is best-effort metadata; never block telemetry on it.
+        }
+        trackCompute(subcommand, config, {
+          success,
+          user_id: userId,
+          ...properties,
+        });
+      }
+    } catch {
+      // Telemetry should never affect command behavior.
+    }
+  } finally {
+    await shutdownAnalytics();
+  }
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -82,6 +82,22 @@ export function trackConfig(
   });
 }
 
+export function trackCompute(
+  subcommand: string,
+  config: ProjectConfig,
+  properties?: Record<string, unknown>,
+): void {
+  captureEvent(config.project_id, 'cli_compute_invoked', {
+    subcommand,
+    project_id: config.project_id,
+    project_name: config.project_name,
+    org_id: config.org_id,
+    region: config.region,
+    oss_mode: config.project_id === FAKE_PROJECT_ID,
+    ...properties,
+  });
+}
+
 export async function shutdownAnalytics(): Promise<void> {
   if (!client) return;
   const c = client;


### PR DESCRIPTION
## What

Adds PostHog usage analytics to every `compute` subcommand. Compute was the only command area with **no** instrumentation while `create` / `branch` / `ai` / `payments` / `diagnose` are all tracked.

A `cli_compute_invoked` event now fires for `deploy`, `list`, `get`, `update`, `start`, `stop`, `delete`, and `events`, on both success and failure paths.

## Event shape

- **Distinct id:** `project_id` — consistent with every other CLI event (`trackPayments`/`trackDiagnose`/`trackConfig`).
- **Properties:** `subcommand`, `project_id`, `project_name`, `org_id`, `region`, `oss_mode`, `success`, **`user_id`** (so usage can be broken down per user), plus for `deploy`: `mode` (`image`|`source`), `cpu`, `memory`, `region`, `port`, `has_env`.
- **Never sent:** the image URL or env var names/values (only `has_env: boolean`).

## How

- `trackCompute()` in `src/lib/analytics.ts` mirrors `trackPayments`.
- `trackComputeUsage()` wrapper in `src/commands/compute/utils.ts` mirrors `payments/utils.ts`'s `trackPaymentUsage`: looks up project config, attaches `user_id` from `getCredentials().user.id`, forwards a `success` flag, flushes analytics in a `finally`. Best-effort — telemetry never changes command behavior.
- Wired into all 8 compute commands alongside the existing `reportCliUsage` calls (legacy OSS telemetry left untouched).

Follows `DEVELOPMENT.md §2` (PostHog conventions: distinct id, `cli_<feature>_invoked` naming, non-sensitive property allow-list, flush in `finally`, build-time key injection).

## Tests

TDD'd. New tests:
- `compute/utils.test.ts` — wrapper logic: project linked / no project / no credentials / config lookup throws / `success` forwarding.
- `compute/stop.test.ts` — command wiring fires `trackCompute('stop', …, { success, user_id })`.
- `compute/deploy.test.ts` — asserts safe metadata only; image URL and env values never leak into properties.

Full suite: 395 passed / 13 skipped. Changed files lint and typecheck clean.

> Note: tracking only emits when `POSTHOG_API_KEY` is present at build time (no-op locally / OSS), same as all existing CLI telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PostHog usage tracking to all `compute` subcommands via a `cli_compute_invoked` event, bringing compute in line with `create`, `branch`, `ai`, `payments`, and `diagnose`. Events only emit when built with `POSTHOG_API_KEY`.

- **New Features**
  - Fire on `deploy`, `list`, `get`, `update`, `start`, `stop`, `delete`, and `events` for both success and failure.
  - New `trackCompute()` and `trackComputeUsage()` use `project_id` as the distinct id and include `user_id`; flush analytics in `finally`; best-effort and never change behavior.
  - `deploy` sends safe props only: `mode` (`image`|`source`), `cpu`, `memory`, `region`, `port`, `has_env`; never image URLs or env keys/values.
  - Wired into all commands alongside existing `reportCliUsage` (legacy OSS telemetry unchanged).

<sup>Written for commit 3f3b741b2c19889c142bcf2218a091df9ad82ee5. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PostHog telemetry tracking to all compute CLI subcommands
> - Adds a `trackComputeUsage` helper in [`utils.ts`](https://github.com/InsForge/CLI/pull/140/files#diff-8ed1e95ab375705ea3f4031f72484b787ddddba13e0e7b9174003f3136a8d1ee) that emits a `cli_compute_invoked` event via PostHog, capturing subcommand, project/org identifiers, success status, and optional metadata. It never throws and always flushes analytics.
> - Instruments all compute subcommands (`deploy`, `delete`, `get`, `list`, `start`, `stop`, `update`, `events`) to call `trackComputeUsage` on both success and failure paths.
> - The `deploy` command includes additional safe metadata (mode, cpu, memory, region, port, has_env), explicitly excluding sensitive fields like image URLs and env var values.
> - Behavioral Change: every compute command now awaits an async analytics flush before exiting, adding a small latency to all compute command completions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f3b741.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Compute commands (delete, deploy, events, get, list, start, stop, update) now record usage data across operations.

* **Tests**
  * Added test coverage for compute command usage tracking behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->