### PR TITLE
Report marketplace download via TemplateMarket edge function

### DIFF
--- a/src/commands/create.marketplace.test.ts
+++ b/src/commands/create.marketplace.test.ts
@@ -19,39 +19,39 @@ describe('reportMarketplaceDownload', () => {
     vi.unstubAllGlobals();
   });
 
-  it('POSTs to /templates/v1/<slug>/downloads on the given apiUrl', async () => {
+  it('POSTs slug body to TemplateMarket /functions/report-download', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ count: 1 }) });
 
-    await reportMarketplaceDownload('chatbot', 'https://api.insforge.dev');
+    await reportMarketplaceDownload('chatbot');
 
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe('https://api.insforge.dev/templates/v1/chatbot/downloads');
-    expect(init).toMatchObject({ method: 'POST' });
+    expect(url).toBe('https://p8n7m7ci.us-east.insforge.app/functions/report-download');
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'chatbot' }),
+    });
   });
 
-  it('URL-encodes the slug', async () => {
+  it('sends the slug verbatim in the JSON body (no URL encoding hazard)', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ count: 1 }) });
 
-    await reportMarketplaceDownload('weird slug', 'https://api.insforge.dev');
+    await reportMarketplaceDownload('weird slug');
 
-    const [url] = fetchMock.mock.calls[0];
-    expect(url).toContain('weird%20slug');
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.body).toBe(JSON.stringify({ slug: 'weird slug' }));
   });
 
   it('swallows network errors (does not throw)', async () => {
     fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
 
-    await expect(
-      reportMarketplaceDownload('chatbot', 'https://api.insforge.dev'),
-    ).resolves.toBeUndefined();
+    await expect(reportMarketplaceDownload('chatbot')).resolves.toBeUndefined();
   });
 
   it('swallows non-2xx responses (does not throw)', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
 
-    await expect(
-      reportMarketplaceDownload('chatbot', 'https://api.insforge.dev'),
-    ).resolves.toBeUndefined();
+    await expect(reportMarketplaceDownload('chatbot')).resolves.toBeUndefined();
   });
 });
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -750,10 +750,16 @@ const MARKETPLACE_REPORT_URL =
  */
 export async function reportMarketplaceDownload(slug: string): Promise<void> {
   try {
+    // Bounded timeout: the call is `void`-awaited at the call site so the
+    // install command returns immediately, but an unresolved fetch keeps
+    // the Node event loop alive — without a signal the CLI process would
+    // hang for the OS socket timeout (minutes) whenever the marketplace
+    // counter endpoint is unreachable.
     const res = await fetch(MARKETPLACE_REPORT_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ slug }),
+      signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) {
       // Swallow — best-effort counter ping.

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -382,10 +382,7 @@ export function registerCreateCommand(program: Command): void {
             json,
           );
           if (downloaded) {
-            void reportMarketplaceDownload(
-              opts.marketplace as string,
-              apiUrl ?? 'https://api.insforge.dev',
-            );
+            void reportMarketplaceDownload(opts.marketplace as string);
           }
         } else if (githubTemplates.includes(template!)) {
           await downloadGitHubTemplate(template!, projectConfig, json);
@@ -737,18 +734,25 @@ export async function downloadGitHubTemplate(
   }
 }
 
+// TemplateMarket is a single-tenant InsForge project hosted independently
+// of any per-user backend, so the counter URL is a constant rather than
+// derived from `apiUrl`. The function takes only {slug}; auth + RPC
+// dispatch is handled inside the edge function (no anon key needed here).
+const MARKETPLACE_REPORT_URL =
+  'https://p8n7m7ci.us-east.insforge.app/functions/report-download';
+
 /**
  * Fire-and-forget POST to the marketplace download counter.
  * Network errors and non-2xx responses are swallowed — a transient
  * counter blip must not kill the install. The DB counter is the source
  * of truth; PostHog is intentionally not used (per spec §6.3).
  */
-export async function reportMarketplaceDownload(slug: string, apiUrl: string): Promise<void> {
+export async function reportMarketplaceDownload(slug: string): Promise<void> {
   try {
-    const res = await fetch(`${apiUrl}/templates/v1/${encodeURIComponent(slug)}/downloads`, {
+    const res = await fetch(MARKETPLACE_REPORT_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: '{}',
+      body: JSON.stringify({ slug }),
     });
     if (!res.ok) {
       // Swallow — best-effort counter ping.

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -739,6 +739,7 @@ export async function downloadGitHubTemplate(
 // derived from `apiUrl`. The function takes only {slug}; auth + RPC
 // dispatch is handled inside the edge function (no anon key needed here).
 const MARKETPLACE_REPORT_URL =
+  process.env.INSFORGE_MARKETPLACE_REPORT_URL ??
   'https://p8n7m7ci.us-east.insforge.app/functions/report-download';
 
 /**


### PR DESCRIPTION
## Summary
- `reportMarketplaceDownload` now POSTs `{slug}` to `https://p8n7m7ci.us-east.insforge.app/functions/report-download` (TemplateMarket project's new public proxy) instead of `${apiUrl}/templates/v1/<slug>/downloads` on cloud-backend.
- Drops the `apiUrl` parameter — marketplace is single-tenant so the URL is a constant, not derived from the per-user backend host.
- Edge function internally calls `increment_template_download` RPC with the auto-injected `API_KEY`, so the CLI ships no anon key.
- Sync workflow on `insforge-templates` is being repointed in InsForge/insforge-templates#46. Cloud-backend's `template.controller.ts` + migration 073 will drop in a follow-up.

## Test plan
- [x] `npx vitest run src/commands/create.marketplace.test.ts` — 9/9 pass
- [ ] Manual smoke after merge: `npx @insforge/cli create test-project --marketplace e-commerce` and confirm `template_downloads.count` increments by 1 in the TemplateMarket project (verified out-of-band: `POST /functions/report-download {"slug":"e-commerce"}` returned `{count:2}` and DB row shows `count=2`).

## Backend status (already live)
- TemplateMarket project (`c6366c10-…`): tables, 4 RPCs, `sync-templates` + `report-download` edge functions all deployed.
- `report-download` smoke-tested: existing slug 200/count, unknown slug 200/`{count:0,unknown:true}`, bad format 400, GET 405.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report marketplace downloads via the TemplateMarket edge function. Removes `apiUrl`, sends `{slug}` to a fixed URL (overridable via `INSFORGE_MARKETPLACE_REPORT_URL`), and bounds the request to 5s to avoid hangs.

- **Refactors**
  - POST `{slug}` as JSON to `https://p8n7m7ci.us-east.insforge.app/functions/report-download`; override via `INSFORGE_MARKETPLACE_REPORT_URL`.
  - Remove `apiUrl` from `reportMarketplaceDownload` and its call site.
  - Add 5s `AbortSignal.timeout` to prevent the CLI from hanging when the endpoint is unreachable.
  - Edge function handles auth/RPC; keep best-effort, non-blocking behavior.

<sup>Written for commit 3c2a947ad53045cd94e30847e90e51183d4e555a. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/142?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified marketplace template download reporting by removing the extra parameter and consolidating reporting to a single fixed endpoint with a standardized JSON request format. No visible change to end-user behavior.

* **Tests**
  * Updated marketplace download report tests to match the new endpoint and request contract; network errors and non-2xx responses remain swallowed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report marketplace downloads via a fixed TemplateMarket edge function endpoint
> - Changes `reportMarketplaceDownload` in [create.ts](https://github.com/InsForge/CLI/pull/142/files#diff-b6d810b0306723c2b160e529addd463ae24be806303358ff1f6a2209bc13357d) to POST the template `slug` as JSON to a fixed endpoint instead of deriving the URL from `apiUrl`.
> - Adds a `MARKETPLACE_REPORT_URL` constant defaulting to `https://p8n7m7ci.us-east.insforge.app/functions/report-download`, overridable via `INSFORGE_MARKETPLACE_REPORT_URL`.
> - Adds a 5-second `AbortSignal.timeout` to bound request duration; network errors and non-2xx responses continue to be swallowed.
> - Behavioral Change: callers no longer pass `apiUrl` to `reportMarketplaceDownload`; the endpoint is always resolved internally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c2a947.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->