### PR TITLE
feat(posthog): track cli_posthog_invoked on posthog setup

### DIFF
--- a/src/commands/posthog/setup.test.ts
+++ b/src/commands/posthog/setup.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../lib/api/posthog.js', () => apiMock);
 const configMock = vi.hoisted(() => ({
   getProjectConfig: vi.fn(() => ({ project_id: 'p1', project_name: 'Test Project' })),
   getAccessToken: vi.fn(() => 'tok'),
+  FAKE_PROJECT_ID: 'fa4e0000-1234-5678-90ab-cd1234567890',
 }));
 vi.mock('../../lib/config.js', () => configMock);
 

--- a/src/commands/posthog/setup.test.ts
+++ b/src/commands/posthog/setup.test.ts
@@ -11,9 +11,14 @@ vi.mock('../../lib/api/posthog.js', () => apiMock);
 const configMock = vi.hoisted(() => ({
   getProjectConfig: vi.fn(() => ({ project_id: 'p1', project_name: 'Test Project' })),
   getAccessToken: vi.fn(() => 'tok'),
-  FAKE_PROJECT_ID: 'fa4e0000-1234-5678-90ab-cd1234567890',
 }));
 vi.mock('../../lib/config.js', () => configMock);
+
+const analyticsMock = vi.hoisted(() => ({
+  trackPosthog: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+vi.mock('../../lib/analytics.js', () => analyticsMock);
 
 vi.mock('../../lib/prompts.js', () => ({ isInteractive: false }));
 
@@ -82,6 +87,8 @@ beforeEach(() => {
   outputMock.outputJson.mockReset();
   outputMock.outputSuccess.mockReset();
   clackNoteMock.mockReset();
+  analyticsMock.trackPosthog.mockReset();
+  analyticsMock.shutdownAnalytics.mockClear();
   configMock.getProjectConfig.mockReturnValue({ project_id: 'p1', project_name: 'Test Project' });
   configMock.getAccessToken.mockReturnValue('tok');
 });
@@ -174,6 +181,34 @@ describe('posthog setup', () => {
       expect(payload.success).toBe(true);
       expect(payload.wizardSkipped).toBe(true);
       expect(payload.wizardCommand).toMatch(/^npx(\.cmd)? -y @posthog\/wizard@latest$/);
+    });
+  });
+
+  describe('analytics', () => {
+    it('fires cli_posthog_invoked with the project config and flushes on success', async () => {
+      apiMock.startPosthogCliFlow.mockResolvedValue({ type: 'connected' });
+      apiMock.fetchPosthogConnection.mockResolvedValue({
+        kind: 'connected',
+        connection: { apiKey: 'phc_', host: 'h', posthogProjectId: '1' },
+      });
+
+      await runSetup(['--skip-browser']);
+
+      expect(analyticsMock.trackPosthog).toHaveBeenCalledOnce();
+      expect(analyticsMock.trackPosthog).toHaveBeenCalledWith(
+        'setup',
+        expect.objectContaining({ project_id: 'p1' }),
+      );
+      expect(analyticsMock.shutdownAnalytics).toHaveBeenCalledOnce();
+    });
+
+    it('still flushes analytics when setup fails', async () => {
+      apiMock.startPosthogCliFlow.mockResolvedValue({ type: 'connected' });
+      apiMock.fetchPosthogConnection.mockResolvedValue({ kind: 'not-connected' });
+
+      await runSetup(['--skip-browser']);
+
+      expect(analyticsMock.shutdownAnalytics).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/commands/posthog/setup.ts
+++ b/src/commands/posthog/setup.ts
@@ -16,6 +16,7 @@ import {
   startPosthogCliFlow,
 } from '../../lib/api/posthog.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackPosthog, shutdownAnalytics } from '../../lib/analytics.js';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 15 * 60 * 1000;
@@ -52,6 +53,8 @@ export function registerPosthogSetupCommand(program: Command): void {
         }
       } catch (err) {
         handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
       }
     });
 }
@@ -82,6 +85,10 @@ async function runSetup(opts: RunSetupOpts): Promise<SetupResult> {
   if (!token) {
     throw new AuthError('Not logged in. Run `insforge login` first.');
   }
+
+  // Step 2 of the "dashboard connect → CLI posthog setup" funnel; pairs
+  // with backend `posthog_connect_started` joined on project_id.
+  trackPosthog('setup', proj);
 
   if (!opts.json) {
     clack.intro('PostHog setup');

--- a/src/commands/posthog/setup.ts
+++ b/src/commands/posthog/setup.ts
@@ -86,8 +86,6 @@ async function runSetup(opts: RunSetupOpts): Promise<SetupResult> {
     throw new AuthError('Not logged in. Run `insforge login` first.');
   }
 
-  // Step 2 of the "dashboard connect → CLI posthog setup" funnel; pairs
-  // with backend `posthog_connect_started` joined on project_id.
   trackPosthog('setup', proj);
 
   if (!opts.json) {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -61,6 +61,24 @@ export function trackPayments(
   });
 }
 
+// Step 2 of the "dashboard connect → CLI posthog setup" funnel; pair with
+// backend `posthog_connect_started` joined on project_id.
+export function trackPosthog(
+  subcommand: string,
+  config: ProjectConfig,
+  properties?: Record<string, unknown>,
+): void {
+  captureEvent(config.project_id, 'cli_posthog_invoked', {
+    subcommand,
+    project_id: config.project_id,
+    project_name: config.project_name,
+    org_id: config.org_id,
+    region: config.region,
+    oss_mode: config.project_id === FAKE_PROJECT_ID,
+    ...properties,
+  });
+}
+
 // Config commands (apply/plan/export) operate against an OSS backend and may
 // run without a linked cloud project, so the ProjectConfig is optional.
 // Pure-OSS runs fall back to FAKE_PROJECT_ID as the distinct ID — same


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track `cli_posthog_invoked` when running `insforge posthog setup` to measure step 2 of the connect → setup funnel. Links to backend `posthog_connect_started` via `project_id` and flushes analytics on exit (success or failure).

- New Features
  - Added `trackPosthog('setup', config)` to emit `cli_posthog_invoked` with `project_id`, `project_name`, `org_id`, `region`, and `oss_mode` (via `FAKE_PROJECT_ID`).
  - Always call `shutdownAnalytics()` in the command `finally` to flush events.
  - Tests cover event emission and flushing on success and failure; include `FAKE_PROJECT_ID` for OSS runs.

<sup>Written for commit e54a6e40e149cf9d517146e96f694f058d4eb5d8. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/143?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics so the setup command records a usage event with project metadata.
  * Ensures analytics shutdown is run after setup completes or fails.
* **Tests**
  * Added tests that validate analytics are invoked on successful setup and still shut down on failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track `cli_posthog_invoked` analytics event on posthog setup
> - Adds a `trackPosthog(subcommand, config, properties?)` function in [`analytics.ts`](https://github.com/InsForge/CLI/pull/143/files#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674af) that captures a `cli_posthog_invoked` event with project/org/region/oss_mode properties.
> - Calls `trackPosthog('setup', proj)` early in the `runSetup` flow after project and token validation.
> - Adds a `finally` block in the setup command action to always flush analytics via `shutdownAnalytics()`, regardless of success or failure.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #143 opened
>
> - Added test suite verifying analytics behavior in posthog setup command [e54a6e4]
> - Added analytics mock infrastructure to posthog setup tests [e54a6e4]
> - Removed comment preceding analytics tracking call in `runSetup` function [e54a6e4]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0418cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->