### PR TITLE
chore: bump version to 0.1.84

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.82",
+  "version": "0.1.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.82",
+      "version": "0.1.84",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `@insforge/cli` to version 0.1.84 for the next release. Updates `package.json` and `package-lock.json` to the same version.

<sup>Written for commit 83179dd221a8d7b0cb0ba9ba2b836089343fbcbc. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/CLI/pull/144?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to 0.1.84
> Updates the version field in [package.json](https://github.com/InsForge/CLI/pull/144/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.1.83` to `0.1.84`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83179dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->