### PR TITLE
Track deployment commands in posthog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/deployments/cancel.ts
+++ b/src/commands/deployments/cancel.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { getProjectConfig } from '../../lib/config.js';
 import { handleError, getRootOpts, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackDeploymentUsage } from './utils.js';
 
 export function registerDeploymentsCancelCommand(deploymentsCmd: Command): void {
   deploymentsCmd
@@ -31,7 +32,9 @@ export function registerDeploymentsCancelCommand(deploymentsCmd: Command): void 
         } else {
           outputSuccess(`Deployment ${id} cancelled.`);
         }
+        await trackDeploymentUsage('cancel', true);
       } catch (err) {
+        await trackDeploymentUsage('cancel', false);
         handleError(err, json);
       }
     });

--- a/src/commands/deployments/deploy.ts
+++ b/src/commands/deployments/deploy.ts
@@ -20,7 +20,7 @@ import type {
   ProjectConfig,
   StartDeploymentRequest,
 } from '../../types.js';
-import { reportCliUsage } from '../../lib/skills.js';
+import { trackDeploymentUsage } from './utils.js';
 
 const POLL_INTERVAL_MS = 5_000;
 const POLL_TIMEOUT_MS = 300_000;
@@ -502,9 +502,16 @@ export function registerDeploymentsDeployCommand(deploymentsCmd: Command): void 
             clack.log.info(`Check status with: npx @insforge/cli deployments status ${result.deploymentId}`);
           }
         }
-        await reportCliUsage('cli.deployments.deploy', true);
+        await trackDeploymentUsage('deploy', true, {
+          has_env: opts.env !== undefined,
+          has_meta: opts.meta !== undefined,
+          ready: result.isReady,
+        });
       } catch (err) {
-        await reportCliUsage('cli.deployments.deploy', false);
+        await trackDeploymentUsage('deploy', false, {
+          has_env: opts.env !== undefined,
+          has_meta: opts.meta !== undefined,
+        });
         handleError(err, json);
       }
     });

--- a/src/commands/deployments/env-vars.ts
+++ b/src/commands/deployments/env-vars.ts
@@ -32,12 +32,9 @@ export function registerDeploymentsEnvVarsCommand(deploymentsCmd: Command): void
 
         if (json) {
           outputJson(data);
+        } else if (!envVars.length) {
+          console.log('No environment variables found.');
         } else {
-          if (!envVars.length) {
-            console.log('No environment variables found.');
-            await trackDeploymentUsage('env.list', true);
-            return;
-          }
           outputTable(
             ['ID', 'Key', 'Type', 'Updated At'],
             envVars.map((v) => [

--- a/src/commands/deployments/env-vars.ts
+++ b/src/commands/deployments/env-vars.ts
@@ -4,7 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, ProjectNotLinkedError } from '../../lib/errors.js';
 import { getProjectConfig } from '../../lib/config.js';
 import { outputJson, outputTable, outputSuccess } from '../../lib/output.js';
-import { reportCliUsage } from '../../lib/skills.js';
+import { trackDeploymentUsage } from './utils.js';
 
 interface EnvVar {
   id: string;
@@ -35,6 +35,7 @@ export function registerDeploymentsEnvVarsCommand(deploymentsCmd: Command): void
         } else {
           if (!envVars.length) {
             console.log('No environment variables found.');
+            await trackDeploymentUsage('env.list', true);
             return;
           }
           outputTable(
@@ -47,9 +48,9 @@ export function registerDeploymentsEnvVarsCommand(deploymentsCmd: Command): void
             ]),
           );
         }
-        await reportCliUsage('cli.deployments.env.list', true);
+        await trackDeploymentUsage('env.list', true);
       } catch (err) {
-        await reportCliUsage('cli.deployments.env.list', false);
+        await trackDeploymentUsage('env.list', false);
         handleError(err, json);
       }
     });
@@ -75,9 +76,9 @@ export function registerDeploymentsEnvVarsCommand(deploymentsCmd: Command): void
         } else {
           outputSuccess(data.message);
         }
-        await reportCliUsage('cli.deployments.env.set', true);
+        await trackDeploymentUsage('env.set', true);
       } catch (err) {
-        await reportCliUsage('cli.deployments.env.set', false);
+        await trackDeploymentUsage('env.set', false);
         handleError(err, json);
       }
     });
@@ -102,9 +103,9 @@ export function registerDeploymentsEnvVarsCommand(deploymentsCmd: Command): void
         } else {
           outputSuccess(data.message);
         }
-        await reportCliUsage('cli.deployments.env.delete', true);
+        await trackDeploymentUsage('env.delete', true);
       } catch (err) {
-        await reportCliUsage('cli.deployments.env.delete', false);
+        await trackDeploymentUsage('env.delete', false);
         handleError(err, json);
       }
     });

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -30,12 +30,9 @@ export function registerDeploymentsListCommand(deploymentsCmd: Command): void {
 
         if (json) {
           outputJson(raw);
+        } else if (!deployments.length) {
+          console.log('No deployments found.');
         } else {
-          if (!deployments.length) {
-            console.log('No deployments found.');
-            await trackDeploymentUsage('list', true);
-            return;
-          }
           outputTable(
             ['ID', 'Status', 'Provider', 'URL', 'Created'],
             deployments.map((d) => [

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -5,7 +5,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { handleError, getRootOpts, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { ListDeploymentsResponse } from '../../types.js';
-import { reportCliUsage } from '../../lib/skills.js';
+import { trackDeploymentUsage } from './utils.js';
 
 export function registerDeploymentsListCommand(deploymentsCmd: Command): void {
   deploymentsCmd
@@ -33,6 +33,7 @@ export function registerDeploymentsListCommand(deploymentsCmd: Command): void {
         } else {
           if (!deployments.length) {
             console.log('No deployments found.');
+            await trackDeploymentUsage('list', true);
             return;
           }
           outputTable(
@@ -46,9 +47,9 @@ export function registerDeploymentsListCommand(deploymentsCmd: Command): void {
             ]),
           );
         }
-        await reportCliUsage('cli.deployments.list', true);
+        await trackDeploymentUsage('list', true);
       } catch (err) {
-        await reportCliUsage('cli.deployments.list', false);
+        await trackDeploymentUsage('list', false);
         handleError(err, json);
       }
     });

--- a/src/commands/deployments/status.ts
+++ b/src/commands/deployments/status.ts
@@ -5,6 +5,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { handleError, getRootOpts, ProjectNotLinkedError, getDeploymentError } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { DeploymentSchema } from '../../types.js';
+import { trackDeploymentUsage } from './utils.js';
 
 export function registerDeploymentsStatusCommand(deploymentsCmd: Command): void {
   deploymentsCmd
@@ -43,7 +44,9 @@ export function registerDeploymentsStatusCommand(deploymentsCmd: Command): void 
             ],
           );
         }
+        await trackDeploymentUsage('status', true, { sync: Boolean(opts.sync) });
       } catch (err) {
+        await trackDeploymentUsage('status', false, { sync: Boolean(opts.sync) });
         handleError(err, json);
       }
     });

--- a/src/commands/deployments/utils.ts
+++ b/src/commands/deployments/utils.ts
@@ -12,17 +12,15 @@ export async function trackDeploymentUsage(
   properties: DeploymentCommandTelemetry = {},
 ): Promise<void> {
   try {
-    try {
-      const config = getProjectConfig();
-      if (config) {
-        trackDeployments(subcommand, config, {
-          success,
-          ...properties,
-        });
-      }
-    } catch {
-      // Telemetry should never affect command behavior.
+    const config = getProjectConfig();
+    if (config) {
+      trackDeployments(subcommand, config, {
+        success,
+        ...properties,
+      });
     }
+  } catch {
+    // Telemetry should never affect command behavior.
   } finally {
     await shutdownAnalytics();
   }

--- a/src/commands/deployments/utils.ts
+++ b/src/commands/deployments/utils.ts
@@ -1,0 +1,29 @@
+import { shutdownAnalytics, trackDeployments } from '../../lib/analytics.js';
+import { getProjectConfig } from '../../lib/config.js';
+
+export type DeploymentCommandTelemetry = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+export async function trackDeploymentUsage(
+  subcommand: string,
+  success: boolean,
+  properties: DeploymentCommandTelemetry = {},
+): Promise<void> {
+  try {
+    try {
+      const config = getProjectConfig();
+      if (config) {
+        trackDeployments(subcommand, config, {
+          success,
+          ...properties,
+        });
+      }
+    } catch {
+      // Telemetry should never affect command behavior.
+    }
+  } finally {
+    await shutdownAnalytics();
+  }
+}

--- a/src/commands/payments/utils.ts
+++ b/src/commands/payments/utils.ts
@@ -124,17 +124,15 @@ export async function trackPaymentUsage(
   properties: PaymentCommandTelemetry = {},
 ): Promise<void> {
   try {
-    try {
-      const config = getProjectConfig();
-      if (config) {
-        trackPayments(subcommand, config, {
-          success,
-          ...properties,
-        });
-      }
-    } catch {
-      // Telemetry should never affect command behavior.
+    const config = getProjectConfig();
+    if (config) {
+      trackPayments(subcommand, config, {
+        success,
+        ...properties,
+      });
     }
+  } catch {
+    // Telemetry should never affect command behavior.
   } finally {
     await shutdownAnalytics();
   }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -61,6 +61,22 @@ export function trackPayments(
   });
 }
 
+export function trackDeployments(
+  subcommand: string,
+  config: ProjectConfig,
+  properties?: Record<string, unknown>,
+): void {
+  captureEvent(config.project_id, 'cli_deployments_invoked', {
+    subcommand,
+    project_id: config.project_id,
+    project_name: config.project_name,
+    org_id: config.org_id,
+    region: config.region,
+    oss_mode: config.project_id === FAKE_PROJECT_ID,
+    ...properties,
+  });
+}
+
 // Step 2 of the "dashboard connect → CLI posthog setup" funnel; pair with
 // backend `posthog_connect_started` joined on project_id.
 export function trackPosthog(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PostHog tracking for all deployment CLI commands to measure usage and outcomes. Each command emits a `cli_deployments_invoked` event with success status and key props, and analytics are flushed safely.

- New Features
  - Added `trackDeployments` in `src/lib/analytics.ts` to send `cli_deployments_invoked` with `subcommand`, project/org/region info, and `oss_mode`.
  - Added `trackDeploymentUsage` in `src/commands/deployments/utils.ts` to read project config, merge custom props, and call `shutdownAnalytics` in a finally block.
  - Instrumented `deploy`, `status`, `list`, `cancel`, and `env [list|set|delete]` with success/failure and props (e.g., `has_env`, `has_meta`, `ready`, `sync`).
  - Replaced `reportCliUsage` with the new tracker for deployment commands.

- Refactors
  - Simplified telemetry cleanup to always run `shutdownAnalytics`; aligned approach in `src/commands/payments/utils.ts`.
  - Bumped `@insforge/cli` version to 0.1.85.

<sup>Written for commit 17c3bbdb64738729568c9d8459e90ebfbfb237ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/145?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added usage tracking across deployment commands (cancel, deploy, env list/set/delete, list, status) to record success/failure and relevant flags.
  * Introduced shared telemetry support and a deployments analytics helper.
  * Minor telemetry refactor for payments to consolidate config retrieval and tracking.
  * Bumped CLI package version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track deployment command invocations as PostHog analytics events
> - Adds a new `trackDeployments` function in [`src/lib/analytics.ts`](https://github.com/InsForge/CLI/pull/145/files#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674af) that emits a `cli_deployments_invoked` event with project metadata (org, region, OSS mode).
> - Introduces a `trackDeploymentUsage` utility in [`src/commands/deployments/utils.ts`](https://github.com/InsForge/CLI/pull/145/files#diff-8d007c2f00fc1ca3c53dc9e793b4c6347b431e5460b01d33653ea8411aa95454) that wraps `trackDeployments`, records success/failure, and always flushes analytics via `shutdownAnalytics`.
> - Replaces the previous `reportCliUsage` calls in `deploy`, `cancel`, `list`, `status`, and `env-vars` subcommands with `trackDeploymentUsage`, passing subcommand-specific properties (e.g. `has_env`, `has_meta`, `ready`, `sync`).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #145 opened
>
> - Modified telemetry tracking flow in `env list` and `deployments list` subcommands [2939963]
> - Refactored error handling in `trackDeploymentUsage` and `trackPaymentUsage` utility functions [2939963]
> - Bumped package version from 0.1.84 to 0.1.85 [17c3bbd]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47ce5c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->