### PR TITLE
INS-286: Use PostHog to track template page visits and downloads

### DIFF
--- a/src/commands/create.marketplace.test.ts
+++ b/src/commands/create.marketplace.test.ts
@@ -93,7 +93,7 @@ describe('--marketplace flag wiring', () => {
     // true — a swallowed network/clone failure (return false) must NOT bump
     // the marketplace's install count.
     expect(createSource).toMatch(/const downloaded = await downloadGitHubTemplate/);
-    expect(createSource).toMatch(/if \(downloaded\)[\s\S]{0,80}reportMarketplaceDownload/);
+    expect(createSource).toMatch(/if \(downloaded\)[\s\S]{0,200}reportMarketplaceDownload/);
   });
 
   it('does NOT emit a PostHog template_selected event with a marketplace property', () => {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -382,6 +382,9 @@ export function registerCreateCommand(program: Command): void {
             json,
           );
           if (downloaded) {
+            captureEvent(orgId, 'marketplace_template_downloaded', {
+              template: opts.marketplace,
+            });
             void reportMarketplaceDownload(opts.marketplace as string);
           }
         } else if (githubTemplates.includes(template!)) {
@@ -745,8 +748,9 @@ const MARKETPLACE_REPORT_URL =
 /**
  * Fire-and-forget POST to the marketplace download counter.
  * Network errors and non-2xx responses are swallowed — a transient
- * counter blip must not kill the install. The DB counter is the source
- * of truth; PostHog is intentionally not used (per spec §6.3).
+ * counter blip must not kill the install. This DB counter only backs
+ * the download number shown on the template page; PostHog is the
+ * source of truth for download analytics.
  */
 export async function reportMarketplaceDownload(slug: string): Promise<void> {
   try {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Track marketplace template downloads in PostHog by emitting marketplace_template_downloaded after a successful download, including orgId and template slug. Kept the marketplace counter (fire-and-forget), clarified docs that PostHog is the analytics source of truth, and updated the test regex to allow the new event call.

<sup>Written for commit 63db66f29a1a035f87ae2e7e5cba6effde31d5ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/146?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track `marketplace_template_downloaded` PostHog event on successful marketplace template download
> When `insforge create` is invoked with a valid `--marketplace` slug and the GitHub template download succeeds, a `marketplace_template_downloaded` PostHog event is emitted with the template slug as a property. This fires before the existing `reportMarketplaceDownload` DB counter call, which is now documented as backing the on-page download count rather than analytics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63db66f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics event tracking when downloading marketplace templates, now capturing template selection details.

* **Tests**
  * Updated marketplace template wiring test to accommodate variable code patterns.

* **Documentation**
  * Clarified analytics systems responsible for tracking download metrics and their respective data roles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->