### PR TITLE
chore: bump version to 0.1.86

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump CLI version to 0.1.86 so npm can be republished through the GitHub release workflow.
- Replaces the manually published 0.1.85 artifact that was built without the PostHog API key injection.

## Verification
- npm test -- --run
- npm run lint
- POSTHOG_API_KEY=phc_local_sanity npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@insforge/cli` to 0.1.86 to republish via the GitHub release workflow and replace the 0.1.85 artifact built without PostHog API key injection. Ensures the npm package is published with the correct build configuration.

<sup>Written for commit 2fce4d9c15879bedb3fac370d07903752549b05f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/147?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to 0.1.86
> Updates the version field in [package.json](https://github.com/InsForge/CLI/pull/147/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.1.85` to `0.1.86`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fce4d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.1.86

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/CLI/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->