### PR TITLE
test: suppress flyctl fixture output

### DIFF
--- a/src/lib/flyctl.test.ts
+++ b/src/lib/flyctl.test.ts
@@ -166,6 +166,23 @@ describe('ensureFlyctlAvailable', () => {
 // ─── flyctlBuildAndPush ───────────────────────────────────────────────────────
 
 describe('flyctlBuildAndPush', () => {
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+  });
+
   const baseOpts = {
     dir: '/tmp/app',
     appId: 'my-svc-proj-abc123',
@@ -295,9 +312,6 @@ describe('flyctlBuildAndPush', () => {
     const child = makeFakeChild();
     spawnMock.mockReturnValue(child);
 
-    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-
     setImmediate(() => {
       child.stdout!.emit('data', Buffer.from('build step 1/3\n'));
       child.stderr!.emit('data', Buffer.from('warn: deprecated flag\n'));
@@ -310,11 +324,8 @@ describe('flyctlBuildAndPush', () => {
 
     await flyctlBuildAndPush(baseOpts);
 
-    expect(stdoutSpy).toHaveBeenCalledWith('build step 1/3\n');
-    expect(stderrSpy).toHaveBeenCalledWith('warn: deprecated flag\n');
-
-    stdoutSpy.mockRestore();
-    stderrSpy.mockRestore();
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('build step 1/3\n');
+    expect(stderrWriteSpy).toHaveBeenCalledWith('warn: deprecated flag\n');
   });
 
   // ─── fly.toml stub behavior ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes noisy test output from `flyctlBuildAndPush` tests by mocking `process.stdout.write` and `process.stderr.write` during test execution.

Previously, passing tests printed fake flyctl fixture output such as:

```text
pushing manifest for [registry.fly.io/.](http://registry.fly.io/)..
permission denied
image pushed without manifest line...
```

into normal `npm run test` and `npm run lint` logs.

## Changes

- Added shared stdout/stderr mocks for `flyctlBuildAndPush` tests.
- Restored mocks after each test.
- Updated the tee-behavior test to use the shared spies.

## Validation

- ✅ `npx vitest src/lib/flyctl.test.ts`
- ✅ `npm run test`
- ✅ `npm run lint`

No fake flyctl fixture output is printed during successful runs.

Fixes #154

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses noisy `flyctl` fixture output in `flyctlBuildAndPush` tests by mocking `process.stdout.write` and `process.stderr.write`, so passing runs no longer print fake logs during `npm run test` or `npm run lint`.

- **Bug Fixes**
  - Added shared stdout/stderr spies in `beforeEach`; restored in `afterEach`.
  - Updated tee-behavior test to use the shared spies.

<sup>Written for commit 8797c281c57d1b7d4fdd30e6623af02e1f532a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress flyctl fixture output in tests by mocking process stdout/stderr
> Moves `process.stdout.write` and `process.stderr.write` spies in [flyctl.test.ts](https://github.com/InsForge/CLI/pull/157/files#diff-1c4e2ab2047371606003a749403aa70f1df6eaea05dcb54a06c7fa3fd586be2b) from a single test to suite-level `beforeEach`/`afterEach` hooks, suppressing output across the `flyctlBuildAndPush` test suite during test runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8797c28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure for improved maintainability.

---

**Note:** This release contains internal testing improvements with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->