### PR TITLE
Exclude source maps from npm releases to reduce package size

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,14 +85,18 @@ cross-reference both PRs.
 
 ## 4. Build output and npm package contents
 
-`npm run build` produces a bundled ESM entry at `dist/index.js` and TypeScript
-declarations at `dist/index.d.ts`.
+`npm run build` produces a bundled ESM entry at `dist/index.js`, TypeScript
+declarations at `dist/index.d.ts`, and a local-only source map at
+`dist/index.js.map`.
 
 Source maps are intentionally excluded from npm releases because they increase
-package size and are not required for normal CLI usage.
+package size and are not required for normal CLI usage. The `files` field in
+`package.json` whitelists only `dist/index.js` and `dist/index.d.ts`, so
+`dist/index.js.map` is never published even though local builds may generate
+it. If you add new build outputs under `dist/`, update `package.json` `files`
+accordingly.
 
-The npm package intentionally ships only the runtime bundle and declaration
-file. Inspect what would be published with:
+Inspect what would be published with:
 
 ```bash
 npm run build

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,16 +85,15 @@ cross-reference both PRs.
 
 ## 4. Build output and npm package contents
 
-`npm run build` produces a bundled ESM entry at `dist/index.js`, TypeScript
-declarations at `dist/index.d.ts`, and a local-only source map at
-`dist/index.js.map`.
+`npm run build` produces a bundled ESM entry at `dist/index.js` and TypeScript
+declarations at `dist/index.d.ts`. Local builds (outside CI) also emit
+`dist/index.js.map` for debugging; CI/release builds skip source map generation.
 
 Source maps are intentionally excluded from npm releases because they increase
 package size and are not required for normal CLI usage. The `files` field in
 `package.json` whitelists only `dist/index.js` and `dist/index.d.ts`, so
-`dist/index.js.map` is never published even though local builds may generate
-it. If you add new build outputs under `dist/`, update `package.json` `files`
-accordingly.
+`dist/index.js.map` is never published. If you add new build outputs under
+`dist/`, update `package.json` `files` accordingly.
 
 Inspect what would be published with:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,7 +83,23 @@ Checklist when changing a command:
 Mention the skill repo update in the CLI PR description so reviewers can
 cross-reference both PRs.
 
-## 4. Release workflow
+## 4. Build output and npm package contents
+
+`npm run build` produces a bundled ESM entry at `dist/index.js` and TypeScript
+declarations at `dist/index.d.ts`.
+
+Source maps are intentionally excluded from npm releases because they increase
+package size and are not required for normal CLI usage.
+
+The npm package intentionally ships only the runtime bundle and declaration
+file. Inspect what would be published with:
+
+```bash
+npm run build
+npm pack --dry-run
+```
+
+## 5. Release workflow
 
 Releases are fully automated via GitHub Actions
 ([`.github/workflows/publish.yml`](.github/workflows/publish.yml)).

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "node": ">=18.0.0"
   },
   "files": [
-    "dist"
+    "dist/index.js",
+    "dist/index.d.ts"
   ],
   "dependencies": {
     "@clack/prompts": "^0.9.1",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   target: 'node18',
   outDir: 'dist',
   clean: true,
-  sourcemap: false,
+  sourcemap: true,
   dts: true,
   splitting: false,
   banner: {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   target: 'node18',
   outDir: 'dist',
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   dts: true,
   splitting: false,
   banner: {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   target: 'node18',
   outDir: 'dist',
   clean: true,
-  sourcemap: true,
+  sourcemap: process.env.CI !== 'true',
   dts: true,
   splitting: false,
   banner: {


### PR DESCRIPTION
## Summary

- Disable source map generation in `tsup.config.ts` for release builds
- Restrict npm `files` to `dist/index.js` and `dist/index.d.ts` instead of the whole `dist/` directory
- Document the package contents policy in `DEVELOPMENT.md`

Fixes #155 

## Why

The published npm package included `dist/index.js.map`, which was larger than the compiled CLI bundle and dominated tarball size. Source maps are not needed for normal CLI usage and embed full TypeScript sources.

## Validation

`npm pack --dry-run` (before) vs this branch (after):

| | Before | After |
|---|---|---|
| `dist/index.js.map` | included | removed |
| Total files | 6 | 5 |
| Packed size | 265.9 kB | 93.7 kB |
| Unpacked size | ~1.3 MB | 437.7 kB |

- Packed size reduced by ~172 kB (~65%)
- Unpacked size reduced by ~862 kB (~66%)
- Source map removed completely

Validation confirms the npm package no longer includes `dist/index.js.map`.

## Test plan

- [x] `npm run build` — no `dist/index.js.map` generated
- [x] `npm pack --dry-run` — 5 files, no `.map`
- [x] `npm test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude source maps from npm releases by including only `dist/index.js` and `dist/index.d.ts` in `package.json`, reducing packed size by ~65%. `tsup` now disables source maps in CI (`sourcemap: process.env.CI !== 'true'`); local builds still emit `dist/index.js.map`, and `DEVELOPMENT.md` documents the policy and how to verify with `npm pack --dry-run`.

<sup>Written for commit 7304c6525926c907984b203376f78ca433aab828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude source maps from npm releases to reduce package size
> - Updates [package.json](https://github.com/InsForge/CLI/pull/161/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) `files` whitelist from `dist` to explicit entries `dist/index.js` and `dist/index.d.ts`, so source maps are never included in published packages.
> - Changes `sourcemap` in [tsup.config.ts](https://github.com/InsForge/CLI/pull/161/files#diff-8fed899bdbc24789a7bb4973574e624ed6207c6ce572338bc3c3e117672b2a20) to only emit source maps when `CI !== 'true'`, so local dev builds still get them.
> - Adds a section to [DEVELOPMENT.md](https://github.com/InsForge/CLI/pull/161/files#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33ece) documenting build outputs and how to verify publish contents with `npm pack --dry-run`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7304c65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->