### PR TITLE
Add Razorpay payments CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,104 +536,136 @@ npx @insforge/cli deployments env delete <id>                # delete a variable
 
 ### Payments — `npx @insforge/cli payments`
 
-Manage the Stripe payments foundation for the linked InsForge project. These commands are intended for developers and agents configuring Stripe keys, syncing catalog state, inspecting mirrored customers, and managing products/prices. Runtime checkout and customer portal calls should usually be made from the app via the SDK.
+Manage the payments foundation for the linked InsForge project. Provider-specific commands live under `payments stripe` and `payments razorpay`. These commands are intended for developers and agents configuring provider keys, syncing mirrored provider state, inspecting customers, and managing provider catalog records. Runtime checkout/order/subscription calls should usually be made from the app via the SDK.
 
-#### `npx @insforge/cli payments status`
+#### `npx @insforge/cli payments <provider> status`
 
-Show Stripe key, account, sync, and webhook status for test/live environments.
-
-```bash
-npx @insforge/cli payments status
-npx @insforge/cli payments status --json
-```
-
-#### `npx @insforge/cli payments config`
-
-List, set, or remove Stripe secret keys.
+Show key, account, sync, and webhook status for test/live environments.
 
 ```bash
-npx @insforge/cli payments config
-npx @insforge/cli payments config set test sk_test_xxx
-npx @insforge/cli payments config set live        # prompts securely
-npx @insforge/cli payments config remove test -y
+npx @insforge/cli payments stripe status
+npx @insforge/cli payments razorpay status
+npx @insforge/cli payments stripe status --json
 ```
 
-#### `npx @insforge/cli payments sync`
+#### `npx @insforge/cli payments <provider> config`
 
-Sync Stripe products, prices, customers, and subscriptions from configured environments.
+List, set, or remove provider keys.
 
 ```bash
-npx @insforge/cli payments sync
-npx @insforge/cli payments sync --environment test
-npx @insforge/cli payments sync --environment live --json
+npx @insforge/cli payments stripe config list
+npx @insforge/cli payments stripe config set --environment test sk_test_xxx
+npx @insforge/cli payments stripe config set --environment live        # prompts securely
+npx @insforge/cli payments stripe config remove --environment test -y
+npx @insforge/cli payments razorpay config list
+npx @insforge/cli payments razorpay config set --environment test --key-id rzp_test_xxx --key-secret xxx
+npx @insforge/cli payments razorpay config remove --environment test -y
 ```
 
-#### `npx @insforge/cli payments webhooks configure <environment>`
+#### `npx @insforge/cli payments <provider> sync`
+
+Sync provider catalog, customers, subscriptions, and transaction projections from configured environments.
+
+```bash
+npx @insforge/cli payments stripe sync
+npx @insforge/cli payments stripe sync --environment test
+npx @insforge/cli payments razorpay sync --environment test
+npx @insforge/cli payments stripe sync --environment live --json
+```
+
+#### `npx @insforge/cli payments stripe webhooks configure --environment <environment>`
 
 Create or recreate the InsForge-managed Stripe webhook endpoint for an environment.
 
 ```bash
-npx @insforge/cli payments webhooks configure test
+npx @insforge/cli payments stripe webhooks configure --environment test
 ```
 
-#### `npx @insforge/cli payments catalog --environment <environment>`
+#### Razorpay webhook setup
 
-Inspect mirrored Stripe products and prices for one environment.
+Razorpay webhooks are configured manually in the Razorpay dashboard. Use the InsForge dashboard payments settings dialog to copy the webhook URL and webhook secret, then select the recommended events on Razorpay's website.
+
+#### `npx @insforge/cli payments <provider> catalog --environment <environment>`
+
+Inspect mirrored provider catalog records for one environment.
 
 ```bash
-npx @insforge/cli payments catalog --environment test
-npx @insforge/cli payments catalog --environment test --json
+npx @insforge/cli payments stripe catalog --environment test
+npx @insforge/cli payments razorpay catalog --environment test
+npx @insforge/cli payments stripe catalog --environment test --json
 ```
 
-#### `npx @insforge/cli payments customers --environment <environment>`
+#### `npx @insforge/cli payments <provider> customers --environment <environment>`
 
-List mirrored Stripe customers for admin/debugging workflows.
+List mirrored provider customers for admin/debugging workflows.
 
 ```bash
-npx @insforge/cli payments customers --environment test
-npx @insforge/cli payments customers --environment test --limit 20 --json
+npx @insforge/cli payments stripe customers --environment test
+npx @insforge/cli payments razorpay customers --environment test
+npx @insforge/cli payments stripe customers --environment test --limit 20 --json
 ```
 
-#### `npx @insforge/cli payments products`
+#### `npx @insforge/cli payments stripe products`
 
 List, inspect, create, update, or delete Stripe products.
 
 ```bash
-npx @insforge/cli payments products list --environment test
-npx @insforge/cli payments products get prod_123 --environment test
-npx @insforge/cli payments products create --environment test --name "Pro Plan"
-npx @insforge/cli payments products update prod_123 --environment test --description "Updated"
-npx @insforge/cli payments products delete prod_123 --environment test -y
+npx @insforge/cli payments stripe products list --environment test
+npx @insforge/cli payments stripe products get prod_123 --environment test
+npx @insforge/cli payments stripe products create --environment test --name "Pro Plan"
+npx @insforge/cli payments stripe products update prod_123 --environment test --description "Updated"
+npx @insforge/cli payments stripe products delete prod_123 --environment test -y
 ```
 
-#### `npx @insforge/cli payments prices`
+#### `npx @insforge/cli payments stripe prices`
 
 List, inspect, create, update, or archive Stripe prices.
 
 ```bash
-npx @insforge/cli payments prices list --environment test
-npx @insforge/cli payments prices create --environment test --product prod_123 --currency usd --unit-amount 2000
-npx @insforge/cli payments prices create --environment test --product prod_123 --currency usd --unit-amount 2000 --interval month
-npx @insforge/cli payments prices update price_123 --environment test --active false
-npx @insforge/cli payments prices archive price_123 --environment test
+npx @insforge/cli payments stripe prices list --environment test
+npx @insforge/cli payments stripe prices create --environment test --product prod_123 --currency usd --unit-amount 2000
+npx @insforge/cli payments stripe prices create --environment test --product prod_123 --currency usd --unit-amount 2000 --interval month
+npx @insforge/cli payments stripe prices update price_123 --environment test --active false
+npx @insforge/cli payments stripe prices archive price_123 --environment test
 ```
 
-#### `npx @insforge/cli payments subscriptions`
+#### `npx @insforge/cli payments razorpay items`
 
-List mirrored Stripe subscriptions for admin/debugging workflows.
+List, create, or update Razorpay items.
 
 ```bash
-npx @insforge/cli payments subscriptions --environment test
-npx @insforge/cli payments subscriptions --environment test --subject-type team --subject-id team_123
+npx @insforge/cli payments razorpay items list --environment test
+npx @insforge/cli payments razorpay items create --environment test --name "Pro Plan" --amount 200000 --currency inr
+npx @insforge/cli payments razorpay items update item_123 --environment test --active false
 ```
 
-#### `npx @insforge/cli payments history`
+#### `npx @insforge/cli payments razorpay plans`
 
-List mirrored payment history for admin/debugging workflows.
+List or create Razorpay subscription plans.
 
 ```bash
-npx @insforge/cli payments history --environment test
-npx @insforge/cli payments history --environment test --limit 20 --json
+npx @insforge/cli payments razorpay plans list --environment test
+npx @insforge/cli payments razorpay plans create --environment test --period monthly --interval 1 --item-name "Pro Plan" --item-amount 200000 --item-currency inr
+```
+
+#### `npx @insforge/cli payments <provider> subscriptions --environment <environment>`
+
+List mirrored provider subscriptions for admin/debugging workflows.
+
+```bash
+npx @insforge/cli payments stripe subscriptions --environment test
+npx @insforge/cli payments razorpay subscriptions --environment test
+npx @insforge/cli payments stripe subscriptions --environment test --subject-type team --subject-id team_123
+```
+
+#### `npx @insforge/cli payments <provider> transactions --environment <environment>`
+
+List mirrored payment transactions for admin/debugging workflows. `--subject-type` and `--subject-id` refer to the app billing subject passed to InsForge, such as `team:team_123` or `user:user_123`; they are not provider customer, payment, order, or subscription ids.
+
+```bash
+npx @insforge/cli payments stripe transactions --environment test
+npx @insforge/cli payments razorpay transactions --environment test
+npx @insforge/cli payments stripe transactions --environment test --limit 20 --json
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -550,14 +550,12 @@ npx @insforge/cli payments stripe status --json
 
 #### `npx @insforge/cli payments <provider> config`
 
-List, set, or remove provider keys.
+Set or remove provider keys. Use `payments <provider> status` to inspect whether keys are configured and whether account, sync, and webhook state are healthy.
 
 ```bash
-npx @insforge/cli payments stripe config list
 npx @insforge/cli payments stripe config set --environment test sk_test_xxx
 npx @insforge/cli payments stripe config set --environment live        # prompts securely
 npx @insforge/cli payments stripe config remove --environment test -y
-npx @insforge/cli payments razorpay config list
 npx @insforge/cli payments razorpay config set --environment test --key-id rzp_test_xxx --key-secret xxx
 npx @insforge/cli payments razorpay config remove --environment test -y
 ```

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ npx @insforge/cli payments stripe status --json
 
 #### `npx @insforge/cli payments <provider> config`
 
-Set or remove provider keys. Use `payments <provider> status` to inspect whether keys are configured and whether account, sync, and webhook state are healthy.
+Set or remove provider keys. `config set` validates the keys and automatically syncs provider state when the key or account changes. Use `payments <provider> status` to inspect key, account, sync, and webhook health.
 
 ```bash
 npx @insforge/cli payments stripe config set --environment test sk_test_xxx
@@ -562,7 +562,7 @@ npx @insforge/cli payments razorpay config remove --environment test -y
 
 #### `npx @insforge/cli payments <provider> sync`
 
-Sync provider catalog, customers, subscriptions, and transaction projections from configured environments.
+Manually refresh or retry provider catalog, customers, subscriptions, and transaction projections from configured environments. `config set` already syncs automatically when keys or accounts change.
 
 ```bash
 npx @insforge/cli payments stripe sync
@@ -645,6 +645,8 @@ List or create Razorpay subscription plans.
 npx @insforge/cli payments razorpay plans list --environment test
 npx @insforge/cli payments razorpay plans create --environment test --period monthly --interval 1 --item-name "Pro Plan" --item-amount 200000 --item-currency inr
 ```
+
+Use `--notes '{"key":"value"}'` when the Razorpay Plan needs native Razorpay notes.
 
 #### `npx @insforge/cli payments <provider> subscriptions --environment <environment>`
 
@@ -1058,13 +1060,13 @@ If you build the CLI from source without setting `POSTHOG_API_KEY` at build time
 
 ## Environment Variables
 
-| Variable                | Description                                                     |
-| ----------------------- | --------------------------------------------------------------- |
-| `INSFORGE_ACCESS_TOKEN` | Override the stored access token                                |
-| `INSFORGE_PROJECT_ID`   | Override the linked project ID                                  |
-| `INSFORGE_API_URL`      | Override the Platform API URL                                   |
-| `INSFORGE_EMAIL`        | Email for non-interactive login                                 |
-| `INSFORGE_PASSWORD`     | Password for non-interactive login                              |
+| Variable                | Description                        |
+| ----------------------- | ---------------------------------- |
+| `INSFORGE_ACCESS_TOKEN` | Override the stored access token   |
+| `INSFORGE_PROJECT_ID`   | Override the linked project ID     |
+| `INSFORGE_API_URL`      | Override the Platform API URL      |
+| `INSFORGE_EMAIL`        | Email for non-interactive login    |
+| `INSFORGE_PASSWORD`     | Password for non-interactive login |
 
 ## Non-Interactive / CI Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.87",
+  "version": "0.1.88-razorpay.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.87",
+      "version": "0.1.88-razorpay.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
-        "@insforge/shared-schemas": "^1.1.56",
+        "@insforge/shared-schemas": "^1.1.57",
         "archiver": "^7.0.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.56",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.56.tgz",
-      "integrity": "sha512-x7mjHu2mLxKc2ELChRAFvTtGJGrA6GPuZ8B6F6HrfOfYcPewy2fNkVL0ySReg3x5ZLrg0LvgfH/3+pdbm+Ck9w==",
+      "version": "1.1.57",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.57.tgz",
+      "integrity": "sha512-+4OTOB4Vw5P/TmdmqKZMpLt37bU1re3R2nFDUtcEXO7+BAmTx7dTqXRAWYXR+iGamnufk7vSmO8uzJocq0a2BQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
-        "@insforge/shared-schemas": "^1.1.57",
+        "@insforge/shared-schemas": "^1.1.58",
         "archiver": "^7.0.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.57",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.57.tgz",
-      "integrity": "sha512-+4OTOB4Vw5P/TmdmqKZMpLt37bU1re3R2nFDUtcEXO7+BAmTx7dTqXRAWYXR+iGamnufk7vSmO8uzJocq0a2BQ==",
+      "version": "1.1.58",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.58.tgz",
+      "integrity": "sha512-of494/PttH+nf5SBz63mAtgCBimDPIDF/tPEYb9zMNOySsGYNXYXWyqcyPuxnQcVuThlV5cdUwxW3cImvXyAvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
-        "@insforge/shared-schemas": "^1.1.52",
+        "@insforge/shared-schemas": "^1.1.56",
         "archiver": "^7.0.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.52",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.52.tgz",
-      "integrity": "sha512-jCaZz9MM9gTcSij1aXU0Dva2J9Ynsd5KExq51iNg+qbzGaggzAdwDrarIVMhm+AWsaaw1GBMEzNvUlWes1qBEA==",
+      "version": "1.1.56",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.56.tgz",
+      "integrity": "sha512-x7mjHu2mLxKc2ELChRAFvTtGJGrA6GPuZ8B6F6HrfOfYcPewy2fNkVL0ySReg3x5ZLrg0LvgfH/3+pdbm+Ck9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.88-razorpay.1",
+  "version": "0.1.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.88-razorpay.1",
+      "version": "0.1.89",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@insforge/shared-schemas": "^1.1.57",
+    "@insforge/shared-schemas": "^1.1.58",
     "archiver": "^7.0.1",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@insforge/shared-schemas": "^1.1.52",
+    "@insforge/shared-schemas": "^1.1.56",
     "archiver": "^7.0.1",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.87",
+  "version": "0.1.88-razorpay.1",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@insforge/shared-schemas": "^1.1.56",
+    "@insforge/shared-schemas": "^1.1.57",
     "archiver": "^7.0.1",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.88-razorpay.1",
+  "version": "0.1.89",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/payments/catalog.ts
+++ b/src/commands/payments/catalog.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { listPaymentCatalog } from "../../lib/api/payments.js";
+import {
+  listRazorpayCatalog,
+  listStripeCatalog,
+} from "../../lib/api/payments.js";
+import type { PaymentProvider } from "@insforge/shared-schemas";
 import { requireAuth } from "../../lib/credentials.js";
 import { getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputTable } from "../../lib/output.js";
@@ -10,13 +14,16 @@ import {
   trackPaymentUsage,
 } from "./utils.js";
 
-export function registerPaymentsCatalogCommand(paymentsCmd: Command): void {
+export function registerPaymentsCatalogCommand(
+  paymentsCmd: Command,
+  provider: PaymentProvider,
+): void {
   paymentsCmd
     .command("catalog")
-    .description("List mirrored Stripe products and prices for one environment")
+    .description("List mirrored provider catalog records for one environment")
     .requiredOption(
       "--environment <environment>",
-      "Stripe environment: test or live",
+      "Payment environment: test or live",
     )
     .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
@@ -24,64 +31,129 @@ export function registerPaymentsCatalogCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const data = await listPaymentCatalog(environment);
+        if (provider === "stripe") {
+          const data = await listStripeCatalog(environment);
 
-        if (json) {
-          outputJson(data);
+          if (json) {
+            outputJson(data);
+          } else {
+            if (data.products.length === 0 && data.prices.length === 0) {
+              console.log("No Stripe catalog records found.");
+              await trackPaymentUsage("catalog", true, {
+                provider,
+                environment,
+              });
+              return;
+            }
+
+            if (data.products.length > 0) {
+              console.log("Products");
+              outputTable(
+                ["Env", "Product ID", "Name", "Active", "Default Price"],
+                data.products.map((product) => [
+                  product.environment,
+                  product.productId,
+                  product.name,
+                  product.active ? "Yes" : "No",
+                  product.defaultPriceId ?? "-",
+                ]),
+              );
+            }
+
+            if (data.prices.length > 0) {
+              console.log("Prices");
+              outputTable(
+                [
+                  "Env",
+                  "Price ID",
+                  "Product ID",
+                  "Amount",
+                  "Type",
+                  "Active",
+                  "Recurring",
+                ],
+                data.prices.map((price) => [
+                  price.environment,
+                  price.priceId,
+                  price.productId ?? "-",
+                  formatAmount(price.unitAmount, price.currency),
+                  price.type,
+                  price.active ? "Yes" : "No",
+                  formatRecurring(
+                    price.recurringInterval,
+                    price.recurringIntervalCount,
+                  ),
+                ]),
+              );
+            }
+          }
         } else {
-          if (data.products.length === 0 && data.prices.length === 0) {
-            console.log("No Stripe catalog records found.");
-            await trackPaymentUsage("catalog", true, { environment });
-            return;
-          }
+          const data = await listRazorpayCatalog(environment);
 
-          if (data.products.length > 0) {
-            console.log("Products");
-            outputTable(
-              ["Env", "Product ID", "Name", "Active", "Default Price"],
-              data.products.map((product) => [
-                product.environment,
-                product.stripeProductId,
-                product.name,
-                product.active ? "Yes" : "No",
-                product.defaultPriceId ?? "-",
-              ]),
-            );
-          }
+          if (json) {
+            outputJson(data);
+          } else {
+            if (data.items.length === 0 && data.plans.length === 0) {
+              console.log("No Razorpay catalog records found.");
+              await trackPaymentUsage("catalog", true, {
+                provider,
+                environment,
+              });
+              return;
+            }
 
-          if (data.prices.length > 0) {
-            console.log("Prices");
-            outputTable(
-              [
-                "Env",
-                "Price ID",
-                "Product ID",
-                "Amount",
-                "Type",
-                "Active",
-                "Recurring",
-              ],
-              data.prices.map((price) => [
-                price.environment,
-                price.stripePriceId,
-                price.stripeProductId ?? "-",
-                formatAmount(price.unitAmount, price.currency),
-                price.type,
-                price.active ? "Yes" : "No",
-                formatRecurring(
-                  price.recurringInterval,
-                  price.recurringIntervalCount,
-                ),
-              ]),
-            );
+            if (data.items.length > 0) {
+              console.log("Items");
+              outputTable(
+                ["Env", "Item ID", "Name", "Amount", "Active", "Type"],
+                data.items.map((item) => [
+                  item.environment,
+                  item.itemId,
+                  item.name,
+                  formatAmount(item.amount, item.currency),
+                  item.active ? "Yes" : "No",
+                  item.type ?? "-",
+                ]),
+              );
+            }
+
+            if (data.plans.length > 0) {
+              console.log("Plans");
+              outputTable(
+                [
+                  "Env",
+                  "Plan ID",
+                  "Item ID",
+                  "Amount",
+                  "Period",
+                  "Interval",
+                  "Active",
+                ],
+                data.plans.map((plan) => [
+                  plan.environment,
+                  plan.planId,
+                  plan.itemId,
+                  formatAmount(plan.amount, plan.currency),
+                  plan.period,
+                  String(plan.interval),
+                  plan.active ? "Yes" : "No",
+                ]),
+              );
+            }
           }
         }
 
-        await trackPaymentUsage("catalog", true, { environment });
+        await trackPaymentUsage("catalog", true, { provider, environment });
       } catch (err) {
-        await trackPaymentUsage("catalog", false, {
-          environment: opts.environment,
-        });
+        await trackPaymentUsage(
+          "catalog",
+          false,
+          {
+            provider,
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/catalog.ts
+++ b/src/commands/payments/catalog.ts
@@ -26,10 +26,10 @@ export function registerPaymentsCatalogCommand(
       "Payment environment: test or live",
     )
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         if (provider === "stripe") {
           const data = await listStripeCatalog(environment);

--- a/src/commands/payments/config.ts
+++ b/src/commands/payments/config.ts
@@ -45,10 +45,10 @@ export function registerPaymentsConfigCommand(
       "Payment environment: test or live",
     )
     .action(async (opts, cmd) => {
-      const { json, yes } = getRootOpts(cmd);
+      const { json, yes, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         if (json && !yes) {
           throw new CLIError(
@@ -104,10 +104,10 @@ function registerStripeConfigSetCommand(configCmd: Command): void {
     )
     .option("--secret-key <secretKey>", "Stripe secret key")
     .action(async (secretKeyValue: string | undefined, opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         let secretKey = opts.secretKey ?? secretKeyValue;
         if (!secretKey) {
@@ -162,10 +162,10 @@ function registerRazorpayConfigSetCommand(configCmd: Command): void {
     .option("--key-id <keyId>", "Razorpay key id")
     .option("--key-secret <keySecret>", "Razorpay key secret")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         let keyId: string | undefined = opts.keyId;
         let keySecret: string | undefined = opts.keySecret;

--- a/src/commands/payments/config.ts
+++ b/src/commands/payments/config.ts
@@ -1,54 +1,26 @@
 import type { Command } from "commander";
 import * as prompts from "../../lib/prompts.js";
 import {
-  getRazorpayPaymentsConfig,
-  getStripePaymentsConfig,
   removeRazorpayKeys,
   removeStripeSecretKey,
   setRazorpayKeys,
   setStripeSecretKey,
 } from "../../lib/api/payments.js";
-import type { PaymentProvider } from "@insforge/shared-schemas";
+import type {
+  PaymentEnvironment,
+  PaymentProvider,
+} from "@insforge/shared-schemas";
 import { requireAuth } from "../../lib/credentials.js";
 import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
-import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
+import { outputJson, outputSuccess } from "../../lib/output.js";
 import { parseEnvironment, trackPaymentUsage } from "./utils.js";
 
-function outputStripeConfigTable(
-  data: Awaited<ReturnType<typeof getStripePaymentsConfig>>,
+function outputConfigMutationJson(
+  provider: PaymentProvider,
+  environment: PaymentEnvironment,
+  configured: boolean,
 ): void {
-  if (data.keys.length === 0) {
-    console.log("No Stripe keys configured.");
-    return;
-  }
-
-  outputTable(
-    ["Env", "Configured", "Key"],
-    data.keys.map((key) => [
-      key.environment,
-      key.hasKey ? "Yes" : "No",
-      key.maskedKey ?? "-",
-    ]),
-  );
-}
-
-function outputRazorpayConfigTable(
-  data: Awaited<ReturnType<typeof getRazorpayPaymentsConfig>>,
-): void {
-  if (data.razorpayKeys.length === 0) {
-    console.log("No Razorpay keys configured.");
-    return;
-  }
-
-  outputTable(
-    ["Env", "Type", "Configured", "Key"],
-    data.razorpayKeys.map((key) => [
-      key.environment,
-      key.keyType,
-      key.hasKey ? "Yes" : "No",
-      key.maskedKey ?? "-",
-    ]),
-  );
+  outputJson({ provider, environment, configured });
 }
 
 export function registerPaymentsConfigCommand(
@@ -57,38 +29,7 @@ export function registerPaymentsConfigCommand(
 ): void {
   const configCmd = paymentsCmd
     .command("config")
-    .description("Manage payment provider keys");
-
-  configCmd
-    .command("list")
-    .description("List configured payment provider keys")
-    .action(async (_opts, cmd) => {
-      const { json } = getRootOpts(cmd);
-      try {
-        await requireAuth();
-
-        if (provider === "stripe") {
-          const data = await getStripePaymentsConfig();
-          if (json) {
-            outputJson(data);
-          } else {
-            outputStripeConfigTable(data);
-          }
-        } else {
-          const data = await getRazorpayPaymentsConfig();
-          if (json) {
-            outputJson(data);
-          } else {
-            outputRazorpayConfigTable(data);
-          }
-        }
-
-        await trackPaymentUsage("config", true, { provider });
-      } catch (err) {
-        await trackPaymentUsage("config", false, { provider }, err);
-        handleError(err, json);
-      }
-    });
+    .description("Set or remove payment provider keys");
 
   if (provider === "stripe") {
     registerStripeConfigSetCommand(configCmd);
@@ -122,13 +63,14 @@ export function registerPaymentsConfigCommand(
           if (prompts.isCancel(confirm) || !confirm) process.exit(0);
         }
 
-        const data =
-          provider === "stripe"
-            ? await removeStripeSecretKey(environment)
-            : await removeRazorpayKeys(environment);
+        if (provider === "stripe") {
+          await removeStripeSecretKey(environment);
+        } else {
+          await removeRazorpayKeys(environment);
+        }
 
         if (json) {
-          outputJson(data);
+          outputConfigMutationJson(provider, environment, false);
         } else {
           outputSuccess(`${provider} ${environment} keys removed.`);
         }
@@ -182,10 +124,10 @@ function registerStripeConfigSetCommand(configCmd: Command): void {
           secretKey = input;
         }
 
-        const data = await setStripeSecretKey(environment, secretKey);
+        await setStripeSecretKey(environment, secretKey);
 
         if (json) {
-          outputJson(data);
+          outputConfigMutationJson("stripe", environment, true);
         } else {
           outputSuccess(`Stripe ${environment} key configured.`);
         }
@@ -250,13 +192,13 @@ function registerRazorpayConfigSetCommand(configCmd: Command): void {
           keySecret = input;
         }
 
-        const data = await setRazorpayKeys(environment, {
+        await setRazorpayKeys(environment, {
           keyId,
           keySecret,
         });
 
         if (json) {
-          outputJson(data);
+          outputConfigMutationJson("razorpay", environment, true);
         } else {
           outputSuccess(`Razorpay ${environment} keys configured.`);
         }

--- a/src/commands/payments/config.ts
+++ b/src/commands/payments/config.ts
@@ -1,68 +1,178 @@
-import type { Command } from 'commander';
-import * as prompts from '../../lib/prompts.js';
+import type { Command } from "commander";
+import * as prompts from "../../lib/prompts.js";
 import {
-  getPaymentsConfig,
+  getRazorpayPaymentsConfig,
+  getStripePaymentsConfig,
+  removeRazorpayKeys,
   removeStripeSecretKey,
+  setRazorpayKeys,
   setStripeSecretKey,
-} from '../../lib/api/payments.js';
-import { requireAuth } from '../../lib/credentials.js';
-import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
-import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
-import { parseEnvironment, trackPaymentUsage } from './utils.js';
+} from "../../lib/api/payments.js";
+import type { PaymentProvider } from "@insforge/shared-schemas";
+import { requireAuth } from "../../lib/credentials.js";
+import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
+import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
+import { parseEnvironment, trackPaymentUsage } from "./utils.js";
 
-function outputConfigTable(data: Awaited<ReturnType<typeof getPaymentsConfig>>): void {
+function outputStripeConfigTable(
+  data: Awaited<ReturnType<typeof getStripePaymentsConfig>>,
+): void {
   if (data.keys.length === 0) {
-    console.log('No Stripe keys configured.');
+    console.log("No Stripe keys configured.");
     return;
   }
 
   outputTable(
-    ['Env', 'Configured', 'Key'],
+    ["Env", "Configured", "Key"],
     data.keys.map((key) => [
       key.environment,
-      key.hasKey ? 'Yes' : 'No',
-      key.maskedKey ?? '-',
+      key.hasKey ? "Yes" : "No",
+      key.maskedKey ?? "-",
     ]),
   );
 }
 
-export function registerPaymentsConfigCommand(paymentsCmd: Command): void {
+function outputRazorpayConfigTable(
+  data: Awaited<ReturnType<typeof getRazorpayPaymentsConfig>>,
+): void {
+  if (data.razorpayKeys.length === 0) {
+    console.log("No Razorpay keys configured.");
+    return;
+  }
+
+  outputTable(
+    ["Env", "Type", "Configured", "Key"],
+    data.razorpayKeys.map((key) => [
+      key.environment,
+      key.keyType,
+      key.hasKey ? "Yes" : "No",
+      key.maskedKey ?? "-",
+    ]),
+  );
+}
+
+export function registerPaymentsConfigCommand(
+  paymentsCmd: Command,
+  provider: PaymentProvider,
+): void {
   const configCmd = paymentsCmd
-    .command('config')
-    .description('Manage Stripe API keys for payments')
+    .command("config")
+    .description("Manage payment provider keys");
+
+  configCmd
+    .command("list")
+    .description("List configured payment provider keys")
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
         await requireAuth();
 
-        const data = await getPaymentsConfig();
-
-        if (json) {
-          outputJson(data);
+        if (provider === "stripe") {
+          const data = await getStripePaymentsConfig();
+          if (json) {
+            outputJson(data);
+          } else {
+            outputStripeConfigTable(data);
+          }
         } else {
-          outputConfigTable(data);
+          const data = await getRazorpayPaymentsConfig();
+          if (json) {
+            outputJson(data);
+          } else {
+            outputRazorpayConfigTable(data);
+          }
         }
 
-        await trackPaymentUsage('config', true);
+        await trackPaymentUsage("config", true, { provider });
       } catch (err) {
-        await trackPaymentUsage('config', false);
+        await trackPaymentUsage("config", false, { provider }, err);
         handleError(err, json);
       }
     });
 
+  if (provider === "stripe") {
+    registerStripeConfigSetCommand(configCmd);
+  } else {
+    registerRazorpayConfigSetCommand(configCmd);
+  }
+
   configCmd
-    .command('set <environment> [secretKey]')
-    .description('Configure a Stripe secret key for test or live payments')
-    .action(async (environmentValue: string, secretKeyValue: string | undefined, _opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+    .command("remove")
+    .description("Remove configured payment provider keys")
+    .requiredOption(
+      "--environment <environment>",
+      "Payment environment: test or live",
+    )
+    .action(async (opts, cmd) => {
+      const { json, yes } = getRootOpts(cmd);
       try {
-        const environment = parseEnvironment(environmentValue);
+        const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        let secretKey = secretKeyValue;
+        if (json && !yes) {
+          throw new CLIError(
+            "Use --yes with --json to remove payment keys non-interactively.",
+          );
+        }
+
+        if (!yes) {
+          const confirm = await prompts.confirm({
+            message: `Remove ${provider} ${environment} keys? Payment sync and mutations for this environment will stop.`,
+          });
+          if (prompts.isCancel(confirm) || !confirm) process.exit(0);
+        }
+
+        const data =
+          provider === "stripe"
+            ? await removeStripeSecretKey(environment)
+            : await removeRazorpayKeys(environment);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`${provider} ${environment} keys removed.`);
+        }
+
+        await trackPaymentUsage("config.remove", true, {
+          provider,
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "config.remove",
+          false,
+          {
+            provider,
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+}
+
+function registerStripeConfigSetCommand(configCmd: Command): void {
+  configCmd
+    .command("set [secretKey]")
+    .description("Configure a Stripe secret key for test or live payments")
+    .requiredOption(
+      "--environment <environment>",
+      "Stripe environment: test or live",
+    )
+    .option("--secret-key <secretKey>", "Stripe secret key")
+    .action(async (secretKeyValue: string | undefined, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        let secretKey = opts.secretKey ?? secretKeyValue;
         if (!secretKey) {
           if (json) {
-            throw new CLIError('Provide secretKey when using --json.');
+            throw new CLIError(
+              "Provide secretKey or --secret-key when using --json.",
+            );
           }
 
           const input = await prompts.password({
@@ -80,45 +190,91 @@ export function registerPaymentsConfigCommand(paymentsCmd: Command): void {
           outputSuccess(`Stripe ${environment} key configured.`);
         }
 
-        await trackPaymentUsage('config.set', true, { environment });
+        await trackPaymentUsage("config.set", true, {
+          provider: "stripe",
+          environment,
+        });
       } catch (err) {
-        await trackPaymentUsage('config.set', false, { environment: environmentValue });
+        await trackPaymentUsage(
+          "config.set",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
+}
 
+function registerRazorpayConfigSetCommand(configCmd: Command): void {
   configCmd
-    .command('remove <environment>')
-    .alias('delete')
-    .description('Remove a configured Stripe secret key')
-    .action(async (environmentValue: string, _opts, cmd) => {
-      const { json, yes } = getRootOpts(cmd);
+    .command("set")
+    .description("Configure Razorpay keys for test or live payments")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .option("--key-id <keyId>", "Razorpay key id")
+    .option("--key-secret <keySecret>", "Razorpay key secret")
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
       try {
-        const environment = parseEnvironment(environmentValue);
+        const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        if (json && !yes) {
-          throw new CLIError('Use --yes with --json to remove a Stripe key non-interactively.');
-        }
+        let keyId: string | undefined = opts.keyId;
+        let keySecret: string | undefined = opts.keySecret;
+        if (!keyId) {
+          if (json) {
+            throw new CLIError("Provide --key-id when using --json.");
+          }
 
-        if (!yes) {
-          const confirm = await prompts.confirm({
-            message: `Remove Stripe ${environment} key? Payment sync and mutations for this environment will stop.`,
+          const input = await prompts.text({
+            message: `Razorpay ${environment} key id`,
           });
-          if (prompts.isCancel(confirm) || !confirm) process.exit(0);
+          if (prompts.isCancel(input)) process.exit(0);
+          keyId = input;
+        }
+        if (!keySecret) {
+          if (json) {
+            throw new CLIError("Provide --key-secret when using --json.");
+          }
+
+          const input = await prompts.password({
+            message: `Razorpay ${environment} key secret`,
+          });
+          if (prompts.isCancel(input)) process.exit(0);
+          keySecret = input;
         }
 
-        const data = await removeStripeSecretKey(environment);
+        const data = await setRazorpayKeys(environment, {
+          keyId,
+          keySecret,
+        });
 
         if (json) {
           outputJson(data);
         } else {
-          outputSuccess(`Stripe ${environment} key removed.`);
+          outputSuccess(`Razorpay ${environment} keys configured.`);
         }
 
-        await trackPaymentUsage('config.remove', true, { environment });
+        await trackPaymentUsage("config.set", true, {
+          provider: "razorpay",
+          environment,
+        });
       } catch (err) {
-        await trackPaymentUsage('config.remove', false, { environment: environmentValue });
+        await trackPaymentUsage(
+          "config.set",
+          false,
+          {
+            provider: "razorpay",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/customers.ts
+++ b/src/commands/payments/customers.ts
@@ -1,6 +1,9 @@
 import type { Command } from "commander";
 import { listPaymentCustomers } from "../../lib/api/payments.js";
-import type { ListPaymentCustomersResponse } from "@insforge/shared-schemas";
+import type {
+  ListPaymentCustomersResponse,
+  PaymentProvider,
+} from "@insforge/shared-schemas";
 import { requireAuth } from "../../lib/credentials.js";
 import { getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputTable } from "../../lib/output.js";
@@ -27,13 +30,16 @@ function formatPaymentMethod(customer: PaymentCustomer): string {
   return "-";
 }
 
-export function registerPaymentsCustomersCommand(paymentsCmd: Command): void {
+export function registerPaymentsCustomersCommand(
+  paymentsCmd: Command,
+  provider: PaymentProvider,
+): void {
   paymentsCmd
     .command("customers")
-    .description("List mirrored Stripe customers")
+    .description("List mirrored payment provider customers")
     .requiredOption(
       "--environment <environment>",
-      "Stripe environment: test or live",
+      "Payment environment: test or live",
     )
     .option("--limit <limit>", "Maximum rows to return (1-100)", "50")
     .action(async (opts, cmd) => {
@@ -44,12 +50,14 @@ export function registerPaymentsCustomersCommand(paymentsCmd: Command): void {
           parseIntegerOption(opts.limit, "--limit", { min: 1, max: 100 }) ?? 50;
         await requireAuth();
 
-        const data = await listPaymentCustomers(environment, { limit });
+        const data = await listPaymentCustomers(provider, environment, {
+          limit,
+        });
 
         if (json) {
           outputJson(data);
         } else if (data.customers.length === 0) {
-          console.log("No Stripe customers found.");
+          console.log(`No ${provider} customers found.`);
         } else {
           outputTable(
             [
@@ -63,7 +71,7 @@ export function registerPaymentsCustomersCommand(paymentsCmd: Command): void {
               "Country",
             ],
             data.customers.map((customer) => [
-              customer.stripeCustomerId,
+              customer.providerCustomerId,
               customer.email ?? "-",
               customer.name ?? "-",
               String(customer.paymentsCount),
@@ -75,11 +83,17 @@ export function registerPaymentsCustomersCommand(paymentsCmd: Command): void {
           );
         }
 
-        await trackPaymentUsage("customers", true, { environment });
+        await trackPaymentUsage("customers", true, { provider, environment });
       } catch (err) {
-        await trackPaymentUsage("customers", false, {
-          environment: opts.environment,
-        });
+        await trackPaymentUsage(
+          "customers",
+          false,
+          {
+            provider,
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/customers.ts
+++ b/src/commands/payments/customers.ts
@@ -43,12 +43,12 @@ export function registerPaymentsCustomersCommand(
     )
     .option("--limit <limit>", "Maximum rows to return (1-100)", "50")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
         const limit =
           parseIntegerOption(opts.limit, "--limit", { min: 1, max: 100 }) ?? 50;
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await listPaymentCustomers(provider, environment, {
           limit,

--- a/src/commands/payments/index.ts
+++ b/src/commands/payments/index.ts
@@ -2,25 +2,43 @@ import type { Command } from "commander";
 import { registerPaymentsCatalogCommand } from "./catalog.js";
 import { registerPaymentsConfigCommand } from "./config.js";
 import { registerPaymentsCustomersCommand } from "./customers.js";
-import { registerPaymentsHistoryCommand } from "./history.js";
+import { registerPaymentsItemsCommand } from "./items.js";
+import { registerPaymentsPlansCommand } from "./plans.js";
 import { registerPaymentsPricesCommand } from "./prices.js";
 import { registerPaymentsProductsCommand } from "./products.js";
 import { registerPaymentsStatusCommand } from "./status.js";
 import { registerPaymentsSubscriptionsCommand } from "./subscriptions.js";
 import { registerPaymentsSyncCommand } from "./sync.js";
+import { registerPaymentsTransactionsCommand } from "./transactions.js";
 import { registerPaymentsWebhooksCommand } from "./webhooks.js";
 
 export function registerPaymentsCommands(paymentsCmd: Command): void {
-  paymentsCmd.description("Manage Stripe payments");
+  paymentsCmd.description("Manage payments");
 
-  registerPaymentsStatusCommand(paymentsCmd);
-  registerPaymentsConfigCommand(paymentsCmd);
-  registerPaymentsSyncCommand(paymentsCmd);
-  registerPaymentsWebhooksCommand(paymentsCmd);
-  registerPaymentsCatalogCommand(paymentsCmd);
-  registerPaymentsCustomersCommand(paymentsCmd);
-  registerPaymentsProductsCommand(paymentsCmd);
-  registerPaymentsPricesCommand(paymentsCmd);
-  registerPaymentsSubscriptionsCommand(paymentsCmd);
-  registerPaymentsHistoryCommand(paymentsCmd);
+  const stripeCmd = paymentsCmd
+    .command("stripe")
+    .description("Manage Stripe payments");
+  registerPaymentsStatusCommand(stripeCmd, "stripe");
+  registerPaymentsConfigCommand(stripeCmd, "stripe");
+  registerPaymentsSyncCommand(stripeCmd, "stripe");
+  registerPaymentsWebhooksCommand(stripeCmd);
+  registerPaymentsCatalogCommand(stripeCmd, "stripe");
+  registerPaymentsCustomersCommand(stripeCmd, "stripe");
+  registerPaymentsProductsCommand(stripeCmd);
+  registerPaymentsPricesCommand(stripeCmd);
+  registerPaymentsSubscriptionsCommand(stripeCmd, "stripe");
+  registerPaymentsTransactionsCommand(stripeCmd, "stripe");
+
+  const razorpayCmd = paymentsCmd
+    .command("razorpay")
+    .description("Manage Razorpay payments");
+  registerPaymentsStatusCommand(razorpayCmd, "razorpay");
+  registerPaymentsConfigCommand(razorpayCmd, "razorpay");
+  registerPaymentsSyncCommand(razorpayCmd, "razorpay");
+  registerPaymentsCatalogCommand(razorpayCmd, "razorpay");
+  registerPaymentsCustomersCommand(razorpayCmd, "razorpay");
+  registerPaymentsItemsCommand(razorpayCmd);
+  registerPaymentsPlansCommand(razorpayCmd);
+  registerPaymentsSubscriptionsCommand(razorpayCmd, "razorpay");
+  registerPaymentsTransactionsCommand(razorpayCmd, "razorpay");
 }

--- a/src/commands/payments/items.ts
+++ b/src/commands/payments/items.ts
@@ -1,0 +1,215 @@
+import type { Command } from "commander";
+import {
+  createRazorpayItem,
+  listRazorpayCatalog,
+  updateRazorpayItem,
+} from "../../lib/api/payments.js";
+import { requireAuth } from "../../lib/credentials.js";
+import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
+import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
+import type {
+  CreateRazorpayItemBody,
+  ListRazorpayCatalogResponse,
+  UpdateRazorpayItemBody,
+} from "@insforge/shared-schemas";
+import {
+  formatAmount,
+  formatDate,
+  parseBooleanOption,
+  parseEnvironment,
+  parseIntegerOption,
+  parseMetadataOption,
+  trackPaymentUsage,
+} from "./utils.js";
+
+type RazorpayItem = ListRazorpayCatalogResponse["items"][number];
+
+function nullableString(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  return value === "null" ? null : value;
+}
+
+function outputItemsTable(items: RazorpayItem[]): void {
+  if (items.length === 0) {
+    console.log("No Razorpay items found.");
+    return;
+  }
+
+  outputTable(
+    ["Env", "Item ID", "Name", "Amount", "Active", "Type", "Synced At"],
+    items.map((item) => [
+      item.environment,
+      item.itemId,
+      item.name,
+      formatAmount(item.amount, item.currency),
+      item.active ? "Yes" : "No",
+      item.type ?? "-",
+      formatDate(item.syncedAt),
+    ]),
+  );
+}
+
+export function registerPaymentsItemsCommand(paymentsCmd: Command): void {
+  const itemsCmd = paymentsCmd
+    .command("items")
+    .description("Manage Razorpay items");
+
+  itemsCmd
+    .command("list")
+    .description("List mirrored Razorpay items")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const data = await listRazorpayCatalog(environment);
+
+        if (json) {
+          outputJson({ items: data.items });
+        } else {
+          outputItemsTable(data.items);
+        }
+
+        await trackPaymentUsage("items.list", true, {
+          provider: "razorpay",
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "items.list",
+          false,
+          {
+            provider: "razorpay",
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+
+  itemsCmd
+    .command("create")
+    .description("Create a Razorpay item")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .requiredOption("--name <name>", "Item name")
+    .requiredOption("--amount <amount>", "Amount in the smallest currency unit")
+    .requiredOption(
+      "--currency <currency>",
+      "Three-letter currency code, e.g. inr",
+    )
+    .option("--description <description>", 'Item description, or "null"')
+    .option("--metadata <json>", "Metadata JSON object with string values")
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const request: CreateRazorpayItemBody = {
+          name: opts.name,
+          amount: parseIntegerOption(opts.amount, "--amount", { min: 0 }) ?? 0,
+          currency: opts.currency,
+        };
+        const description = nullableString(opts.description);
+        const metadata = parseMetadataOption(opts.metadata);
+        if (description !== undefined) request.description = description;
+        if (metadata !== undefined) request.metadata = metadata;
+
+        const data = await createRazorpayItem(environment, request);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Razorpay item created: ${data.item.itemId}`);
+        }
+
+        await trackPaymentUsage("items.create", true, {
+          provider: "razorpay",
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "items.create",
+          false,
+          {
+            provider: "razorpay",
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+
+  itemsCmd
+    .command("update <itemId>")
+    .description("Update a Razorpay item")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .option("--name <name>", "Item name")
+    .option("--description <description>", 'Item description, or "null"')
+    .option("--amount <amount>", "Amount in the smallest currency unit")
+    .option("--currency <currency>", "Three-letter currency code")
+    .option("--active <bool>", "Set active status (true/false)")
+    .option("--metadata <json>", "Metadata JSON object with string values")
+    .action(async (itemId: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const request: UpdateRazorpayItemBody = {};
+        const description = nullableString(opts.description);
+        const amount = parseIntegerOption(opts.amount, "--amount", { min: 0 });
+        const active = parseBooleanOption(opts.active, "--active");
+        const metadata = parseMetadataOption(opts.metadata);
+        if (opts.name !== undefined) request.name = opts.name;
+        if (description !== undefined) request.description = description;
+        if (amount !== undefined) request.amount = amount;
+        if (opts.currency !== undefined) request.currency = opts.currency;
+        if (active !== undefined) request.active = active;
+        if (metadata !== undefined) request.metadata = metadata;
+
+        if (Object.keys(request).length === 0) {
+          throw new CLIError(
+            "Provide at least one option to update (--name, --description, --amount, --currency, --active, --metadata).",
+          );
+        }
+
+        const data = await updateRazorpayItem(environment, itemId, request);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Razorpay item updated: ${data.item.itemId}`);
+        }
+
+        await trackPaymentUsage("items.update", true, {
+          provider: "razorpay",
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "items.update",
+          false,
+          {
+            provider: "razorpay",
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/items.ts
+++ b/src/commands/payments/items.ts
@@ -15,19 +15,15 @@ import type {
 import {
   formatAmount,
   formatDate,
+  nullableString,
   parseBooleanOption,
   parseEnvironment,
   parseIntegerOption,
-  parseMetadataOption,
+  parseRequiredIntegerOption,
   trackPaymentUsage,
 } from "./utils.js";
 
 type RazorpayItem = ListRazorpayCatalogResponse["items"][number];
-
-function nullableString(value: string | undefined): string | null | undefined {
-  if (value === undefined) return undefined;
-  return value === "null" ? null : value;
-}
 
 function outputItemsTable(items: RazorpayItem[]): void {
   if (items.length === 0) {
@@ -62,10 +58,10 @@ export function registerPaymentsItemsCommand(paymentsCmd: Command): void {
       "Razorpay environment: test or live",
     )
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await listRazorpayCatalog(environment);
 
@@ -107,22 +103,21 @@ export function registerPaymentsItemsCommand(paymentsCmd: Command): void {
       "Three-letter currency code, e.g. inr",
     )
     .option("--description <description>", 'Item description, or "null"')
-    .option("--metadata <json>", "Metadata JSON object with string values")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const request: CreateRazorpayItemBody = {
           name: opts.name,
-          amount: parseIntegerOption(opts.amount, "--amount", { min: 0 }) ?? 0,
+          amount: parseRequiredIntegerOption(opts.amount, "--amount", {
+            min: 0,
+          }),
           currency: opts.currency,
         };
         const description = nullableString(opts.description);
-        const metadata = parseMetadataOption(opts.metadata);
         if (description !== undefined) request.description = description;
-        if (metadata !== undefined) request.metadata = metadata;
 
         const data = await createRazorpayItem(environment, request);
 
@@ -162,28 +157,25 @@ export function registerPaymentsItemsCommand(paymentsCmd: Command): void {
     .option("--amount <amount>", "Amount in the smallest currency unit")
     .option("--currency <currency>", "Three-letter currency code")
     .option("--active <bool>", "Set active status (true/false)")
-    .option("--metadata <json>", "Metadata JSON object with string values")
     .action(async (itemId: string, opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const request: UpdateRazorpayItemBody = {};
         const description = nullableString(opts.description);
         const amount = parseIntegerOption(opts.amount, "--amount", { min: 0 });
         const active = parseBooleanOption(opts.active, "--active");
-        const metadata = parseMetadataOption(opts.metadata);
         if (opts.name !== undefined) request.name = opts.name;
         if (description !== undefined) request.description = description;
         if (amount !== undefined) request.amount = amount;
         if (opts.currency !== undefined) request.currency = opts.currency;
         if (active !== undefined) request.active = active;
-        if (metadata !== undefined) request.metadata = metadata;
 
         if (Object.keys(request).length === 0) {
           throw new CLIError(
-            "Provide at least one option to update (--name, --description, --amount, --currency, --active, --metadata).",
+            "Provide at least one option to update (--name, --description, --amount, --currency, --active).",
           );
         }
 

--- a/src/commands/payments/plans.ts
+++ b/src/commands/payments/plans.ts
@@ -4,7 +4,7 @@ import {
   listRazorpayCatalog,
 } from "../../lib/api/payments.js";
 import { requireAuth } from "../../lib/credentials.js";
-import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
+import { getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
 import type {
   CreateRazorpayPlanBody,
@@ -13,19 +13,15 @@ import type {
 import {
   formatAmount,
   formatDate,
+  nullableString,
   parseEnvironment,
-  parseIntegerOption,
-  parseMetadataOption,
-  parseRazorpayPlanPeriod,
+  parseNotesOption,
+  parseRequiredIntegerOption,
+  parseRequiredRazorpayPlanPeriod,
   trackPaymentUsage,
 } from "./utils.js";
 
 type RazorpayPlan = ListRazorpayCatalogResponse["plans"][number];
-
-function nullableString(value: string | undefined): string | null | undefined {
-  if (value === undefined) return undefined;
-  return value === "null" ? null : value;
-}
 
 function outputPlansTable(plans: RazorpayPlan[]): void {
   if (plans.length === 0) {
@@ -70,10 +66,10 @@ export function registerPaymentsPlansCommand(paymentsCmd: Command): void {
       "Razorpay environment: test or live",
     )
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await listRazorpayCatalog(environment);
 
@@ -126,26 +122,25 @@ export function registerPaymentsPlansCommand(paymentsCmd: Command): void {
       "--item-description <description>",
       'Plan item description, or "null"',
     )
-    .option("--metadata <json>", "Metadata JSON object with string values")
+    .option("--notes <json>", "Razorpay notes JSON object with string values")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        const period = parseRazorpayPlanPeriod(opts.period);
-        const interval = parseIntegerOption(opts.interval, "--interval", {
-          min: 1,
-        });
-        const itemAmount = parseIntegerOption(
+        const period = parseRequiredRazorpayPlanPeriod(opts.period);
+        const interval = parseRequiredIntegerOption(
+          opts.interval,
+          "--interval",
+          {
+            min: 1,
+          },
+        );
+        const itemAmount = parseRequiredIntegerOption(
           opts.itemAmount,
           "--item-amount",
           { min: 0 },
         );
-        if (!period || interval === undefined || itemAmount === undefined) {
-          throw new CLIError(
-            "Provide --period, --interval, and --item-amount.",
-          );
-        }
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const request: CreateRazorpayPlanBody = {
           period,
@@ -157,11 +152,11 @@ export function registerPaymentsPlansCommand(paymentsCmd: Command): void {
           },
         };
         const itemDescription = nullableString(opts.itemDescription);
-        const metadata = parseMetadataOption(opts.metadata);
+        const notes = parseNotesOption(opts.notes);
         if (itemDescription !== undefined) {
           request.item.description = itemDescription;
         }
-        if (metadata !== undefined) request.metadata = metadata;
+        if (notes !== undefined) request.notes = notes;
 
         const data = await createRazorpayPlan(environment, request);
 

--- a/src/commands/payments/plans.ts
+++ b/src/commands/payments/plans.ts
@@ -1,0 +1,191 @@
+import type { Command } from "commander";
+import {
+  createRazorpayPlan,
+  listRazorpayCatalog,
+} from "../../lib/api/payments.js";
+import { requireAuth } from "../../lib/credentials.js";
+import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
+import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
+import type {
+  CreateRazorpayPlanBody,
+  ListRazorpayCatalogResponse,
+} from "@insforge/shared-schemas";
+import {
+  formatAmount,
+  formatDate,
+  parseEnvironment,
+  parseIntegerOption,
+  parseMetadataOption,
+  parseRazorpayPlanPeriod,
+  trackPaymentUsage,
+} from "./utils.js";
+
+type RazorpayPlan = ListRazorpayCatalogResponse["plans"][number];
+
+function nullableString(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  return value === "null" ? null : value;
+}
+
+function outputPlansTable(plans: RazorpayPlan[]): void {
+  if (plans.length === 0) {
+    console.log("No Razorpay plans found.");
+    return;
+  }
+
+  outputTable(
+    [
+      "Env",
+      "Plan ID",
+      "Item ID",
+      "Amount",
+      "Period",
+      "Interval",
+      "Active",
+      "Synced At",
+    ],
+    plans.map((plan) => [
+      plan.environment,
+      plan.planId,
+      plan.itemId,
+      formatAmount(plan.amount, plan.currency),
+      plan.period,
+      String(plan.interval),
+      plan.active ? "Yes" : "No",
+      formatDate(plan.syncedAt),
+    ]),
+  );
+}
+
+export function registerPaymentsPlansCommand(paymentsCmd: Command): void {
+  const plansCmd = paymentsCmd
+    .command("plans")
+    .description("Manage Razorpay plans");
+
+  plansCmd
+    .command("list")
+    .description("List mirrored Razorpay plans")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth();
+
+        const data = await listRazorpayCatalog(environment);
+
+        if (json) {
+          outputJson({ plans: data.plans });
+        } else {
+          outputPlansTable(data.plans);
+        }
+
+        await trackPaymentUsage("plans.list", true, {
+          provider: "razorpay",
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "plans.list",
+          false,
+          {
+            provider: "razorpay",
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+
+  plansCmd
+    .command("create")
+    .description("Create a Razorpay subscription plan")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .requiredOption(
+      "--period <period>",
+      "Plan period: daily, weekly, monthly, or yearly",
+    )
+    .requiredOption("--interval <count>", "Billing interval count")
+    .requiredOption("--item-name <name>", "Plan item name")
+    .requiredOption(
+      "--item-amount <amount>",
+      "Plan item amount in the smallest currency unit",
+    )
+    .requiredOption(
+      "--item-currency <currency>",
+      "Three-letter currency code, e.g. inr",
+    )
+    .option(
+      "--item-description <description>",
+      'Plan item description, or "null"',
+    )
+    .option("--metadata <json>", "Metadata JSON object with string values")
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        const period = parseRazorpayPlanPeriod(opts.period);
+        const interval = parseIntegerOption(opts.interval, "--interval", {
+          min: 1,
+        });
+        const itemAmount = parseIntegerOption(
+          opts.itemAmount,
+          "--item-amount",
+          { min: 0 },
+        );
+        if (!period || interval === undefined || itemAmount === undefined) {
+          throw new CLIError(
+            "Provide --period, --interval, and --item-amount.",
+          );
+        }
+        await requireAuth();
+
+        const request: CreateRazorpayPlanBody = {
+          period,
+          interval,
+          item: {
+            name: opts.itemName,
+            amount: itemAmount,
+            currency: opts.itemCurrency,
+          },
+        };
+        const itemDescription = nullableString(opts.itemDescription);
+        const metadata = parseMetadataOption(opts.metadata);
+        if (itemDescription !== undefined) {
+          request.item.description = itemDescription;
+        }
+        if (metadata !== undefined) request.metadata = metadata;
+
+        const data = await createRazorpayPlan(environment, request);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputSuccess(`Razorpay plan created: ${data.plan.planId}`);
+        }
+
+        await trackPaymentUsage("plans.create", true, {
+          provider: "razorpay",
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "plans.create",
+          false,
+          {
+            provider: "razorpay",
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/payments/prices.ts
+++ b/src/commands/payments/prices.ts
@@ -20,18 +20,15 @@ import {
   formatAmount,
   formatDate,
   formatRecurring,
+  nullableString,
   parseBooleanOption,
   parseEnvironment,
   parseIntegerOption,
   parseMetadataOption,
+  parseRequiredIntegerOption,
   trackPaymentUsage,
 } from "./utils.js";
 type StripePrice = ListStripePricesResponse["prices"][number];
-
-function nullableString(value: string | undefined): string | null | undefined {
-  if (value === undefined) return undefined;
-  return value === "null" ? null : value;
-}
 
 function parseRecurringInterval(
   value: string | undefined,
@@ -112,10 +109,10 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
     )
     .option("--product <productId>", "Filter by Stripe product id")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await listStripePrices(environment, opts.product);
 
@@ -151,10 +148,10 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
       "Stripe environment: test or live",
     )
     .action(async (priceId: string, opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await getStripePrice(environment, priceId);
 
@@ -209,10 +206,10 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
     .option("--metadata <json>", "Metadata JSON object with string values")
     .option("--idempotency-key <key>", "Caller-stable idempotency key")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const interval = parseRecurringInterval(opts.interval);
         const intervalCount = parseIntegerOption(
@@ -227,9 +224,11 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
         const request: CreateStripePriceBody = {
           productId: opts.product,
           currency: opts.currency,
-          unitAmount:
-            parseIntegerOption(opts.unitAmount, "--unit-amount", { min: 0 }) ??
-            0,
+          unitAmount: parseRequiredIntegerOption(
+            opts.unitAmount,
+            "--unit-amount",
+            { min: 0 },
+          ),
         };
         const lookupKey = nullableString(opts.lookupKey);
         const active = parseBooleanOption(opts.active, "--active");
@@ -287,10 +286,10 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
     .option("--tax-behavior <behavior>", "exclusive, inclusive, or unspecified")
     .option("--metadata <json>", "Metadata JSON object with string values")
     .action(async (priceId: string, opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const request: UpdateStripePriceBody = {};
         const active = parseBooleanOption(opts.active, "--active");
@@ -342,10 +341,10 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
       "Stripe environment: test or live",
     )
     .action(async (priceId: string, opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await archiveStripePrice(environment, priceId);
 

--- a/src/commands/payments/prices.ts
+++ b/src/commands/payments/prices.ts
@@ -1,20 +1,20 @@
 import type { Command } from "commander";
 import {
-  archivePaymentPrice,
-  createPaymentPrice,
-  getPaymentPrice,
-  listPaymentPrices,
-  updatePaymentPrice,
+  archiveStripePrice,
+  createStripePrice,
+  getStripePrice,
+  listStripePrices,
+  updateStripePrice,
 } from "../../lib/api/payments.js";
 import { requireAuth } from "../../lib/credentials.js";
 import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
 import type {
-  CreatePaymentPriceBody,
-  ListPaymentPricesResponse,
+  CreateStripePriceBody,
+  ListStripePricesResponse,
   StripePriceRecurringInterval,
   StripePriceTaxBehavior,
-  UpdatePaymentPriceBody,
+  UpdateStripePriceBody,
 } from "@insforge/shared-schemas";
 import {
   formatAmount,
@@ -26,7 +26,7 @@ import {
   parseMetadataOption,
   trackPaymentUsage,
 } from "./utils.js";
-type PaymentPrice = ListPaymentPricesResponse["prices"][number];
+type StripePrice = ListStripePricesResponse["prices"][number];
 
 function nullableString(value: string | undefined): string | null | undefined {
   if (value === undefined) return undefined;
@@ -68,7 +68,7 @@ function parseTaxBehavior(
   );
 }
 
-function outputPricesTable(prices: PaymentPrice[]): void {
+function outputPricesTable(prices: StripePrice[]): void {
   if (prices.length === 0) {
     console.log("No Stripe prices found.");
     return;
@@ -87,8 +87,8 @@ function outputPricesTable(prices: PaymentPrice[]): void {
     ],
     prices.map((price) => [
       price.environment,
-      price.stripePriceId,
-      price.stripeProductId ?? "-",
+      price.priceId,
+      price.productId ?? "-",
       formatAmount(price.unitAmount, price.currency),
       price.type,
       price.active ? "Yes" : "No",
@@ -117,7 +117,7 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const data = await listPaymentPrices(environment, opts.product);
+        const data = await listStripePrices(environment, opts.product);
 
         if (json) {
           outputJson(data);
@@ -125,11 +125,20 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
           outputPricesTable(data.prices);
         }
 
-        await trackPaymentUsage("prices.list", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("prices.list", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("prices.list", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "prices.list",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
@@ -147,7 +156,7 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const data = await getPaymentPrice(environment, priceId);
+        const data = await getStripePrice(environment, priceId);
 
         if (json) {
           outputJson(data);
@@ -155,11 +164,20 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
           outputPricesTable([data.price]);
         }
 
-        await trackPaymentUsage("prices.get", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("prices.get", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("prices.get", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "prices.get",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
@@ -206,8 +224,8 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
           throw new CLIError("Provide --interval when using --interval-count.");
         }
 
-        const request: CreatePaymentPriceBody = {
-          stripeProductId: opts.product,
+        const request: CreateStripePriceBody = {
+          productId: opts.product,
           currency: opts.currency,
           unitAmount:
             parseIntegerOption(opts.unitAmount, "--unit-amount", { min: 0 }) ??
@@ -231,19 +249,28 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
           };
         }
 
-        const data = await createPaymentPrice(environment, request);
+        const data = await createStripePrice(environment, request);
 
         if (json) {
           outputJson(data);
         } else {
-          outputSuccess(`Stripe price created: ${data.price.stripePriceId}`);
+          outputSuccess(`Stripe price created: ${data.price.priceId}`);
         }
 
-        await trackPaymentUsage("prices.create", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("prices.create", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("prices.create", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "prices.create",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
@@ -265,7 +292,7 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const request: UpdatePaymentPriceBody = {};
+        const request: UpdateStripePriceBody = {};
         const active = parseBooleanOption(opts.active, "--active");
         const lookupKey = nullableString(opts.lookupKey);
         const taxBehavior = parseTaxBehavior(opts.taxBehavior);
@@ -281,26 +308,34 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
           );
         }
 
-        const data = await updatePaymentPrice(environment, priceId, request);
+        const data = await updateStripePrice(environment, priceId, request);
 
         if (json) {
           outputJson(data);
         } else {
-          outputSuccess(`Stripe price updated: ${data.price.stripePriceId}`);
+          outputSuccess(`Stripe price updated: ${data.price.priceId}`);
         }
 
-        await trackPaymentUsage("prices.update", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("prices.update", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("prices.update", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "prices.update",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
 
   pricesCmd
     .command("archive <priceId>")
-    .alias("delete")
     .description("Archive a Stripe price")
     .requiredOption(
       "--environment <environment>",
@@ -312,19 +347,28 @@ export function registerPaymentsPricesCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const data = await archivePaymentPrice(environment, priceId);
+        const data = await archiveStripePrice(environment, priceId);
 
         if (json) {
           outputJson(data);
         } else {
-          outputSuccess(`Stripe price archived: ${data.price.stripePriceId}`);
+          outputSuccess(`Stripe price archived: ${data.price.priceId}`);
         }
 
-        await trackPaymentUsage("prices.archive", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("prices.archive", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("prices.archive", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "prices.archive",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/products.ts
+++ b/src/commands/payments/products.ts
@@ -18,17 +18,13 @@ import type {
 import {
   formatAmount,
   formatDate,
+  nullableString,
   parseBooleanOption,
   parseEnvironment,
   parseMetadataOption,
   trackPaymentUsage,
 } from "./utils.js";
 type StripeProduct = ListStripeProductsResponse["products"][number];
-
-function nullableString(value: string | undefined): string | null | undefined {
-  if (value === undefined) return undefined;
-  return value === "null" ? null : value;
-}
 
 function outputProductsTable(products: StripeProduct[]): void {
   if (products.length === 0) {
@@ -62,10 +58,10 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
       "Stripe environment: test or live",
     )
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await listStripeProducts(environment);
 
@@ -101,10 +97,10 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
       "Stripe environment: test or live",
     )
     .action(async (productId: string, opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await getStripeProduct(environment, productId);
 
@@ -158,10 +154,10 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
     .option("--metadata <json>", "Metadata JSON object with string values")
     .option("--idempotency-key <key>", "Caller-stable idempotency key")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const request: CreateStripeProductBody = { name: opts.name };
         const description = nullableString(opts.description);
@@ -212,10 +208,10 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
     .option("--active <bool>", "Set active status (true/false)")
     .option("--metadata <json>", "Metadata JSON object with string values")
     .action(async (productId: string, opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const request: UpdateStripeProductBody = {};
         const description = nullableString(opts.description);
@@ -266,10 +262,10 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
       "Stripe environment: test or live",
     )
     .action(async (productId: string, opts, cmd) => {
-      const { json, yes } = getRootOpts(cmd);
+      const { json, yes, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         if (json && !yes) {
           throw new CLIError(

--- a/src/commands/payments/products.ts
+++ b/src/commands/payments/products.ts
@@ -1,19 +1,19 @@
 import type { Command } from "commander";
 import * as prompts from "../../lib/prompts.js";
 import {
-  createPaymentProduct,
-  deletePaymentProduct,
-  getPaymentProduct,
-  listPaymentProducts,
-  updatePaymentProduct,
+  createStripeProduct,
+  deleteStripeProduct,
+  getStripeProduct,
+  listStripeProducts,
+  updateStripeProduct,
 } from "../../lib/api/payments.js";
 import { requireAuth } from "../../lib/credentials.js";
 import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
 import type {
-  CreatePaymentProductBody,
-  ListPaymentProductsResponse,
-  UpdatePaymentProductBody,
+  CreateStripeProductBody,
+  ListStripeProductsResponse,
+  UpdateStripeProductBody,
 } from "@insforge/shared-schemas";
 import {
   formatAmount,
@@ -23,14 +23,14 @@ import {
   parseMetadataOption,
   trackPaymentUsage,
 } from "./utils.js";
-type PaymentProduct = ListPaymentProductsResponse["products"][number];
+type StripeProduct = ListStripeProductsResponse["products"][number];
 
 function nullableString(value: string | undefined): string | null | undefined {
   if (value === undefined) return undefined;
   return value === "null" ? null : value;
 }
 
-function outputProductsTable(products: PaymentProduct[]): void {
+function outputProductsTable(products: StripeProduct[]): void {
   if (products.length === 0) {
     console.log("No Stripe products found.");
     return;
@@ -40,7 +40,7 @@ function outputProductsTable(products: PaymentProduct[]): void {
     ["Env", "Product ID", "Name", "Active", "Default Price", "Synced At"],
     products.map((product) => [
       product.environment,
-      product.stripeProductId,
+      product.productId,
       product.name,
       product.active ? "Yes" : "No",
       product.defaultPriceId ?? "-",
@@ -67,7 +67,7 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const data = await listPaymentProducts(environment);
+        const data = await listStripeProducts(environment);
 
         if (json) {
           outputJson(data);
@@ -75,11 +75,20 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
           outputProductsTable(data.products);
         }
 
-        await trackPaymentUsage("products.list", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("products.list", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("products.list", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "products.list",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
@@ -97,7 +106,7 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const data = await getPaymentProduct(environment, productId);
+        const data = await getStripeProduct(environment, productId);
 
         if (json) {
           outputJson(data);
@@ -108,7 +117,7 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
             outputTable(
               ["Price ID", "Amount", "Type", "Active", "Lookup Key"],
               data.prices.map((price) => [
-                price.stripePriceId,
+                price.priceId,
                 formatAmount(price.unitAmount, price.currency),
                 price.type,
                 price.active ? "Yes" : "No",
@@ -118,11 +127,20 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
           }
         }
 
-        await trackPaymentUsage("products.get", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("products.get", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("products.get", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "products.get",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
@@ -145,7 +163,7 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const request: CreatePaymentProductBody = { name: opts.name };
+        const request: CreateStripeProductBody = { name: opts.name };
         const description = nullableString(opts.description);
         const active = parseBooleanOption(opts.active, "--active");
         const metadata = parseMetadataOption(opts.metadata);
@@ -156,21 +174,28 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
           request.idempotencyKey = opts.idempotencyKey;
         }
 
-        const data = await createPaymentProduct(environment, request);
+        const data = await createStripeProduct(environment, request);
 
         if (json) {
           outputJson(data);
         } else {
-          outputSuccess(
-            `Stripe product created: ${data.product.stripeProductId}`,
-          );
+          outputSuccess(`Stripe product created: ${data.product.productId}`);
         }
 
-        await trackPaymentUsage("products.create", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("products.create", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("products.create", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "products.create",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
@@ -192,7 +217,7 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
         const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const request: UpdatePaymentProductBody = {};
+        const request: UpdateStripeProductBody = {};
         const description = nullableString(opts.description);
         const active = parseBooleanOption(opts.active, "--active");
         const metadata = parseMetadataOption(opts.metadata);
@@ -207,25 +232,28 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
           );
         }
 
-        const data = await updatePaymentProduct(
-          environment,
-          productId,
-          request,
-        );
+        const data = await updateStripeProduct(environment, productId, request);
 
         if (json) {
           outputJson(data);
         } else {
-          outputSuccess(
-            `Stripe product updated: ${data.product.stripeProductId}`,
-          );
+          outputSuccess(`Stripe product updated: ${data.product.productId}`);
         }
 
-        await trackPaymentUsage("products.update", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("products.update", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("products.update", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "products.update",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });
@@ -256,19 +284,28 @@ export function registerPaymentsProductsCommand(paymentsCmd: Command): void {
           if (prompts.isCancel(confirm) || !confirm) process.exit(0);
         }
 
-        const data = await deletePaymentProduct(environment, productId);
+        const data = await deleteStripeProduct(environment, productId);
 
         if (json) {
           outputJson(data);
         } else {
-          outputSuccess(`Stripe product deleted: ${data.stripeProductId}`);
+          outputSuccess(`Stripe product deleted: ${data.productId}`);
         }
 
-        await trackPaymentUsage("products.delete", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("products.delete", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("products.delete", true, {
+          provider: "stripe",
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "products.delete",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/status.ts
+++ b/src/commands/payments/status.ts
@@ -17,9 +17,9 @@ export function registerPaymentsStatusCommand(
     .command("status")
     .description("Show payment connection, sync, and webhook status")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         if (provider === "stripe") {
           const data = await getStripePaymentsStatus();

--- a/src/commands/payments/status.ts
+++ b/src/commands/payments/status.ts
@@ -1,43 +1,91 @@
-import type { Command } from 'commander';
-import { getPaymentsStatus } from '../../lib/api/payments.js';
-import { requireAuth } from '../../lib/credentials.js';
-import { getRootOpts, handleError } from '../../lib/errors.js';
-import { outputJson, outputTable } from '../../lib/output.js';
-import { formatDate, trackPaymentUsage } from './utils.js';
+import type { Command } from "commander";
+import {
+  getRazorpayPaymentsStatus,
+  getStripePaymentsStatus,
+} from "../../lib/api/payments.js";
+import type { PaymentProvider } from "@insforge/shared-schemas";
+import { requireAuth } from "../../lib/credentials.js";
+import { getRootOpts, handleError } from "../../lib/errors.js";
+import { outputJson, outputTable } from "../../lib/output.js";
+import { formatDate, trackPaymentUsage } from "./utils.js";
 
-export function registerPaymentsStatusCommand(paymentsCmd: Command): void {
+export function registerPaymentsStatusCommand(
+  paymentsCmd: Command,
+  provider: PaymentProvider,
+): void {
   paymentsCmd
-    .command('status')
-    .description('Show Stripe payment connection, sync, and webhook status')
-    .action(async (_opts, cmd) => {
+    .command("status")
+    .description("Show payment connection, sync, and webhook status")
+    .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
         await requireAuth();
 
-        const data = await getPaymentsStatus();
+        if (provider === "stripe") {
+          const data = await getStripePaymentsStatus();
 
-        if (json) {
-          outputJson(data);
-        } else if (data.connections.length === 0) {
-          console.log('No Stripe payment environments found.');
+          if (json) {
+            outputJson(data);
+          } else if (data.connections.length === 0) {
+            console.log("No Stripe payment environments found.");
+          } else {
+            outputTable(
+              [
+                "Env",
+                "Status",
+                "Key",
+                "Account",
+                "Webhook",
+                "Last Sync",
+                "Synced At",
+              ],
+              data.connections.map((connection) => [
+                connection.environment,
+                connection.status,
+                connection.maskedKey ?? "-",
+                connection.accountId ?? "-",
+                connection.webhookEndpointId ? "Configured" : "-",
+                connection.lastSyncStatus ?? "-",
+                formatDate(connection.lastSyncedAt),
+              ]),
+            );
+          }
         } else {
-          outputTable(
-            ['Env', 'Status', 'Key', 'Account', 'Webhook', 'Last Sync', 'Synced At'],
-            data.connections.map((connection) => [
-              connection.environment,
-              connection.status,
-              connection.maskedKey ?? '-',
-              connection.stripeAccountId ?? '-',
-              connection.webhookEndpointId ? 'Configured' : '-',
-              connection.lastSyncStatus ?? '-',
-              formatDate(connection.lastSyncedAt),
-            ]),
-          );
+          const data = await getRazorpayPaymentsStatus();
+
+          if (json) {
+            outputJson(data);
+          } else if (data.razorpayConnections.length === 0) {
+            console.log("No Razorpay payment environments found.");
+          } else {
+            outputTable(
+              [
+                "Env",
+                "Status",
+                "Key",
+                "Account",
+                "Merchant",
+                "Webhook",
+                "Last Sync",
+                "Synced At",
+              ],
+              data.razorpayConnections.map((connection) => [
+                connection.environment,
+                connection.status,
+                connection.maskedKey ?? "-",
+                connection.accountId ?? "-",
+                connection.merchantName ?? "-",
+                connection.webhookEndpointUrl ? "Manual" : "-",
+                connection.lastSyncStatus ?? "-",
+                formatDate(connection.lastSyncedAt),
+              ]),
+            );
+          }
         }
 
-        await trackPaymentUsage('status', true);
+        await trackPaymentUsage("status", true, { provider });
       } catch (err) {
-        await trackPaymentUsage('status', false);
+        await trackPaymentUsage("status", false, { provider }, err);
         handleError(err, json);
       }
     });

--- a/src/commands/payments/subscriptions.ts
+++ b/src/commands/payments/subscriptions.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { listSubscriptions } from "../../lib/api/payments.js";
+import {
+  listRazorpaySubscriptions,
+  listStripeSubscriptions,
+} from "../../lib/api/payments.js";
+import type { PaymentProvider } from "@insforge/shared-schemas";
 import { requireAuth } from "../../lib/credentials.js";
 import { getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputTable } from "../../lib/output.js";
@@ -10,18 +14,29 @@ import {
   trackPaymentUsage,
 } from "./utils.js";
 
+function formatSubject(
+  subjectType: string | null | undefined,
+  subjectId: string | null | undefined,
+): string {
+  return subjectType && subjectId ? `${subjectType}:${subjectId}` : "-";
+}
+
 export function registerPaymentsSubscriptionsCommand(
   paymentsCmd: Command,
+  provider: PaymentProvider,
 ): void {
   paymentsCmd
     .command("subscriptions")
-    .description("List mirrored Stripe subscriptions")
+    .description("List mirrored payment provider subscriptions")
     .requiredOption(
       "--environment <environment>",
-      "Stripe environment: test or live",
+      "Payment environment: test or live",
     )
-    .option("--subject-type <type>", "Filter by billing subject type")
-    .option("--subject-id <id>", "Filter by billing subject id")
+    .option("--subject-type <type>", "Filter by app billing subject type")
+    .option(
+      "--subject-id <id>",
+      "Filter by app billing subject id, not provider id",
+    )
     .option("--limit <limit>", "Maximum rows to return (1-100)", "50")
     .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
@@ -29,9 +44,7 @@ export function registerPaymentsSubscriptionsCommand(
         const environment = parseEnvironment(opts.environment);
         const limit =
           parseIntegerOption(opts.limit, "--limit", { min: 1, max: 100 }) ?? 50;
-        await requireAuth();
-
-        const data = await listSubscriptions(environment, {
+        const request = {
           limit,
           ...(opts.subjectType !== undefined
             ? { subjectType: opts.subjectType }
@@ -39,40 +52,83 @@ export function registerPaymentsSubscriptionsCommand(
           ...(opts.subjectId !== undefined
             ? { subjectId: opts.subjectId }
             : {}),
-        });
+        };
+        await requireAuth();
 
-        if (json) {
-          outputJson(data);
-        } else if (data.subscriptions.length === 0) {
-          console.log("No Stripe subscriptions found.");
+        if (provider === "stripe") {
+          const data = await listStripeSubscriptions(environment, request);
+
+          if (json) {
+            outputJson(data);
+          } else if (data.subscriptions.length === 0) {
+            console.log("No Stripe subscriptions found.");
+          } else {
+            outputTable(
+              [
+                "Subscription ID",
+                "Customer",
+                "Subject",
+                "Status",
+                "Items",
+                "Period End",
+              ],
+              data.subscriptions.map((subscription) => [
+                subscription.subscriptionId,
+                subscription.customerId ?? "-",
+                formatSubject(subscription.subjectType, subscription.subjectId),
+                subscription.status,
+                String(subscription.items?.length ?? 0),
+                formatDate(subscription.currentPeriodEnd),
+              ]),
+            );
+          }
         } else {
-          outputTable(
-            [
-              "Subscription ID",
-              "Customer",
-              "Subject",
-              "Status",
-              "Items",
-              "Period End",
-            ],
-            data.subscriptions.map((subscription) => [
-              subscription.stripeSubscriptionId,
-              subscription.stripeCustomerId,
-              subscription.subjectType && subscription.subjectId
-                ? `${subscription.subjectType}:${subscription.subjectId}`
-                : "-",
-              subscription.status,
-              String(subscription.items?.length ?? 0),
-              formatDate(subscription.currentPeriodEnd),
-            ]),
-          );
+          const data = await listRazorpaySubscriptions(environment, request);
+
+          if (json) {
+            outputJson(data);
+          } else if (data.subscriptions.length === 0) {
+            console.log("No Razorpay subscriptions found.");
+          } else {
+            outputTable(
+              [
+                "Subscription ID",
+                "Plan ID",
+                "Customer",
+                "Subject",
+                "Status",
+                "Paid",
+                "Remaining",
+                "Current End",
+              ],
+              data.subscriptions.map((subscription) => [
+                subscription.subscriptionId,
+                subscription.planId,
+                subscription.customerId ?? "-",
+                formatSubject(subscription.subjectType, subscription.subjectId),
+                subscription.status,
+                String(subscription.paidCount ?? "-"),
+                String(subscription.remainingCount ?? "-"),
+                formatDate(subscription.currentEnd),
+              ]),
+            );
+          }
         }
 
-        await trackPaymentUsage("subscriptions", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("subscriptions", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("subscriptions", true, {
+          provider,
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "subscriptions",
+          false,
+          {
+            provider,
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/subscriptions.ts
+++ b/src/commands/payments/subscriptions.ts
@@ -39,7 +39,7 @@ export function registerPaymentsSubscriptionsCommand(
     )
     .option("--limit <limit>", "Maximum rows to return (1-100)", "50")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
         const limit =
@@ -53,7 +53,7 @@ export function registerPaymentsSubscriptionsCommand(
             ? { subjectId: opts.subjectId }
             : {}),
         };
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         if (provider === "stripe") {
           const data = await listStripeSubscriptions(environment, request);

--- a/src/commands/payments/sync.ts
+++ b/src/commands/payments/sync.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { syncPayments } from "../../lib/api/payments.js";
+import {
+  syncRazorpayPayments,
+  syncStripePayments,
+} from "../../lib/api/payments.js";
+import type { PaymentProvider } from "@insforge/shared-schemas";
 import { requireAuth } from "../../lib/credentials.js";
 import { getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
@@ -9,15 +13,16 @@ import {
   trackPaymentUsage,
 } from "./utils.js";
 
-export function registerPaymentsSyncCommand(paymentsCmd: Command): void {
+export function registerPaymentsSyncCommand(
+  paymentsCmd: Command,
+  provider: PaymentProvider,
+): void {
   paymentsCmd
     .command("sync")
-    .description(
-      "Sync configured Stripe products, prices, customers, and subscriptions",
-    )
+    .description("Sync configured payment provider data")
     .option(
       "--environment <environment>",
-      "Stripe environment: test, live, or all",
+      "Payment environment: test, live, or all",
       "all",
     )
     .action(async (opts, cmd) => {
@@ -26,43 +31,85 @@ export function registerPaymentsSyncCommand(paymentsCmd: Command): void {
         const environment = parseEnvironmentOrAll(opts.environment);
         await requireAuth();
 
-        const data = await syncPayments(environment);
+        if (provider === "stripe") {
+          const data = await syncStripePayments(environment);
 
-        if (json) {
-          outputJson(data);
-        } else if (data.results.length === 0) {
-          console.log("No configured Stripe environments to sync.");
+          if (json) {
+            outputJson(data);
+          } else if (data.results.length === 0) {
+            console.log("No configured Stripe environments to sync.");
+          } else {
+            outputTable(
+              [
+                "Env",
+                "Status",
+                "Products",
+                "Prices",
+                "Customers",
+                "Subscriptions",
+                "Unmapped",
+                "Synced At",
+              ],
+              data.results.map((result) => [
+                result.environment,
+                result.connection.lastSyncStatus ?? result.connection.status,
+                String(result.connection.lastSyncCounts.products ?? 0),
+                String(result.connection.lastSyncCounts.prices ?? 0),
+                String(result.connection.lastSyncCounts.customers ?? 0),
+                String(result.subscriptions?.synced ?? 0),
+                String(result.subscriptions?.unmapped ?? 0),
+                formatDate(result.connection.lastSyncedAt),
+              ]),
+            );
+            outputSuccess("Stripe payments synced.");
+          }
         } else {
-          outputTable(
-            [
-              "Env",
-              "Status",
-              "Products",
-              "Prices",
-              "Customers",
-              "Subscriptions",
-              "Unmapped",
-              "Synced At",
-            ],
-            data.results.map((result) => [
-              result.environment,
-              result.connection.lastSyncStatus ?? result.connection.status,
-              String(result.connection.lastSyncCounts.products ?? 0),
-              String(result.connection.lastSyncCounts.prices ?? 0),
-              String(result.connection.lastSyncCounts.customers ?? 0),
-              String(result.subscriptions?.synced ?? 0),
-              String(result.subscriptions?.unmapped ?? 0),
-              formatDate(result.connection.lastSyncedAt),
-            ]),
-          );
-          outputSuccess("Stripe payments synced.");
+          const data = await syncRazorpayPayments(environment);
+
+          if (json) {
+            outputJson(data);
+          } else if (data.results.length === 0) {
+            console.log("No configured Razorpay environments to sync.");
+          } else {
+            outputTable(
+              [
+                "Env",
+                "Status",
+                "Items",
+                "Plans",
+                "Customers",
+                "Subscriptions",
+                "Invoices",
+                "Payments",
+                "Synced At",
+              ],
+              data.results.map((result) => [
+                result.environment,
+                result.status,
+                String(result.syncCounts.items),
+                String(result.syncCounts.plans),
+                String(result.syncCounts.customers),
+                String(result.syncCounts.subscriptions),
+                String(result.syncCounts.invoices),
+                String(result.syncCounts.payments),
+                formatDate(result.connection.lastSyncedAt),
+              ]),
+            );
+            outputSuccess("Razorpay payments synced.");
+          }
         }
 
-        await trackPaymentUsage("sync", true, { environment });
+        await trackPaymentUsage("sync", true, { provider, environment });
       } catch (err) {
-        await trackPaymentUsage("sync", false, {
-          environment: opts.environment,
-        });
+        await trackPaymentUsage(
+          "sync",
+          false,
+          {
+            provider,
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/sync.ts
+++ b/src/commands/payments/sync.ts
@@ -26,10 +26,10 @@ export function registerPaymentsSyncCommand(
       "all",
     )
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironmentOrAll(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         if (provider === "stripe") {
           const data = await syncStripePayments(environment);

--- a/src/commands/payments/transactions.test.ts
+++ b/src/commands/payments/transactions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { getTransactionTimestamp } from "./transactions.js";
+
+type TransactionInput = Parameters<typeof getTransactionTimestamp>[0];
+
+function transaction(
+  overrides: Record<string, unknown> = {},
+): TransactionInput {
+  return {
+    type: "payment",
+    status: "paid",
+    amount: 1000,
+    amountRefunded: 0,
+    currency: "usd",
+    providerCustomerId: "cus_123",
+    customerEmailSnapshot: null,
+    providerReferenceType: "payment_intent",
+    providerReferenceId: "pi_123",
+    subjectType: "team",
+    subjectId: "team_123",
+    paidAt: "2026-01-01T00:00:00.000Z",
+    failedAt: null,
+    refundedAt: null,
+    providerCreatedAt: "2025-12-31T00:00:00.000Z",
+    createdAt: "2025-12-30T00:00:00.000Z",
+    ...overrides,
+  } as TransactionInput;
+}
+
+describe("getTransactionTimestamp", () => {
+  it("prefers refund time for refunded transactions", () => {
+    expect(
+      getTransactionTimestamp(
+        transaction({
+          status: "refunded",
+          refundedAt: "2026-01-02T00:00:00.000Z",
+        }),
+      ),
+    ).toBe("2026-01-02T00:00:00.000Z");
+  });
+
+  it("prefers failure time for failed transactions", () => {
+    expect(
+      getTransactionTimestamp(
+        transaction({
+          status: "failed",
+          failedAt: "2026-01-03T00:00:00.000Z",
+        }),
+      ),
+    ).toBe("2026-01-03T00:00:00.000Z");
+  });
+
+  it("uses paid time for non-refund successful transactions", () => {
+    expect(getTransactionTimestamp(transaction({ status: "paid" }))).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+});

--- a/src/commands/payments/transactions.ts
+++ b/src/commands/payments/transactions.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
-import { listPaymentHistory } from "../../lib/api/payments.js";
+import { listPaymentTransactions } from "../../lib/api/payments.js";
+import type { PaymentProvider } from "@insforge/shared-schemas";
 import { requireAuth } from "../../lib/credentials.js";
 import { getRootOpts, handleError } from "../../lib/errors.js";
 import { outputJson, outputTable } from "../../lib/output.js";
@@ -11,16 +12,22 @@ import {
   trackPaymentUsage,
 } from "./utils.js";
 
-export function registerPaymentsHistoryCommand(paymentsCmd: Command): void {
+export function registerPaymentsTransactionsCommand(
+  paymentsCmd: Command,
+  provider: PaymentProvider,
+): void {
   paymentsCmd
-    .command("history")
-    .description("List mirrored Stripe payment history")
+    .command("transactions")
+    .description("List mirrored payment transactions")
     .requiredOption(
       "--environment <environment>",
-      "Stripe environment: test or live",
+      "Payment environment: test or live",
     )
-    .option("--subject-type <type>", "Filter by billing subject type")
-    .option("--subject-id <id>", "Filter by billing subject id")
+    .option("--subject-type <type>", "Filter by app billing subject type")
+    .option(
+      "--subject-id <id>",
+      "Filter by app billing subject id, not provider id",
+    )
     .option("--limit <limit>", "Maximum rows to return (1-100)", "50")
     .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
@@ -30,7 +37,7 @@ export function registerPaymentsHistoryCommand(paymentsCmd: Command): void {
           parseIntegerOption(opts.limit, "--limit", { min: 1, max: 100 }) ?? 50;
         await requireAuth();
 
-        const data = await listPaymentHistory(environment, {
+        const data = await listPaymentTransactions(provider, environment, {
           limit,
           ...(opts.subjectType !== undefined
             ? { subjectType: opts.subjectType }
@@ -42,8 +49,8 @@ export function registerPaymentsHistoryCommand(paymentsCmd: Command): void {
 
         if (json) {
           outputJson(data);
-        } else if (data.paymentHistory.length === 0) {
-          console.log("No Stripe payment history found.");
+        } else if (data.transactions.length === 0) {
+          console.log(`No ${provider} transactions found.`);
         } else {
           outputTable(
             [
@@ -51,38 +58,48 @@ export function registerPaymentsHistoryCommand(paymentsCmd: Command): void {
               "Status",
               "Subject",
               "Amount",
+              "Refunded",
               "Customer",
-              "Stripe Object",
+              "Provider Object",
               "When",
             ],
-            data.paymentHistory.map((entry) => [
+            data.transactions.map((entry) => [
               entry.type,
               entry.status,
               entry.subjectType && entry.subjectId
                 ? `${entry.subjectType}:${entry.subjectId}`
                 : "-",
               formatAmount(entry.amount, entry.currency),
-              entry.stripeCustomerId ?? "-",
-              entry.stripeCheckoutSessionId ??
-                entry.stripeInvoiceId ??
-                entry.stripePaymentIntentId ??
-                entry.stripeRefundId ??
-                "-",
+              formatAmount(entry.amountRefunded, entry.currency),
+              entry.providerCustomerId ?? entry.customerEmailSnapshot ?? "-",
+              entry.providerReferenceType && entry.providerReferenceId
+                ? `${entry.providerReferenceType}:${entry.providerReferenceId}`
+                : (entry.providerReferenceId ?? "-"),
               formatDate(
                 entry.paidAt ??
                   entry.failedAt ??
                   entry.refundedAt ??
-                  entry.stripeCreatedAt,
+                  entry.providerCreatedAt ??
+                  entry.createdAt,
               ),
             ]),
           );
         }
 
-        await trackPaymentUsage("history", true, { environment });
-      } catch (err) {
-        await trackPaymentUsage("history", false, {
-          environment: opts.environment,
+        await trackPaymentUsage("transactions", true, {
+          provider,
+          environment,
         });
+      } catch (err) {
+        await trackPaymentUsage(
+          "transactions",
+          false,
+          {
+            provider,
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/transactions.ts
+++ b/src/commands/payments/transactions.ts
@@ -12,6 +12,27 @@ import {
   trackPaymentUsage,
 } from "./utils.js";
 
+type PaymentTransaction = Awaited<
+  ReturnType<typeof listPaymentTransactions>
+>["transactions"][number];
+
+export function getTransactionTimestamp(
+  entry: PaymentTransaction,
+): string | null {
+  if (String(entry.status).includes("refund")) {
+    return (
+      entry.refundedAt ??
+      entry.paidAt ??
+      entry.providerCreatedAt ??
+      entry.createdAt
+    );
+  }
+  if (entry.status === "failed") {
+    return entry.failedAt ?? entry.providerCreatedAt ?? entry.createdAt;
+  }
+  return entry.paidAt ?? entry.providerCreatedAt ?? entry.createdAt;
+}
+
 export function registerPaymentsTransactionsCommand(
   paymentsCmd: Command,
   provider: PaymentProvider,
@@ -30,12 +51,12 @@ export function registerPaymentsTransactionsCommand(
     )
     .option("--limit <limit>", "Maximum rows to return (1-100)", "50")
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
         const limit =
           parseIntegerOption(opts.limit, "--limit", { min: 1, max: 100 }) ?? 50;
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await listPaymentTransactions(provider, environment, {
           limit,
@@ -75,13 +96,7 @@ export function registerPaymentsTransactionsCommand(
               entry.providerReferenceType && entry.providerReferenceId
                 ? `${entry.providerReferenceType}:${entry.providerReferenceId}`
                 : (entry.providerReferenceId ?? "-"),
-              formatDate(
-                entry.paidAt ??
-                  entry.failedAt ??
-                  entry.refundedAt ??
-                  entry.providerCreatedAt ??
-                  entry.createdAt,
-              ),
+              formatDate(getTransactionTimestamp(entry)),
             ]),
           );
         }

--- a/src/commands/payments/utils.test.ts
+++ b/src/commands/payments/utils.test.ts
@@ -17,7 +17,12 @@ const analyticsMock = vi.hoisted(() => ({
 vi.mock("../../lib/analytics.js", () => analyticsMock);
 
 import { CLIError } from "../../lib/errors.js";
-import { trackPaymentUsage } from "./utils.js";
+import {
+  nullableString,
+  parseRequiredIntegerOption,
+  parseRequiredRazorpayPlanPeriod,
+  trackPaymentUsage,
+} from "./utils.js";
 
 describe("payment command telemetry", () => {
   beforeEach(() => {
@@ -31,7 +36,7 @@ describe("payment command telemetry", () => {
     });
   });
 
-  it("includes provider and structured error fields for failed payment commands", async () => {
+  it("includes provider and structured error fields without raw messages", async () => {
     const error = new CLIError(
       `${"failed ".repeat(100)}done`,
       5,
@@ -63,8 +68,52 @@ describe("payment command telemetry", () => {
     const properties = analyticsMock.trackPayments.mock.calls[0]?.[2] as
       | Record<string, unknown>
       | undefined;
-    expect(properties?.error_message).toMatch(/^failed failed/);
-    expect(String(properties?.error_message).length).toBeLessThanOrEqual(503);
+    expect(properties).not.toHaveProperty("error_message");
     expect(analyticsMock.shutdownAnalytics).toHaveBeenCalledOnce();
+  });
+
+  it("does not send raw invalid environment telemetry", async () => {
+    await trackPaymentUsage(
+      "sync",
+      false,
+      { provider: "stripe", environment: "prod free text" },
+      new Error("user entered free text"),
+    );
+
+    const properties = analyticsMock.trackPayments.mock.calls[0]?.[2] as
+      | Record<string, unknown>
+      | undefined;
+    expect(properties).toEqual(
+      expect.objectContaining({
+        success: false,
+        provider: "stripe",
+        environment_valid: false,
+        error_name: "Error",
+      }),
+    );
+    expect(properties).not.toHaveProperty("environment");
+    expect(properties).not.toHaveProperty("error_message");
+  });
+});
+
+describe("payment command parsers", () => {
+  it("normalizes nullable strings", () => {
+    expect(nullableString(undefined)).toBeUndefined();
+    expect(nullableString("null")).toBeNull();
+    expect(nullableString("value")).toBe("value");
+  });
+
+  it("parses required integer options without defaulting missing values", () => {
+    expect(parseRequiredIntegerOption("0", "--amount", { min: 0 })).toBe(0);
+    expect(() => parseRequiredIntegerOption(undefined, "--amount")).toThrow(
+      "Provide --amount.",
+    );
+  });
+
+  it("parses required Razorpay plan periods", () => {
+    expect(parseRequiredRazorpayPlanPeriod("monthly")).toBe("monthly");
+    expect(() => parseRequiredRazorpayPlanPeriod(undefined)).toThrow(
+      "Provide --period.",
+    );
   });
 });

--- a/src/commands/payments/utils.test.ts
+++ b/src/commands/payments/utils.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const configMock = vi.hoisted(() => ({
+  getProjectConfig: vi.fn(() => ({
+    project_id: "p1",
+    project_name: "Test Project",
+    org_id: "o1",
+    region: "us",
+  })),
+}));
+vi.mock("../../lib/config.js", () => configMock);
+
+const analyticsMock = vi.hoisted(() => ({
+  trackPayments: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+vi.mock("../../lib/analytics.js", () => analyticsMock);
+
+import { CLIError } from "../../lib/errors.js";
+import { trackPaymentUsage } from "./utils.js";
+
+describe("payment command telemetry", () => {
+  beforeEach(() => {
+    analyticsMock.trackPayments.mockClear();
+    analyticsMock.shutdownAnalytics.mockClear();
+    configMock.getProjectConfig.mockReturnValue({
+      project_id: "p1",
+      project_name: "Test Project",
+      org_id: "o1",
+      region: "us",
+    });
+  });
+
+  it("includes provider and structured error fields for failed payment commands", async () => {
+    const error = new CLIError(
+      `${"failed ".repeat(100)}done`,
+      5,
+      "PAYMENT_ERROR",
+      502,
+    );
+
+    await trackPaymentUsage(
+      "sync",
+      false,
+      { provider: "razorpay", environment: "test" },
+      error,
+    );
+
+    expect(analyticsMock.trackPayments).toHaveBeenCalledWith(
+      "sync",
+      expect.objectContaining({ project_id: "p1" }),
+      expect.objectContaining({
+        success: false,
+        provider: "razorpay",
+        environment: "test",
+        error_name: "CLIError",
+        error_code: "PAYMENT_ERROR",
+        exit_code: 5,
+        status_code: 502,
+      }),
+    );
+
+    const properties = analyticsMock.trackPayments.mock.calls[0]?.[2] as
+      | Record<string, unknown>
+      | undefined;
+    expect(properties?.error_message).toMatch(/^failed failed/);
+    expect(String(properties?.error_message).length).toBeLessThanOrEqual(503);
+    expect(analyticsMock.shutdownAnalytics).toHaveBeenCalledOnce();
+  });
+});

--- a/src/commands/payments/utils.ts
+++ b/src/commands/payments/utils.ts
@@ -1,23 +1,65 @@
-import type { StripeEnvironment } from "@insforge/shared-schemas";
+import type {
+  PaymentEnvironment,
+  RazorpayPlanPeriod,
+} from "@insforge/shared-schemas";
 import { getProjectConfig } from "../../lib/config.js";
 import { CLIError } from "../../lib/errors.js";
 import { shutdownAnalytics, trackPayments } from "../../lib/analytics.js";
+
+const MAX_TELEMETRY_ERROR_MESSAGE_LENGTH = 500;
 
 export type PaymentCommandTelemetry = Record<
   string,
   string | number | boolean | undefined
 >;
 
-export function parseEnvironment(value: string): StripeEnvironment {
+function getErrorTelemetry(error: unknown): PaymentCommandTelemetry {
+  const message = error instanceof Error ? error.message : String(error);
+  const truncatedMessage =
+    message.length > MAX_TELEMETRY_ERROR_MESSAGE_LENGTH
+      ? `${message.slice(0, MAX_TELEMETRY_ERROR_MESSAGE_LENGTH)}...`
+      : message;
+
+  return {
+    error_name: error instanceof Error ? error.name : typeof error,
+    error_message: truncatedMessage,
+    ...(error instanceof CLIError
+      ? {
+          error_code: error.code,
+          exit_code: error.exitCode,
+          status_code: error.statusCode,
+        }
+      : {}),
+  };
+}
+
+export function parseEnvironment(value: string): PaymentEnvironment {
   if (value === "test" || value === "live") return value;
   throw new CLIError('Environment must be "test" or "live".');
 }
 
 export function parseEnvironmentOrAll(
   value: string,
-): StripeEnvironment | "all" {
+): PaymentEnvironment | "all" {
   if (value === "all") return value;
   return parseEnvironment(value);
+}
+
+export function parseRazorpayPlanPeriod(
+  value: string | undefined,
+): RazorpayPlanPeriod | undefined {
+  if (value === undefined) return undefined;
+  if (
+    value === "daily" ||
+    value === "weekly" ||
+    value === "monthly" ||
+    value === "yearly"
+  ) {
+    return value;
+  }
+  throw new CLIError(
+    "--period must be one of: daily, weekly, monthly, yearly.",
+  );
 }
 
 export function parseBooleanOption(
@@ -122,6 +164,7 @@ export async function trackPaymentUsage(
   subcommand: string,
   success: boolean,
   properties: PaymentCommandTelemetry = {},
+  error?: unknown,
 ): Promise<void> {
   try {
     const config = getProjectConfig();
@@ -129,6 +172,7 @@ export async function trackPaymentUsage(
       trackPayments(subcommand, config, {
         success,
         ...properties,
+        ...(error !== undefined ? getErrorTelemetry(error) : {}),
       });
     }
   } catch {

--- a/src/commands/payments/utils.ts
+++ b/src/commands/payments/utils.ts
@@ -6,23 +6,49 @@ import { getProjectConfig } from "../../lib/config.js";
 import { CLIError } from "../../lib/errors.js";
 import { shutdownAnalytics, trackPayments } from "../../lib/analytics.js";
 
-const MAX_TELEMETRY_ERROR_MESSAGE_LENGTH = 500;
-
 export type PaymentCommandTelemetry = Record<
   string,
   string | number | boolean | undefined
 >;
 
-function getErrorTelemetry(error: unknown): PaymentCommandTelemetry {
-  const message = error instanceof Error ? error.message : String(error);
-  const truncatedMessage =
-    message.length > MAX_TELEMETRY_ERROR_MESSAGE_LENGTH
-      ? `${message.slice(0, MAX_TELEMETRY_ERROR_MESSAGE_LENGTH)}...`
-      : message;
+function sanitizePaymentTelemetry(
+  properties: PaymentCommandTelemetry,
+): PaymentCommandTelemetry {
+  const sanitized: PaymentCommandTelemetry = {};
 
+  if (properties.provider === "stripe" || properties.provider === "razorpay") {
+    sanitized.provider = properties.provider;
+  }
+
+  if (
+    properties.environment === "test" ||
+    properties.environment === "live" ||
+    properties.environment === "all"
+  ) {
+    sanitized.environment = properties.environment;
+  } else if (properties.environment !== undefined) {
+    sanitized.environment_valid = false;
+  }
+
+  if (typeof properties.error_name === "string") {
+    sanitized.error_name = properties.error_name;
+  }
+  if (typeof properties.error_code === "string") {
+    sanitized.error_code = properties.error_code;
+  }
+  if (typeof properties.exit_code === "number") {
+    sanitized.exit_code = properties.exit_code;
+  }
+  if (typeof properties.status_code === "number") {
+    sanitized.status_code = properties.status_code;
+  }
+
+  return sanitized;
+}
+
+function getErrorTelemetry(error: unknown): PaymentCommandTelemetry {
   return {
     error_name: error instanceof Error ? error.name : typeof error,
-    error_message: truncatedMessage,
     ...(error instanceof CLIError
       ? {
           error_code: error.code,
@@ -62,6 +88,21 @@ export function parseRazorpayPlanPeriod(
   );
 }
 
+export function parseRequiredRazorpayPlanPeriod(
+  value: string | undefined,
+): RazorpayPlanPeriod {
+  const period = parseRazorpayPlanPeriod(value);
+  if (period === undefined) throw new CLIError("Provide --period.");
+  return period;
+}
+
+export function nullableString(
+  value: string | undefined,
+): string | null | undefined {
+  if (value === undefined) return undefined;
+  return value === "null" ? null : value;
+}
+
 export function parseBooleanOption(
   value: string | undefined,
   flagName: string,
@@ -95,8 +136,20 @@ export function parseIntegerOption(
   return parsed;
 }
 
-export function parseMetadataOption(
+export function parseRequiredIntegerOption(
   value: string | undefined,
+  flagName: string,
+  options: { min?: number; max?: number } = {},
+): number {
+  const parsed = parseIntegerOption(value, flagName, options);
+  if (parsed === undefined) throw new CLIError(`Provide ${flagName}.`);
+  return parsed;
+}
+
+function parseStringRecordOption(
+  value: string | undefined,
+  flagName: string,
+  fieldName: string,
 ): Record<string, string> | undefined {
   if (value === undefined) return undefined;
 
@@ -104,22 +157,34 @@ export function parseMetadataOption(
   try {
     parsed = JSON.parse(value);
   } catch {
-    throw new CLIError("Invalid JSON for --metadata.");
+    throw new CLIError(`Invalid JSON for ${flagName}.`);
   }
 
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new CLIError("--metadata must be a JSON object.");
+    throw new CLIError(`${flagName} must be a JSON object.`);
   }
 
-  const metadata: Record<string, string> = {};
+  const result: Record<string, string> = {};
   for (const [key, raw] of Object.entries(parsed)) {
     if (typeof raw !== "string") {
-      throw new CLIError(`Metadata value for "${key}" must be a string.`);
+      throw new CLIError(`${fieldName} value for "${key}" must be a string.`);
     }
-    metadata[key] = raw;
+    result[key] = raw;
   }
 
-  return metadata;
+  return result;
+}
+
+export function parseMetadataOption(
+  value: string | undefined,
+): Record<string, string> | undefined {
+  return parseStringRecordOption(value, "--metadata", "Metadata");
+}
+
+export function parseNotesOption(
+  value: string | undefined,
+): Record<string, string> | undefined {
+  return parseStringRecordOption(value, "--notes", "Notes");
 }
 
 export function formatDate(value: string | null | undefined): string {
@@ -171,8 +236,10 @@ export async function trackPaymentUsage(
     if (config) {
       trackPayments(subcommand, config, {
         success,
-        ...properties,
-        ...(error !== undefined ? getErrorTelemetry(error) : {}),
+        ...sanitizePaymentTelemetry({
+          ...properties,
+          ...(error !== undefined ? getErrorTelemetry(error) : {}),
+        }),
       });
     }
   } catch {

--- a/src/commands/payments/webhooks.ts
+++ b/src/commands/payments/webhooks.ts
@@ -1,44 +1,61 @@
-import type { Command } from 'commander';
-import { configurePaymentWebhook } from '../../lib/api/payments.js';
-import { requireAuth } from '../../lib/credentials.js';
-import { getRootOpts, handleError } from '../../lib/errors.js';
-import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
-import { formatDate, parseEnvironment, trackPaymentUsage } from './utils.js';
+import type { Command } from "commander";
+import { configureStripeWebhook } from "../../lib/api/payments.js";
+import { requireAuth } from "../../lib/credentials.js";
+import { getRootOpts, handleError } from "../../lib/errors.js";
+import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
+import { formatDate, parseEnvironment, trackPaymentUsage } from "./utils.js";
 
 export function registerPaymentsWebhooksCommand(paymentsCmd: Command): void {
   const webhooksCmd = paymentsCmd
-    .command('webhooks')
-    .description('Manage InsForge-managed Stripe webhooks');
+    .command("webhooks")
+    .description("Manage Stripe webhooks");
 
   webhooksCmd
-    .command('configure <environment>')
-    .description('Create or recreate the managed Stripe webhook endpoint')
-    .action(async (environmentValue: string, _opts, cmd) => {
+    .command("configure")
+    .description("Create or recreate the managed Stripe webhook endpoint")
+    .requiredOption(
+      "--environment <environment>",
+      "Stripe environment: test or live",
+    )
+    .action(async (opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
-        const environment = parseEnvironment(environmentValue);
+        const environment = parseEnvironment(opts.environment);
         await requireAuth();
 
-        const data = await configurePaymentWebhook(environment);
+        const data = await configureStripeWebhook(environment);
 
         if (json) {
           outputJson(data);
         } else {
           outputTable(
-            ['Env', 'Webhook ID', 'URL', 'Configured At'],
-            [[
-              data.connection.environment,
-              data.connection.webhookEndpointId ?? '-',
-              data.connection.webhookEndpointUrl ?? '-',
-              formatDate(data.connection.webhookConfiguredAt),
-            ]],
+            ["Env", "Webhook ID", "URL", "Configured At"],
+            [
+              [
+                data.connection.environment,
+                data.connection.webhookEndpointId ?? "-",
+                data.connection.webhookEndpointUrl ?? "-",
+                formatDate(data.connection.webhookConfiguredAt),
+              ],
+            ],
           );
           outputSuccess(`Stripe ${environment} webhook configured.`);
         }
 
-        await trackPaymentUsage('webhooks.configure', true, { environment });
+        await trackPaymentUsage("webhooks.configure", true, {
+          provider: "stripe",
+          environment,
+        });
       } catch (err) {
-        await trackPaymentUsage('webhooks.configure', false, { environment: environmentValue });
+        await trackPaymentUsage(
+          "webhooks.configure",
+          false,
+          {
+            provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
         handleError(err, json);
       }
     });

--- a/src/commands/payments/webhooks.ts
+++ b/src/commands/payments/webhooks.ts
@@ -18,10 +18,10 @@ export function registerPaymentsWebhooksCommand(paymentsCmd: Command): void {
       "Stripe environment: test or live",
     )
     .action(async (opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth();
+        await requireAuth(apiUrl);
 
         const data = await configureStripeWebhook(environment);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,7 @@ const diagnoseCmd = program.command('diagnose');
 registerDiagnoseCommands(diagnoseCmd);
 
 // Payments commands
-const paymentsCmd = program.command('payments').description('Manage Stripe payments');
+const paymentsCmd = program.command('payments').description('Manage payments');
 registerPaymentsCommands(paymentsCmd);
 
 // Compute commands

--- a/src/lib/api/payments.test.ts
+++ b/src/lib/api/payments.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ossFetchMock = vi.hoisted(() => vi.fn());
+vi.mock("./oss.js", () => ({
+  ossFetch: ossFetchMock,
+}));
+
+import {
+  createRazorpayItem,
+  createRazorpayPlan,
+  createStripePrice,
+  getStripeProduct,
+  getStripePaymentsStatus,
+  listPaymentTransactions,
+  listRazorpayCatalog,
+  listStripePrices,
+  syncRazorpayPayments,
+  syncStripePayments,
+  updateRazorpayItem,
+} from "./payments.js";
+
+function mockJsonResponse(value: unknown = {}): Response {
+  return {
+    json: async () => value,
+  } as Response;
+}
+
+describe("payments API client", () => {
+  beforeEach(() => {
+    ossFetchMock.mockReset();
+    ossFetchMock.mockResolvedValue(mockJsonResponse());
+  });
+
+  it("builds provider status and sync paths", async () => {
+    await getStripePaymentsStatus();
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/stripe/status",
+    );
+
+    await syncStripePayments("live");
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/stripe/live/sync",
+      { method: "POST" },
+    );
+
+    await syncRazorpayPayments();
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/razorpay/sync",
+      { method: "POST" },
+    );
+  });
+
+  it("builds provider environment catalog paths", async () => {
+    await listRazorpayCatalog("test");
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/razorpay/test/catalog",
+    );
+
+    await listStripePrices("live", "prod_123");
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/stripe/live/catalog/prices?productId=prod_123",
+    );
+  });
+
+  it("encodes path segments for resource operations", async () => {
+    await getStripeProduct("test", "prod/with space");
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/stripe/test/catalog/products/prod%2Fwith%20space",
+    );
+
+    await updateRazorpayItem("live", "item/with space", { active: false });
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/razorpay/live/catalog/items/item%2Fwith%20space",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ active: false }),
+      },
+    );
+  });
+
+  it("sends mutation methods and JSON bodies", async () => {
+    await createStripePrice("test", {
+      productId: "prod_123",
+      currency: "usd",
+      unitAmount: 1000,
+    });
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/stripe/test/catalog/prices",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          productId: "prod_123",
+          currency: "usd",
+          unitAmount: 1000,
+        }),
+      },
+    );
+
+    await createRazorpayItem("test", {
+      name: "Pro",
+      amount: 200000,
+      currency: "inr",
+    });
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/razorpay/test/catalog/items",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Pro",
+          amount: 200000,
+          currency: "inr",
+        }),
+      },
+    );
+
+    await createRazorpayPlan("test", {
+      period: "monthly",
+      interval: 1,
+      item: {
+        name: "Pro",
+        amount: 200000,
+        currency: "inr",
+      },
+    });
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/razorpay/test/catalog/plans",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          period: "monthly",
+          interval: 1,
+          item: {
+            name: "Pro",
+            amount: 200000,
+            currency: "inr",
+          },
+        }),
+      },
+    );
+  });
+
+  it("builds provider-scoped transaction query paths", async () => {
+    await listPaymentTransactions("stripe", "live", {
+      limit: 20,
+      subjectType: "team",
+      subjectId: "team 123",
+    });
+
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/stripe/live/transactions?limit=20&subjectType=team&subjectId=team+123",
+    );
+  });
+});

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -1,31 +1,47 @@
 import { ossFetch } from "./oss.js";
 import type {
-  ArchivePaymentPriceResponse,
-  ConfigurePaymentWebhookResponse,
-  CreatePaymentPriceBody,
-  CreatePaymentProductBody,
-  DeletePaymentProductResponse,
-  GetPaymentPriceResponse,
-  GetPaymentProductResponse,
-  GetPaymentsConfigResponse,
-  GetPaymentsStatusResponse,
-  ListPaymentCatalogResponse,
+  ArchiveStripePriceResponse,
+  ConfigureStripeWebhookResponse,
+  CreateRazorpayItemBody,
+  CreateRazorpayPlanBody,
+  CreateStripePriceBody,
+  CreateStripeProductBody,
+  DeleteStripeProductResponse,
+  GetRazorpayConfigResponse,
+  GetRazorpayStatusResponse,
+  GetStripeConfigResponse,
+  GetStripePriceResponse,
+  GetStripeProductResponse,
+  GetStripeStatusResponse,
   ListPaymentCustomersRequest,
   ListPaymentCustomersResponse,
-  ListPaymentHistoryQuery,
-  ListPaymentHistoryResponse,
-  ListPaymentPricesResponse,
-  ListPaymentProductsResponse,
-  ListSubscriptionsQuery,
-  ListSubscriptionsResponse,
-  MutatePaymentPriceResponse,
-  MutatePaymentProductResponse,
-  StripeEnvironment,
-  SyncPaymentsRequest,
-  SyncPaymentsResponse,
-  UpdatePaymentPriceBody,
-  UpdatePaymentProductBody,
+  ListPaymentTransactionsQuery,
+  ListPaymentTransactionsResponse,
+  ListRazorpayCatalogResponse,
+  ListRazorpaySubscriptionsQuery,
+  ListRazorpaySubscriptionsResponse,
+  ListStripeCatalogResponse,
+  ListStripePricesResponse,
+  ListStripeProductsResponse,
+  ListStripeSubscriptionsQuery,
+  ListStripeSubscriptionsResponse,
+  MutateRazorpayItemResponse,
+  MutateRazorpayPlanResponse,
+  MutateStripePriceResponse,
+  MutateStripeProductResponse,
+  PaymentEnvironment,
+  PaymentProvider,
+  SyncRazorpayPaymentsRequest,
+  SyncRazorpayPaymentsResponse,
+  SyncStripePaymentsRequest,
+  SyncStripePaymentsResponse,
+  UpdateRazorpayItemBody,
+  UpdateStripePriceBody,
+  UpdateStripeProductBody,
+  UpsertRazorpayConfigBody,
+  UpsertStripeConfigBody,
 } from "@insforge/shared-schemas";
+
 type ListPaymentCustomersQuery = Partial<
   Omit<ListPaymentCustomersRequest, "environment">
 >;
@@ -46,87 +62,169 @@ async function readJson<T>(res: Response): Promise<T> {
   return (await res.json()) as T;
 }
 
-function withEnvironmentPath(
-  environment: StripeEnvironment,
+function withProviderPath(provider: PaymentProvider, suffix: string): string {
+  return `/api/payments/${encodeURIComponent(provider)}${suffix}`;
+}
+
+function withProviderEnvironmentPath(
+  provider: PaymentProvider,
+  environment: PaymentEnvironment,
   suffix: string,
 ): string {
-  return `/api/payments/${encodeURIComponent(environment)}${suffix}`;
+  return withProviderPath(
+    provider,
+    `/${encodeURIComponent(environment)}${suffix}`,
+  );
 }
 
-export async function getPaymentsStatus(): Promise<GetPaymentsStatusResponse> {
-  return readJson(await ossFetch("/api/payments/status"));
+export async function getStripePaymentsStatus(): Promise<GetStripeStatusResponse> {
+  return readJson(await ossFetch(withProviderPath("stripe", "/status")));
 }
 
-export async function getPaymentsConfig(): Promise<GetPaymentsConfigResponse> {
-  return readJson(await ossFetch("/api/payments/config"));
+export async function getRazorpayPaymentsStatus(): Promise<GetRazorpayStatusResponse> {
+  return readJson(await ossFetch(withProviderPath("razorpay", "/status")));
+}
+
+export async function getStripePaymentsConfig(): Promise<GetStripeConfigResponse> {
+  return readJson(await ossFetch(withProviderPath("stripe", "/config")));
+}
+
+export async function getRazorpayPaymentsConfig(): Promise<GetRazorpayConfigResponse> {
+  return readJson(await ossFetch(withProviderPath("razorpay", "/config")));
 }
 
 export async function setStripeSecretKey(
-  environment: StripeEnvironment,
+  environment: PaymentEnvironment,
   secretKey: string,
-): Promise<GetPaymentsConfigResponse> {
+): Promise<GetStripeConfigResponse> {
+  const request: UpsertStripeConfigBody = { secretKey };
   return readJson(
-    await ossFetch(withEnvironmentPath(environment, "/config"), {
-      method: "PUT",
-      body: JSON.stringify({ secretKey }),
-    }),
+    await ossFetch(
+      withProviderEnvironmentPath("stripe", environment, "/config"),
+      {
+        method: "PUT",
+        body: JSON.stringify(request),
+      },
+    ),
+  );
+}
+
+export async function setRazorpayKeys(
+  environment: PaymentEnvironment,
+  request: UpsertRazorpayConfigBody,
+): Promise<GetRazorpayConfigResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("razorpay", environment, "/config"),
+      {
+        method: "PUT",
+        body: JSON.stringify(request),
+      },
+    ),
   );
 }
 
 export async function removeStripeSecretKey(
-  environment: StripeEnvironment,
-): Promise<GetPaymentsConfigResponse> {
+  environment: PaymentEnvironment,
+): Promise<GetStripeConfigResponse> {
   return readJson(
-    await ossFetch(withEnvironmentPath(environment, "/config"), {
-      method: "DELETE",
-    }),
+    await ossFetch(
+      withProviderEnvironmentPath("stripe", environment, "/config"),
+      {
+        method: "DELETE",
+      },
+    ),
   );
 }
 
-export async function syncPayments(
-  environment: SyncPaymentsRequest["environment"] = "all",
-): Promise<SyncPaymentsResponse> {
+export async function removeRazorpayKeys(
+  environment: PaymentEnvironment,
+): Promise<GetRazorpayConfigResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("razorpay", environment, "/config"),
+      { method: "DELETE" },
+    ),
+  );
+}
+
+export async function syncStripePayments(
+  environment: SyncStripePaymentsRequest["environment"] = "all",
+): Promise<SyncStripePaymentsResponse> {
   return readJson(
     await ossFetch(
       environment === "all"
-        ? "/api/payments/sync"
-        : withEnvironmentPath(environment, "/sync"),
+        ? withProviderPath("stripe", "/sync")
+        : withProviderEnvironmentPath("stripe", environment, "/sync"),
       { method: "POST" },
     ),
   );
 }
 
-export async function configurePaymentWebhook(
-  environment: StripeEnvironment,
-): Promise<ConfigurePaymentWebhookResponse> {
-  return readJson(
-    await ossFetch(withEnvironmentPath(environment, "/webhook"), {
-      method: "POST",
-    }),
-  );
-}
-
-export async function listPaymentCatalog(
-  environment: StripeEnvironment,
-): Promise<ListPaymentCatalogResponse> {
-  return readJson(await ossFetch(withEnvironmentPath(environment, "/catalog")));
-}
-
-export async function listPaymentProducts(
-  environment: StripeEnvironment,
-): Promise<ListPaymentProductsResponse> {
-  return readJson(
-    await ossFetch(withEnvironmentPath(environment, "/catalog/products")),
-  );
-}
-
-export async function getPaymentProduct(
-  environment: StripeEnvironment,
-  productId: string,
-): Promise<GetPaymentProductResponse> {
+export async function syncRazorpayPayments(
+  environment: SyncRazorpayPaymentsRequest["environment"] = "all",
+): Promise<SyncRazorpayPaymentsResponse> {
   return readJson(
     await ossFetch(
-      withEnvironmentPath(
+      environment === "all"
+        ? withProviderPath("razorpay", "/sync")
+        : withProviderEnvironmentPath("razorpay", environment, "/sync"),
+      { method: "POST" },
+    ),
+  );
+}
+
+export async function configureStripeWebhook(
+  environment: PaymentEnvironment,
+): Promise<ConfigureStripeWebhookResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("stripe", environment, "/webhook"),
+      {
+        method: "POST",
+      },
+    ),
+  );
+}
+
+export async function listStripeCatalog(
+  environment: PaymentEnvironment,
+): Promise<ListStripeCatalogResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("stripe", environment, "/catalog"),
+    ),
+  );
+}
+
+export async function listRazorpayCatalog(
+  environment: PaymentEnvironment,
+): Promise<ListRazorpayCatalogResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("razorpay", environment, "/catalog"),
+    ),
+  );
+}
+
+export async function listStripeProducts(
+  environment: PaymentEnvironment,
+): Promise<ListStripeProductsResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("stripe", environment, "/catalog/products"),
+    ),
+  );
+}
+
+export async function getStripeProduct(
+  environment: PaymentEnvironment,
+  productId: string,
+): Promise<GetStripeProductResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath(
+        "stripe",
         environment,
         `/catalog/products/${encodeURIComponent(productId)}`,
       ),
@@ -134,26 +232,30 @@ export async function getPaymentProduct(
   );
 }
 
-export async function createPaymentProduct(
-  environment: StripeEnvironment,
-  request: CreatePaymentProductBody,
-): Promise<MutatePaymentProductResponse> {
+export async function createStripeProduct(
+  environment: PaymentEnvironment,
+  request: CreateStripeProductBody,
+): Promise<MutateStripeProductResponse> {
   return readJson(
-    await ossFetch(withEnvironmentPath(environment, "/catalog/products"), {
-      method: "POST",
-      body: JSON.stringify(request),
-    }),
+    await ossFetch(
+      withProviderEnvironmentPath("stripe", environment, "/catalog/products"),
+      {
+        method: "POST",
+        body: JSON.stringify(request),
+      },
+    ),
   );
 }
 
-export async function updatePaymentProduct(
-  environment: StripeEnvironment,
+export async function updateStripeProduct(
+  environment: PaymentEnvironment,
   productId: string,
-  request: UpdatePaymentProductBody,
-): Promise<MutatePaymentProductResponse> {
+  request: UpdateStripeProductBody,
+): Promise<MutateStripeProductResponse> {
   return readJson(
     await ossFetch(
-      withEnvironmentPath(
+      withProviderEnvironmentPath(
+        "stripe",
         environment,
         `/catalog/products/${encodeURIComponent(productId)}`,
       ),
@@ -165,13 +267,14 @@ export async function updatePaymentProduct(
   );
 }
 
-export async function deletePaymentProduct(
-  environment: StripeEnvironment,
+export async function deleteStripeProduct(
+  environment: PaymentEnvironment,
   productId: string,
-): Promise<DeletePaymentProductResponse> {
+): Promise<DeleteStripeProductResponse> {
   return readJson(
     await ossFetch(
-      withEnvironmentPath(
+      withProviderEnvironmentPath(
+        "stripe",
         environment,
         `/catalog/products/${encodeURIComponent(productId)}`,
       ),
@@ -180,26 +283,28 @@ export async function deletePaymentProduct(
   );
 }
 
-export async function listPaymentPrices(
-  environment: StripeEnvironment,
-  stripeProductId?: string,
-): Promise<ListPaymentPricesResponse> {
+export async function listStripePrices(
+  environment: PaymentEnvironment,
+  productId?: string,
+): Promise<ListStripePricesResponse> {
   return readJson(
     await ossFetch(
-      withQuery(withEnvironmentPath(environment, "/catalog/prices"), {
-        stripeProductId,
-      }),
+      withQuery(
+        withProviderEnvironmentPath("stripe", environment, "/catalog/prices"),
+        { productId },
+      ),
     ),
   );
 }
 
-export async function getPaymentPrice(
-  environment: StripeEnvironment,
+export async function getStripePrice(
+  environment: PaymentEnvironment,
   priceId: string,
-): Promise<GetPaymentPriceResponse> {
+): Promise<GetStripePriceResponse> {
   return readJson(
     await ossFetch(
-      withEnvironmentPath(
+      withProviderEnvironmentPath(
+        "stripe",
         environment,
         `/catalog/prices/${encodeURIComponent(priceId)}`,
       ),
@@ -207,26 +312,30 @@ export async function getPaymentPrice(
   );
 }
 
-export async function createPaymentPrice(
-  environment: StripeEnvironment,
-  request: CreatePaymentPriceBody,
-): Promise<MutatePaymentPriceResponse> {
+export async function createStripePrice(
+  environment: PaymentEnvironment,
+  request: CreateStripePriceBody,
+): Promise<MutateStripePriceResponse> {
   return readJson(
-    await ossFetch(withEnvironmentPath(environment, "/catalog/prices"), {
-      method: "POST",
-      body: JSON.stringify(request),
-    }),
+    await ossFetch(
+      withProviderEnvironmentPath("stripe", environment, "/catalog/prices"),
+      {
+        method: "POST",
+        body: JSON.stringify(request),
+      },
+    ),
   );
 }
 
-export async function updatePaymentPrice(
-  environment: StripeEnvironment,
+export async function updateStripePrice(
+  environment: PaymentEnvironment,
   priceId: string,
-  request: UpdatePaymentPriceBody,
-): Promise<MutatePaymentPriceResponse> {
+  request: UpdateStripePriceBody,
+): Promise<MutateStripePriceResponse> {
   return readJson(
     await ossFetch(
-      withEnvironmentPath(
+      withProviderEnvironmentPath(
+        "stripe",
         environment,
         `/catalog/prices/${encodeURIComponent(priceId)}`,
       ),
@@ -238,13 +347,14 @@ export async function updatePaymentPrice(
   );
 }
 
-export async function archivePaymentPrice(
-  environment: StripeEnvironment,
+export async function archiveStripePrice(
+  environment: PaymentEnvironment,
   priceId: string,
-): Promise<ArchivePaymentPriceResponse> {
+): Promise<ArchiveStripePriceResponse> {
   return readJson(
     await ossFetch(
-      withEnvironmentPath(
+      withProviderEnvironmentPath(
+        "stripe",
         environment,
         `/catalog/prices/${encodeURIComponent(priceId)}`,
       ),
@@ -253,35 +363,110 @@ export async function archivePaymentPrice(
   );
 }
 
-export async function listSubscriptions(
-  environment: StripeEnvironment,
-  request: ListSubscriptionsQuery,
-): Promise<ListSubscriptionsResponse> {
+export async function createRazorpayItem(
+  environment: PaymentEnvironment,
+  request: CreateRazorpayItemBody,
+): Promise<MutateRazorpayItemResponse> {
   return readJson(
     await ossFetch(
-      withQuery(withEnvironmentPath(environment, "/subscriptions"), request),
+      withProviderEnvironmentPath("razorpay", environment, "/catalog/items"),
+      {
+        method: "POST",
+        body: JSON.stringify(request),
+      },
+    ),
+  );
+}
+
+export async function updateRazorpayItem(
+  environment: PaymentEnvironment,
+  itemId: string,
+  request: UpdateRazorpayItemBody,
+): Promise<MutateRazorpayItemResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath(
+        "razorpay",
+        environment,
+        `/catalog/items/${encodeURIComponent(itemId)}`,
+      ),
+      {
+        method: "PATCH",
+        body: JSON.stringify(request),
+      },
+    ),
+  );
+}
+
+export async function createRazorpayPlan(
+  environment: PaymentEnvironment,
+  request: CreateRazorpayPlanBody,
+): Promise<MutateRazorpayPlanResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("razorpay", environment, "/catalog/plans"),
+      {
+        method: "POST",
+        body: JSON.stringify(request),
+      },
+    ),
+  );
+}
+
+export async function listStripeSubscriptions(
+  environment: PaymentEnvironment,
+  request: ListStripeSubscriptionsQuery,
+): Promise<ListStripeSubscriptionsResponse> {
+  return readJson(
+    await ossFetch(
+      withQuery(
+        withProviderEnvironmentPath("stripe", environment, "/subscriptions"),
+        request,
+      ),
+    ),
+  );
+}
+
+export async function listRazorpaySubscriptions(
+  environment: PaymentEnvironment,
+  request: ListRazorpaySubscriptionsQuery,
+): Promise<ListRazorpaySubscriptionsResponse> {
+  return readJson(
+    await ossFetch(
+      withQuery(
+        withProviderEnvironmentPath("razorpay", environment, "/subscriptions"),
+        request,
+      ),
     ),
   );
 }
 
 export async function listPaymentCustomers(
-  environment: StripeEnvironment,
+  provider: PaymentProvider,
+  environment: PaymentEnvironment,
   request: ListPaymentCustomersQuery = {},
 ): Promise<ListPaymentCustomersResponse> {
   return readJson(
     await ossFetch(
-      withQuery(withEnvironmentPath(environment, "/customers"), request),
+      withQuery(
+        withProviderEnvironmentPath(provider, environment, "/customers"),
+        request,
+      ),
     ),
   );
 }
 
-export async function listPaymentHistory(
-  environment: StripeEnvironment,
-  request: ListPaymentHistoryQuery,
-): Promise<ListPaymentHistoryResponse> {
+export async function listPaymentTransactions(
+  provider: PaymentProvider,
+  environment: PaymentEnvironment,
+  request: ListPaymentTransactionsQuery,
+): Promise<ListPaymentTransactionsResponse> {
   return readJson(
     await ossFetch(
-      withQuery(withEnvironmentPath(environment, "/payment-history"), request),
+      withQuery(
+        withProviderEnvironmentPath(provider, environment, "/transactions"),
+        request,
+      ),
     ),
   );
 }

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -7,9 +7,7 @@ import type {
   CreateStripePriceBody,
   CreateStripeProductBody,
   DeleteStripeProductResponse,
-  GetRazorpayConfigResponse,
   GetRazorpayStatusResponse,
-  GetStripeConfigResponse,
   GetStripePriceResponse,
   GetStripeProductResponse,
   GetStripeStatusResponse,
@@ -85,67 +83,44 @@ export async function getRazorpayPaymentsStatus(): Promise<GetRazorpayStatusResp
   return readJson(await ossFetch(withProviderPath("razorpay", "/status")));
 }
 
-export async function getStripePaymentsConfig(): Promise<GetStripeConfigResponse> {
-  return readJson(await ossFetch(withProviderPath("stripe", "/config")));
-}
-
-export async function getRazorpayPaymentsConfig(): Promise<GetRazorpayConfigResponse> {
-  return readJson(await ossFetch(withProviderPath("razorpay", "/config")));
-}
-
 export async function setStripeSecretKey(
   environment: PaymentEnvironment,
   secretKey: string,
-): Promise<GetStripeConfigResponse> {
+): Promise<void> {
   const request: UpsertStripeConfigBody = { secretKey };
-  return readJson(
-    await ossFetch(
-      withProviderEnvironmentPath("stripe", environment, "/config"),
-      {
-        method: "PUT",
-        body: JSON.stringify(request),
-      },
-    ),
-  );
+  await ossFetch(withProviderEnvironmentPath("stripe", environment, "/config"), {
+    method: "PUT",
+    body: JSON.stringify(request),
+  });
 }
 
 export async function setRazorpayKeys(
   environment: PaymentEnvironment,
   request: UpsertRazorpayConfigBody,
-): Promise<GetRazorpayConfigResponse> {
-  return readJson(
-    await ossFetch(
-      withProviderEnvironmentPath("razorpay", environment, "/config"),
-      {
-        method: "PUT",
-        body: JSON.stringify(request),
-      },
-    ),
+): Promise<void> {
+  await ossFetch(
+    withProviderEnvironmentPath("razorpay", environment, "/config"),
+    {
+      method: "PUT",
+      body: JSON.stringify(request),
+    },
   );
 }
 
 export async function removeStripeSecretKey(
   environment: PaymentEnvironment,
-): Promise<GetStripeConfigResponse> {
-  return readJson(
-    await ossFetch(
-      withProviderEnvironmentPath("stripe", environment, "/config"),
-      {
-        method: "DELETE",
-      },
-    ),
-  );
+): Promise<void> {
+  await ossFetch(withProviderEnvironmentPath("stripe", environment, "/config"), {
+    method: "DELETE",
+  });
 }
 
 export async function removeRazorpayKeys(
   environment: PaymentEnvironment,
-): Promise<GetRazorpayConfigResponse> {
-  return readJson(
-    await ossFetch(
-      withProviderEnvironmentPath("razorpay", environment, "/config"),
-      { method: "DELETE" },
-    ),
-  );
+): Promise<void> {
+  await ossFetch(withProviderEnvironmentPath("razorpay", environment, "/config"), {
+    method: "DELETE",
+  });
 }
 
 export async function syncStripePayments(


### PR DESCRIPTION
## Summary

- Add provider-scoped payment commands under `payments stripe` and `payments razorpay`
- Add Razorpay config, sync, catalog, items, plans, customers, subscriptions, and transactions CLI support
- Rename the generic payment history command to provider-scoped transactions
- Keep Stripe webhook management under `payments stripe webhooks`; Razorpay webhook setup is manual via the InsForge dashboard settings values
- Upgrade `@insforge/shared-schemas` to `^1.1.56`
- Add payment telemetry dimensions for provider and structured failure details

## Notes

This is a breaking command-shape change for payments. Legacy top-level aliases such as `payments config`, `payments products`, `payments prices`, and `payments history` are intentionally not retained.

## Validation

- `npx prettier --check` on changed TS/JSON files
- `git diff --check`
- `npm run build`
- `npm run lint`
- CLI help smoke checks for `payments`, `payments stripe`, `payments razorpay`, and Razorpay webhook rejection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Razorpay support and restructures the payments CLI to be provider-scoped, replacing the old history command with a unified transactions view. This is a breaking change for payments command paths.

- **New Features**
  - Provider-scoped commands: `payments stripe` and `payments razorpay`.
  - Razorpay: `config` (set/remove keys), `status`, `sync`, `catalog`, `customers`, `subscriptions`, `transactions`, `items` (list/create/update), `plans` (list/create).
  - Stripe: `products`, `prices`, `webhooks` remain; `status/sync/customers/subscriptions/transactions` are provider-scoped.
  - Replaced `history` with `transactions` and added status-aware timestamp display; fields are provider-agnostic (`priceId`, `productId`, `providerCustomerId`).
  - Provider-specific API paths under `/api/payments/{provider}/...`; all payment commands read `apiUrl` from root options.
  - Creation commands now require explicit numeric params; Razorpay plans use `--notes` (no metadata on items).
  - Telemetry includes provider, whitelists fields, and truncates error details.
  - Bumped `@insforge/shared-schemas` to `^1.1.58`; CLI version to `0.1.89`.

- **Migration**
  - Breaking: remove top-level `payments config/products/prices/history`. Use `payments stripe <...>` or `payments razorpay <...>`.
  - `history` is replaced by `transactions`. Update scripts and docs to new paths.

<sup>Written for commit 0733b99d4657fb372849edfb8c357849e446adc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Razorpay provider support to the payments CLI alongside Stripe
> - Restructures the payments CLI to require a provider subcommand (`stripe` or `razorpay`), so all commands now run as `payments <provider> <subcommand>`
> - Adds Razorpay-specific commands for status, config, sync, catalog, customers, subscriptions, transactions, items, and plans; Stripe retains webhooks, products, and prices
> - All API calls are split into provider-scoped endpoints under `/api/payments/{provider}/...` using new `withProviderPath` and `withProviderEnvironmentPath` helpers in [payments.ts](https://github.com/InsForge/CLI/pull/162/files#diff-cd544d89fdb35333ba039c0edf5d581e7b0a8bd6d6b29f47e477d238b1c4d6d4)
> - Renames the `history` subcommand to `transactions` and updates field names (`priceId`, `productId`, `providerCustomerId`) to be provider-agnostic
> - Extends `trackPaymentUsage` to include provider and structured error telemetry (truncated at 500 chars) for all payment commands
> - Risk: Breaking change — existing `payments <subcommand>` invocations must be updated to `payments stripe <subcommand>` or `payments razorpay <subcommand>`; the `history` subcommand is removed
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #162 opened
>
> - Modified all payment command handlers to read `apiUrl` from root options and pass it to `requireAuth` [ed7cde6]
> - Changed payment item, plan, and price creation to require explicit numeric parameters instead of accepting optional values with defaults [ed7cde6]
> - Replaced `--metadata` flag with `--notes` flag for Razorpay plan creation and removed metadata support from Razorpay items [ed7cde6]
> - Refactored transaction timestamp display to prioritize status-specific timestamp fields [ed7cde6]
> - Implemented telemetry payload sanitization to whitelist fields and remove raw error messages [ed7cde6]
> - Consolidated duplicate `nullableString` helper implementations into shared utility [ed7cde6]
> - Added `parseRequiredIntegerOption` and `parseStringRecordOption` utilities for consistent CLI option parsing [ed7cde6]
> - Expanded test coverage for transaction timestamp logic, utility functions, and payments API client [ed7cde6]
> - Updated `@insforge/shared-schemas` dependency from version 1.1.57 to 1.1.58 [ed7cde6]
> - Updated package version to 0.1.89 [0733b99]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9394ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payments CLI now supports provider-scoped commands (payments <provider> ...) with Stripe and Razorpay subcommands, provider-specific catalog, customers, subscriptions, transactions, sync, and status flows; Razorpay items/plans CRUD added.

* **Documentation**
  * README reorganized into a multi-provider payments section with provider-scoped examples, webhook setup guidance, and updated environment variables formatting.

* **Tests**
  * Added unit tests for payment utilities, transaction timestamp logic, and API client paths.

* **Chores**
  * CLI version and shared-schemas dependency bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->