### PR TITLE
INS-347 feat(deployments): respect .vercelignore in deployments deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,15 @@ npx @insforge/cli deployments deploy ./my-app
 npx @insforge/cli deployments deploy --env '{"API_URL": "https://api.example.com"}'
 ```
 
+To exclude files from the upload, add a `.vercelignore` file to the deploy directory. It uses `.gitignore` syntax (including `!` negation) and is applied on top of the built-in excludes (`node_modules`, `.git`, `.env`, etc. — these always stay excluded and cannot be re-included).
+
+```gitignore
+# .vercelignore
+*.md
+drafts/
+!IMPORTANT.md
+```
+
 #### `npx @insforge/cli deployments list`
 
 List all deployments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "archiver": "^7.0.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
+        "ignore": "^7.0.5",
         "open": "^10.1.0",
         "picocolors": "^1.1.1",
         "posthog-node": "^5.28.9",
@@ -1585,16 +1586,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
@@ -2642,6 +2633,16 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/espree": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
@@ -2983,10 +2984,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "archiver": "^7.0.1",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",
+    "ignore": "^7.0.5",
     "open": "^10.1.0",
     "picocolors": "^1.1.1",
     "posthog-node": "^5.28.9",

--- a/src/commands/deployments/deploy.ts
+++ b/src/commands/deployments/deploy.ts
@@ -153,7 +153,7 @@ export async function collectDeploymentFiles(
   return files;
 }
 
-async function createZipBuffer(
+export async function createZipBuffer(
   sourceDir: string,
   deployIgnore?: DeployIgnore | null,
 ): Promise<Buffer> {

--- a/src/commands/deployments/deploy.ts
+++ b/src/commands/deployments/deploy.ts
@@ -168,7 +168,8 @@ async function createZipBuffer(
     archive.directory(sourceDir, false, (entry) => {
       if (shouldExclude(entry.name)) return false;
       const normalized = entry.name.replace(/\\/g, '/');
-      if (normalized && deployIgnore?.ignores(normalized)) return false;
+      const candidate = entry.stats?.isDirectory() ? `${normalized}/` : normalized;
+      if (normalized && deployIgnore?.ignores(candidate)) return false;
       return entry;
     });
 

--- a/src/commands/deployments/deploy.ts
+++ b/src/commands/deployments/deploy.ts
@@ -21,6 +21,7 @@ import type {
   StartDeploymentRequest,
 } from '../../types.js';
 import { trackDeploymentUsage } from './utils.js';
+import { loadDeployIgnore, IGNORE_FILE_NAME, type DeployIgnore } from './ignore-file.js';
 
 const POLL_INTERVAL_MS = 5_000;
 const POLL_TIMEOUT_MS = 300_000;
@@ -52,6 +53,7 @@ const EXCLUDE_PATTERNS = [
   '.cache',
   'skills',
   'coverage',
+  IGNORE_FILE_NAME,
 ];
 
 type LocalDeploymentFile = DeploymentManifestFileEntry & {
@@ -106,7 +108,10 @@ async function hashFile(filePath: string): Promise<{ sha: string; size: number }
   return { sha: hash.digest('hex'), size };
 }
 
-async function collectDeploymentFiles(sourceDir: string): Promise<LocalDeploymentFile[]> {
+export async function collectDeploymentFiles(
+  sourceDir: string,
+  deployIgnore?: DeployIgnore | null,
+): Promise<LocalDeploymentFile[]> {
   const files: LocalDeploymentFile[] = [];
 
   async function walk(currentDir: string): Promise<void> {
@@ -118,6 +123,10 @@ async function collectDeploymentFiles(sourceDir: string): Promise<LocalDeploymen
       const normalizedPath = normalizeRelativePath(sourceDir, absolutePath);
 
       if (!normalizedPath || shouldExclude(normalizedPath)) {
+        continue;
+      }
+
+      if (deployIgnore?.ignores(entry.isDirectory() ? `${normalizedPath}/` : normalizedPath)) {
         continue;
       }
 
@@ -144,7 +153,10 @@ async function collectDeploymentFiles(sourceDir: string): Promise<LocalDeploymen
   return files;
 }
 
-async function createZipBuffer(sourceDir: string): Promise<Buffer> {
+async function createZipBuffer(
+  sourceDir: string,
+  deployIgnore?: DeployIgnore | null,
+): Promise<Buffer> {
   return new Promise<Buffer>((resolve, reject) => {
     const archive = archiver('zip', { zlib: { level: 9 } });
     const chunks: Buffer[] = [];
@@ -155,6 +167,8 @@ async function createZipBuffer(sourceDir: string): Promise<Buffer> {
 
     archive.directory(sourceDir, false, (entry) => {
       if (shouldExclude(entry.name)) return false;
+      const normalized = entry.name.replace(/\\/g, '/');
+      if (normalized && deployIgnore?.ignores(normalized)) return false;
       return entry;
     });
 
@@ -309,11 +323,12 @@ async function pollDeployment(
 async function deployProjectDirect(
   opts: DeployProjectOptions,
   config: ProjectConfig,
+  deployIgnore: DeployIgnore | null,
 ): Promise<DeployProjectResult> {
   const { sourceDir, startBody = {}, spinner } = opts;
 
   spinner?.start('Scanning source files...');
-  const localFiles = await collectDeploymentFiles(sourceDir);
+  const localFiles = await collectDeploymentFiles(sourceDir, deployIgnore);
   if (localFiles.length === 0) {
     throw new CLIError('No deployable files found in the source directory.');
   }
@@ -349,6 +364,7 @@ async function deployProjectDirect(
 
 async function deployProjectLegacy(
   opts: DeployProjectOptions,
+  deployIgnore: DeployIgnore | null,
 ): Promise<DeployProjectResult> {
   const { sourceDir, startBody = {}, spinner } = opts;
 
@@ -358,7 +374,7 @@ async function deployProjectLegacy(
     (await createRes.json()) as CreateDeploymentResponse;
 
   spinner?.message('Compressing source files...');
-  const zipBuffer = await createZipBuffer(sourceDir);
+  const zipBuffer = await createZipBuffer(sourceDir, deployIgnore);
 
   spinner?.message('Uploading...');
   const formData = new FormData();
@@ -407,15 +423,22 @@ export async function deployProject(opts: DeployProjectOptions): Promise<DeployP
     throw new ProjectNotLinkedError();
   }
 
+  const deployIgnore = await loadDeployIgnore(opts.sourceDir);
+  if (deployIgnore && opts.spinner) {
+    clack.log.info(
+      `Applying ${IGNORE_FILE_NAME} (${deployIgnore.patternCount} pattern${deployIgnore.patternCount === 1 ? '' : 's'})`,
+    );
+  }
+
   try {
-    return await deployProjectDirect(opts, config);
+    return await deployProjectDirect(opts, config, deployIgnore);
   } catch (error) {
     if (!(error instanceof DirectDeploymentUnsupportedError)) {
       throw error;
     }
 
     opts.spinner?.message('Direct deployment is not available on this backend. Falling back to the legacy zip upload flow...');
-    return await deployProjectLegacy(opts);
+    return await deployProjectLegacy(opts, deployIgnore);
   }
 }
 
@@ -427,6 +450,7 @@ export function registerDeploymentsDeployCommand(deploymentsCmd: Command): void 
     .option('--meta <meta>', 'Deployment metadata as JSON')
     .action(async (directory: string | undefined, opts, cmd) => {
       const { json } = getRootOpts(cmd);
+      let hasIgnoreFile = false;
       try {
         await requireAuth();
         const config = getProjectConfig();
@@ -446,6 +470,11 @@ export function registerDeploymentsDeployCommand(deploymentsCmd: Command): void 
             `"${dirName}" is an excluded directory and cannot be used as a deploy source. Please specify your project root or output directory instead.`,
           );
         }
+
+        hasIgnoreFile = await fs
+          .stat(path.join(sourceDir, IGNORE_FILE_NAME))
+          .then((s) => s.isFile())
+          .catch(() => false);
 
         const spinner = !json ? clack.spinner() : null;
 
@@ -505,12 +534,14 @@ export function registerDeploymentsDeployCommand(deploymentsCmd: Command): void 
         await trackDeploymentUsage('deploy', true, {
           has_env: opts.env !== undefined,
           has_meta: opts.meta !== undefined,
+          has_ignore_file: hasIgnoreFile,
           ready: result.isReady,
         });
       } catch (err) {
         await trackDeploymentUsage('deploy', false, {
           has_env: opts.env !== undefined,
           has_meta: opts.meta !== undefined,
+          has_ignore_file: hasIgnoreFile,
         });
         handleError(err, json);
       }

--- a/src/commands/deployments/ignore-file.test.ts
+++ b/src/commands/deployments/ignore-file.test.ts
@@ -3,7 +3,8 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { loadDeployIgnore } from './ignore-file.js';
-import { collectDeploymentFiles } from './deploy.js';
+import { collectDeploymentFiles, createZipBuffer } from './deploy.js';
+import { CLIError } from '../../lib/errors.js';
 
 const tempDirs: string[] = [];
 
@@ -47,6 +48,14 @@ describe('loadDeployIgnore', () => {
     const matcher = await loadDeployIgnore(dir);
     expect(matcher?.ignores('README.md')).toBe(true);
     expect(matcher?.ignores('KEEP.md')).toBe(false);
+  });
+
+  it('throws CLIError when .vercelignore exists but cannot be read', async () => {
+    const dir = await makeTempProject({ 'index.html': '<html></html>' });
+    // A directory named .vercelignore triggers EISDIR — portable, unlike chmod tricks
+    await fs.mkdir(path.join(dir, '.vercelignore'));
+    await expect(loadDeployIgnore(dir)).rejects.toThrow(CLIError);
+    await expect(loadDeployIgnore(dir)).rejects.toThrow(/Failed to read \.vercelignore/);
   });
 
   it('handles CRLF line endings', async () => {
@@ -134,5 +143,61 @@ describe('collectDeploymentFiles with .vercelignore', () => {
     expect(matcher).toBeNull();
     const files = await collectDeploymentFiles(dir, matcher);
     expect(files.map((f) => f.path).sort()).toEqual(['README.md', 'index.html']);
+  });
+});
+
+/** Entry names from a zip buffer's central directory (signature PK\x01\x02). */
+function listZipEntryNames(zip: Buffer): string[] {
+  const names: string[] = [];
+  const SIG = 0x02014b50;
+  let offset = 0;
+  while ((offset = zip.indexOf('PK', offset, 'binary')) !== -1) {
+    if (zip.readUInt32LE(offset) === SIG) {
+      const nameLength = zip.readUInt16LE(offset + 28);
+      names.push(zip.subarray(offset + 46, offset + 46 + nameLength).toString('utf8'));
+    }
+    offset += 4;
+  }
+  return names;
+}
+
+describe('createZipBuffer with .vercelignore (legacy upload path)', () => {
+  it('excludes ignored files, directory-only patterns, and built-ins from the archive', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '*.md\ndrafts/\n!KEEP.md\n',
+      'index.html': '<html></html>',
+      'README.md': '# readme',
+      'KEEP.md': '# kept',
+      'drafts/wip.txt': 'wip',
+      'node_modules/pkg/index.js': 'x',
+      'src/app.js': 'console.log(1)',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    const zip = await createZipBuffer(dir, matcher);
+    const entries = listZipEntryNames(zip).sort();
+
+    expect(entries).toContain('index.html');
+    expect(entries).toContain('KEEP.md');
+    expect(entries).toContain('src/app.js');
+    expect(entries).not.toContain('README.md');
+    expect(entries).not.toContain('.vercelignore');
+    expect(entries.filter((e) => e.startsWith('drafts'))).toEqual([]);
+    expect(entries.filter((e) => e.startsWith('node_modules'))).toEqual([]);
+  });
+
+  it('matches the direct-upload path file set for the same project', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '*.tmp\nprivate/\n',
+      'index.html': '<html></html>',
+      'cache.tmp': 'x',
+      'private/data.json': '{}',
+      'src/main.ts': 'code',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    const walked = (await collectDeploymentFiles(dir, matcher)).map((f) => f.path).sort();
+    const zipped = listZipEntryNames(await createZipBuffer(dir, matcher))
+      .filter((e) => !e.endsWith('/'))
+      .sort();
+    expect(zipped).toEqual(walked);
   });
 });

--- a/src/commands/deployments/ignore-file.test.ts
+++ b/src/commands/deployments/ignore-file.test.ts
@@ -97,6 +97,34 @@ describe('collectDeploymentFiles with .vercelignore', () => {
     expect(files.map((f) => f.path)).toEqual(['index.html']);
   });
 
+  it('aggressive negation cannot re-include built-in excludes at any depth', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '!**\n!node_modules/**\n!packages/app/node_modules\n!.env\n!**/.env\n!debug.log\n',
+      '.env': 'SECRET=1',
+      'debug.log': 'log',
+      'node_modules/pkg/index.js': 'x',
+      'packages/app/node_modules/dep/index.js': 'x',
+      'packages/app/.env': 'SECRET=2',
+      'packages/app/src/main.ts': 'code',
+      'index.html': '<html></html>',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    const files = await collectDeploymentFiles(dir, matcher);
+    expect(files.map((f) => f.path).sort()).toEqual(['index.html', 'packages/app/src/main.ts']);
+  });
+
+  it('vercelignore adds excludes on top of built-ins (union), it never replaces them', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': 'docs/\n',
+      'node_modules/pkg/index.js': 'x',
+      'docs/guide.md': 'doc',
+      'index.html': '<html></html>',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    const files = await collectDeploymentFiles(dir, matcher);
+    expect(files.map((f) => f.path)).toEqual(['index.html']);
+  });
+
   it('behaves as before when no ignore file is present', async () => {
     const dir = await makeTempProject({
       'index.html': '<html></html>',

--- a/src/commands/deployments/ignore-file.test.ts
+++ b/src/commands/deployments/ignore-file.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadDeployIgnore } from './ignore-file.js';
+import { collectDeploymentFiles } from './deploy.js';
+
+const tempDirs: string[] = [];
+
+async function makeTempProject(files: Record<string, string>): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'insforge-ignore-test-'));
+  tempDirs.push(dir);
+  for (const [relPath, content] of Object.entries(files)) {
+    const absPath = path.join(dir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, content);
+  }
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('loadDeployIgnore', () => {
+  it('returns null when .vercelignore does not exist', async () => {
+    const dir = await makeTempProject({ 'index.html': '<html></html>' });
+    expect(await loadDeployIgnore(dir)).toBeNull();
+  });
+
+  it('parses patterns and counts non-comment lines', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '# comment\n\n*.md\ndocs/\n',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    expect(matcher).not.toBeNull();
+    expect(matcher?.patternCount).toBe(2);
+    expect(matcher?.ignores('README.md')).toBe(true);
+    expect(matcher?.ignores('docs/guide.txt')).toBe(true);
+    expect(matcher?.ignores('index.html')).toBe(false);
+  });
+
+  it('supports negation patterns', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '*.md\n!KEEP.md\n',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    expect(matcher?.ignores('README.md')).toBe(true);
+    expect(matcher?.ignores('KEEP.md')).toBe(false);
+  });
+
+  it('handles CRLF line endings', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '*.tmp\r\nprivate/\r\n',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    expect(matcher?.patternCount).toBe(2);
+    expect(matcher?.ignores('a.tmp')).toBe(true);
+    expect(matcher?.ignores('private/data.json')).toBe(true);
+  });
+});
+
+describe('collectDeploymentFiles with .vercelignore', () => {
+  it('excludes files and directories matched by the ignore file', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '*.md\ndrafts/\n',
+      'index.html': '<html></html>',
+      'README.md': '# readme',
+      'drafts/wip.txt': 'wip',
+      'src/app.js': 'console.log(1)',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    const files = await collectDeploymentFiles(dir, matcher);
+    const paths = files.map((f) => f.path).sort();
+    expect(paths).toEqual(['index.html', 'src/app.js']);
+  });
+
+  it('never uploads the .vercelignore file itself', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '*.tmp\n',
+      'index.html': '<html></html>',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    const files = await collectDeploymentFiles(dir, matcher);
+    expect(files.map((f) => f.path)).toEqual(['index.html']);
+  });
+
+  it('built-in excludes still apply and cannot be re-included by negation', async () => {
+    const dir = await makeTempProject({
+      '.vercelignore': '!.env\n!node_modules\n',
+      '.env': 'SECRET=1',
+      'node_modules/pkg/index.js': 'x',
+      'index.html': '<html></html>',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    const files = await collectDeploymentFiles(dir, matcher);
+    expect(files.map((f) => f.path)).toEqual(['index.html']);
+  });
+
+  it('behaves as before when no ignore file is present', async () => {
+    const dir = await makeTempProject({
+      'index.html': '<html></html>',
+      'README.md': '# readme',
+    });
+    const matcher = await loadDeployIgnore(dir);
+    expect(matcher).toBeNull();
+    const files = await collectDeploymentFiles(dir, matcher);
+    expect(files.map((f) => f.path).sort()).toEqual(['README.md', 'index.html']);
+  });
+});

--- a/src/commands/deployments/ignore-file.ts
+++ b/src/commands/deployments/ignore-file.ts
@@ -1,0 +1,45 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import ignore from 'ignore';
+import { CLIError } from '../../lib/errors.js';
+
+export const IGNORE_FILE_NAME = '.vercelignore';
+
+export interface DeployIgnore {
+  /** Test a path relative to the deploy source dir. Directory paths must end with '/'. */
+  ignores(relativePath: string): boolean;
+  patternCount: number;
+}
+
+/**
+ * Loads `.vercelignore` from the deploy source directory, if present.
+ * Patterns follow .gitignore syntax. Returns null when the file does not exist.
+ */
+export async function loadDeployIgnore(sourceDir: string): Promise<DeployIgnore | null> {
+  const ignoreFilePath = path.join(sourceDir, IGNORE_FILE_NAME);
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(ignoreFilePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw new CLIError(
+      `Failed to read ${IGNORE_FILE_NAME}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const matcher = ignore().add(raw);
+  const patternCount = raw
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed.length > 0 && !trimmed.startsWith('#');
+    }).length;
+
+  return {
+    ignores: (relativePath: string) => matcher.ignores(relativePath),
+    patternCount,
+  };
+}


### PR DESCRIPTION
## Summary

`deployments deploy` now honors a `.vercelignore` file in the deploy source directory, letting developers maintain a deploy ignore list. Since deployments run on Vercel underneath, we reuse the existing `.vercelignore` convention instead of introducing a new file — projects migrating from direct Vercel deploys keep working unchanged.

- New `src/commands/deployments/ignore-file.ts`: loads `.vercelignore` via the `ignore` package (gitignore-spec matcher, zero deps). Missing file → no-op; unreadable file → clear `CLIError`.
- Applied in **both** upload paths: the direct-upload scan (`collectDeploymentFiles`, which also skips recursing into ignored directories) and the legacy zip fallback (`createZipBuffer`). `create`'s first-deploy flow reuses `deployProject()` and benefits automatically.
- Full gitignore syntax including `!` negation. Built-in safety excludes (`.env`, `.git`, `node_modules`, …) always win and cannot be re-included. `.vercelignore` itself is never uploaded.
- Non-JSON mode prints `Applying .vercelignore (N patterns)` before the scan.
- Telemetry: `has_ignore_file: boolean` added to the deploy event (file presence only, never pattern contents).
- README: documented in the `deployments deploy` section.

## Scope

Only the `deployments` tree — `compute deploy` and `functions deploy` have separate flows and are unaffected. Version is not bumped here; bump on release per the usual workflow.

## Cross-reference

Companion docs update to the `insforge-cli` skill: InsForge/insforge-skills#94 (merge that one after or together with this).

## Test plan

- [x] 8 new vitest cases in `src/commands/deployments/ignore-file.test.ts` (parsing, comments/CRLF, negation, directory excludes, built-ins not overridable, no-file passthrough) against real temp dirs
- [x] Full suite: 429 passed
- [x] `npm run lint` clean (0 errors)
- [x] `npm run build` + `deployments deploy --help` smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for a deploy ignore file (.vercelignore) to exclude files/directories using .gitignore syntax (including negation); the ignore file itself is never uploaded.

* **Documentation**
  * Updated Deployments docs with instructions and a sample .vercelignore.

* **Bug Fixes / Behavior**
  * Built-in excludes (e.g., node_modules, .git, .env) remain enforced and cannot be re-included.

* **Tests**
  * Added tests covering ignore-file parsing and deployment exclusion behavior.

* **Chores**
  * Added runtime dependency for ignore pattern handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `.vercelignore` support to exclude files from deployment uploads
> - Introduces [ignore-file.ts](https://github.com/InsForge/CLI/pull/163/files#diff-0cec94c0d3347d1fd9cf228f3374d4d08cb02e3bca5b243613f02ddad5a0b339) with `loadDeployIgnore`, which reads `.vercelignore` from the source directory and returns an `ignore`-library matcher (or `null` if absent).
> - Applies the matcher in both direct (`collectDeploymentFiles`) and legacy (`createZipBuffer`) upload paths to skip matched files and directories.
> - The `.vercelignore` file itself is always excluded via `EXCLUDE_PATTERNS`; built-in excludes cannot be overridden by negation patterns.
> - Logs the ignore filename and pattern count when a `.vercelignore` is detected, and records a `has_ignore_file` telemetry flag on deploy.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #163 opened
>
> - Exported `createZipBuffer` function from the deployments deploy module [4f2cd77]
> - Implemented .vercelignore pattern filtering in deployment zip creation [4f2cd77]
> - Added error handling for unreadable .vercelignore file cases [4f2cd77]
> - Created test utilities and test suites for .vercelignore functionality [4f2cd77]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c82514a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->