### PR TITLE
feat(memory): insforge memory remember/recall/list commands

### DIFF
--- a/src/commands/memory/index.ts
+++ b/src/commands/memory/index.ts
@@ -1,0 +1,10 @@
+import type { Command } from 'commander';
+import { registerMemoryRememberCommand } from './remember.js';
+import { registerMemoryRecallCommand } from './recall.js';
+import { registerMemoryListCommand } from './list.js';
+
+export function registerMemoryCommands(memoryCmd: Command): void {
+  registerMemoryRememberCommand(memoryCmd);
+  registerMemoryRecallCommand(memoryCmd);
+  registerMemoryListCommand(memoryCmd);
+}

--- a/src/commands/memory/list.ts
+++ b/src/commands/memory/list.ts
@@ -1,9 +1,10 @@
 import type { Command } from 'commander';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
+import { getProjectConfig } from '../../lib/config.js';
+import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
-import { reportCliUsage } from '../../lib/skills.js';
 
 interface MemoryIndexEntry {
   id: string;
@@ -38,9 +39,18 @@ export function registerMemoryListCommand(memoryCmd: Command): void {
           }
           console.log(`\n${result.entries.length} memories.`);
         }
-        await reportCliUsage('cli.memory.list', true);
+
+        const project = getProjectConfig();
+        if (project) {
+          captureEvent(project.project_id, 'cli_memory_list', {
+            project_id: project.project_id,
+            entries: result.entries.length,
+          });
+        }
       } catch (err) {
         handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
       }
     });
 }

--- a/src/commands/memory/list.ts
+++ b/src/commands/memory/list.ts
@@ -1,0 +1,46 @@
+import type { Command } from 'commander';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+interface MemoryIndexEntry {
+  id: string;
+  kind: string;
+  title: string;
+  updated_at: string;
+}
+
+export function registerMemoryListCommand(memoryCmd: Command): void {
+  memoryCmd
+    .command('list')
+    .description('List all memory titles for a scope (the cheap always-load index)')
+    .option('--scope <scope>', 'Memory scope (project / agent / user)', 'default')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const res = await ossFetch('/api/memory/index', {
+          method: 'POST',
+          body: JSON.stringify({ scope: opts.scope }),
+        });
+        const result = (await res.json()) as { entries: MemoryIndexEntry[] };
+
+        if (json) {
+          outputJson(result);
+        } else if (result.entries.length === 0) {
+          console.log('No memories stored for this scope.');
+        } else {
+          for (const e of result.entries) {
+            console.log(`(${e.kind}) ${e.title}`);
+          }
+          console.log(`\n${result.entries.length} memories.`);
+        }
+        await reportCliUsage('cli.memory.list', true);
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/memory/memory.test.ts
+++ b/src/commands/memory/memory.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+import { registerMemoryCommands } from './index.js';
+
+vi.mock('../../lib/api/oss.js', () => ({
+  ossFetch: vi.fn(),
+}));
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok', userId: 'u' })),
+}));
+vi.mock('../../lib/config.js', () => ({
+  getProjectConfig: vi.fn(() => ({
+    project_id: 'p1',
+    project_name: 'demo',
+    org_id: 'o1',
+    appkey: 'k',
+    region: 'us-east',
+    api_key: 'key',
+    oss_host: 'http://localhost',
+  })),
+}));
+vi.mock('../../lib/analytics.js', () => ({
+  captureEvent: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>');
+  registerMemoryCommands(program.command('memory'));
+  return program;
+}
+
+async function run(argv: string[]) {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  try {
+    await makeProgram().parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+}
+
+function mockResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+describe('memory commands', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('remember stores a single fact (not transcript) and honors --kind/--title', async () => {
+    const { ossFetch } = await import('../../lib/api/oss.js');
+    (ossFetch as any).mockResolvedValue(mockResponse({ results: [{ action: 'ADD', title: 'T' }] }));
+
+    await run(['memory', 'remember', 'some content', '--scope', 's', '--kind', 'decision', '--title', 'T']);
+
+    const [path, opts] = (ossFetch as any).mock.calls[0];
+    expect(path).toBe('/api/memory/remember');
+    const body = JSON.parse(opts.body);
+    expect(body).toMatchObject({ scope: 's', kind: 'decision', title: 'T', content: 'some content' });
+    expect(body.transcript).toBeUndefined();
+
+    const { captureEvent } = await import('../../lib/analytics.js');
+    expect(captureEvent).toHaveBeenCalledWith('p1', 'cli_memory_remember', expect.objectContaining({ mode: 'single' }));
+  });
+
+  it('remember --transcript sends transcript mode', async () => {
+    const { ossFetch } = await import('../../lib/api/oss.js');
+    (ossFetch as any).mockResolvedValue(mockResponse({ results: [] }));
+
+    await run(['memory', 'remember', 'a long transcript', '--transcript', '--scope', 's']);
+
+    const body = JSON.parse((ossFetch as any).mock.calls[0][1].body);
+    expect(body.transcript).toBe('a long transcript');
+    expect(body.content).toBeUndefined();
+  });
+
+  it('recall posts the query to the recall endpoint', async () => {
+    const { ossFetch } = await import('../../lib/api/oss.js');
+    (ossFetch as any).mockResolvedValue(mockResponse({ memories: [] }));
+
+    await run(['memory', 'recall', 'where is the secret', '--scope', 's', '--limit', '3']);
+
+    const [path, opts] = (ossFetch as any).mock.calls[0];
+    expect(path).toBe('/api/memory/recall');
+    expect(JSON.parse(opts.body)).toMatchObject({ scope: 's', query: 'where is the secret', limit: 3 });
+  });
+
+  it('list hits the index endpoint', async () => {
+    const { ossFetch } = await import('../../lib/api/oss.js');
+    (ossFetch as any).mockResolvedValue(mockResponse({ entries: [] }));
+
+    await run(['memory', 'list', '--scope', 's']);
+
+    expect((ossFetch as any).mock.calls[0][0]).toBe('/api/memory/index');
+  });
+});

--- a/src/commands/memory/recall.ts
+++ b/src/commands/memory/recall.ts
@@ -1,9 +1,10 @@
 import type { Command } from 'commander';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
+import { getProjectConfig } from '../../lib/config.js';
+import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
-import { reportCliUsage } from '../../lib/skills.js';
 
 interface RecalledMemory {
   id: string;
@@ -51,9 +52,18 @@ export function registerMemoryRecallCommand(memoryCmd: Command): void {
             console.log(`        ${m.content}`);
           }
         }
-        await reportCliUsage('cli.memory.recall', true);
+
+        const project = getProjectConfig();
+        if (project) {
+          captureEvent(project.project_id, 'cli_memory_recall', {
+            project_id: project.project_id,
+            results: result.memories.length,
+          });
+        }
       } catch (err) {
         handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
       }
     });
 }

--- a/src/commands/memory/recall.ts
+++ b/src/commands/memory/recall.ts
@@ -1,0 +1,59 @@
+import type { Command } from 'commander';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+interface RecalledMemory {
+  id: string;
+  kind: string;
+  title: string;
+  content: string;
+  similarity: number;
+  updated_at: string;
+}
+
+export function registerMemoryRecallCommand(memoryCmd: Command): void {
+  memoryCmd
+    .command('recall <query>')
+    .description('Recall the most relevant memories for a query')
+    .option('--scope <scope>', 'Memory scope (project / agent / user)', 'default')
+    .option('--limit <n>', 'Max memories to return', '5')
+    .option('--threshold <t>', 'Similarity threshold 0-1 (default tuned to 0.45)')
+    .action(async (query: string, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const body: Record<string, unknown> = {
+          scope: opts.scope,
+          query,
+          limit: Number(opts.limit),
+        };
+        if (opts.threshold !== undefined) {
+          body.threshold = Number(opts.threshold);
+        }
+
+        const res = await ossFetch('/api/memory/recall', {
+          method: 'POST',
+          body: JSON.stringify(body),
+        });
+        const result = (await res.json()) as { memories: RecalledMemory[] };
+
+        if (json) {
+          outputJson(result);
+        } else if (result.memories.length === 0) {
+          console.log('No relevant memories found.');
+        } else {
+          for (const m of result.memories) {
+            console.log(`[${(m.similarity * 100).toFixed(1)}%] (${m.kind}) ${m.title}`);
+            console.log(`        ${m.content}`);
+          }
+        }
+        await reportCliUsage('cli.memory.recall', true);
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/memory/remember.ts
+++ b/src/commands/memory/remember.ts
@@ -2,9 +2,10 @@ import type { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
+import { getProjectConfig } from '../../lib/config.js';
+import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
-import { reportCliUsage } from '../../lib/skills.js';
 
 interface RememberResult {
   action: 'ADD' | 'UPDATE' | 'NOOP';
@@ -21,20 +22,28 @@ export function registerMemoryRememberCommand(memoryCmd: Command): void {
     .option('--title <title>', 'One-line title (defaults to the content)')
     .option('--source <source>', 'Where this memory came from (task / session id)')
     .option('--transcript', 'Treat the content as a task transcript to extract memories from')
-    .option('--file <path>', 'Read the transcript/content from a file')
+    .option('--file <path>', 'Read the content/transcript text from a file')
     .action(async (content: string | undefined, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
         await requireAuth();
 
+        // --file is just a text source; --transcript decides the mode, so
+        // `--file foo.txt` alone still stores a single fact honoring --kind/--title.
         const text = opts.file ? readFileSync(opts.file, 'utf8') : content;
         if (!text) {
           throw new Error('Provide content as an argument or via --file');
         }
 
-        const body = opts.transcript || opts.file
+        const body = opts.transcript
           ? { scope: opts.scope, source: opts.source, transcript: text }
-          : { scope: opts.scope, source: opts.source, kind: opts.kind, title: opts.title ?? text, content: text };
+          : {
+              scope: opts.scope,
+              source: opts.source,
+              kind: opts.kind,
+              title: opts.title ?? text,
+              content: text,
+            };
 
         const res = await ossFetch('/api/memory/remember', {
           method: 'POST',
@@ -51,9 +60,20 @@ export function registerMemoryRememberCommand(memoryCmd: Command): void {
           const stored = result.results.filter((r) => r.action !== 'NOOP').length;
           console.log(`\n${stored} stored, ${result.results.length - stored} unchanged.`);
         }
-        await reportCliUsage('cli.memory.remember', true);
+
+        const project = getProjectConfig();
+        if (project) {
+          captureEvent(project.project_id, 'cli_memory_remember', {
+            project_id: project.project_id,
+            mode: opts.transcript ? 'transcript' : 'single',
+            from_file: Boolean(opts.file),
+            results: result.results.length,
+          });
+        }
       } catch (err) {
         handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
       }
     });
 }

--- a/src/commands/memory/remember.ts
+++ b/src/commands/memory/remember.ts
@@ -1,0 +1,59 @@
+import type { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { ossFetch } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+interface RememberResult {
+  action: 'ADD' | 'UPDATE' | 'NOOP';
+  id?: string;
+  title: string;
+}
+
+export function registerMemoryRememberCommand(memoryCmd: Command): void {
+  memoryCmd
+    .command('remember [content]')
+    .description('Store a durable memory, or extract memories from a task transcript')
+    .option('--scope <scope>', 'Memory scope (project / agent / user)', 'default')
+    .option('--kind <kind>', 'fact | decision | preference | reference', 'fact')
+    .option('--title <title>', 'One-line title (defaults to the content)')
+    .option('--source <source>', 'Where this memory came from (task / session id)')
+    .option('--transcript', 'Treat the content as a task transcript to extract memories from')
+    .option('--file <path>', 'Read the transcript/content from a file')
+    .action(async (content: string | undefined, opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+
+        const text = opts.file ? readFileSync(opts.file, 'utf8') : content;
+        if (!text) {
+          throw new Error('Provide content as an argument or via --file');
+        }
+
+        const body = opts.transcript || opts.file
+          ? { scope: opts.scope, source: opts.source, transcript: text }
+          : { scope: opts.scope, source: opts.source, kind: opts.kind, title: opts.title ?? text, content: text };
+
+        const res = await ossFetch('/api/memory/remember', {
+          method: 'POST',
+          body: JSON.stringify(body),
+        });
+        const result = (await res.json()) as { results: RememberResult[] };
+
+        if (json) {
+          outputJson(result);
+        } else {
+          for (const r of result.results) {
+            console.log(`${r.action.padEnd(6)} ${r.title}`);
+          }
+          const stored = result.results.filter((r) => r.action !== 'NOOP').length;
+          console.log(`\n${stored} stored, ${result.results.length - stored} unchanged.`);
+        }
+        await reportCliUsage('cli.memory.remember', true);
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ import { registerPaymentsCommands } from './commands/payments/index.js';
 import { registerPosthogSetupCommand } from './commands/posthog/setup.js';
 import { registerConfigCommand } from './commands/config/index.js';
 import { registerAiCommands } from './commands/ai/index.js';
+import { registerMemoryCommands } from './commands/memory/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
@@ -213,6 +214,9 @@ registerPosthogSetupCommand(posthogCmd);
 // AI commands
 const aiCmd = program.command('ai').description('Manage AI model gateway setup');
 registerAiCommands(aiCmd);
+
+const memoryCmd = program.command('memory').description('Store and recall durable agent memories');
+registerMemoryCommands(memoryCmd);
 
 // Schedules commands
 const schedulesCmd = program.command('schedules').description('Manage scheduled tasks (cron jobs)');

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -158,6 +158,10 @@ export async function ossFetch(
       message = 'AI Model Gateway setup is not available on this backend.\nUpgrade your InsForge project to a version with Model Gateway support, or keep using the legacy @insforge/sdk AI modules for projects that still rely on the older AI API surface.';
     }
 
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/memory')) {
+      message = 'Agent memory is not available on this backend.\nSelf-hosted: upgrade your InsForge instance to a version with the memory feature. Cloud: contact your InsForge admin to enable agent memory.';
+    }
+
     throw new CLIError(message, 1, err.error, res.status);
   }
 


### PR DESCRIPTION
## What

Adds an `insforge memory` command group that wraps the native `/api/memory` endpoints (see InsForge/InsForge#1502):

- **`insforge memory remember [content]`** — store a single durable fact, or extract memories from a task transcript with `--transcript` / `--file`. Options: `--scope`, `--kind`, `--title`, `--source`. Prints a per-result `ADD`/`UPDATE`/`NOOP` summary.
- **`insforge memory recall <query>`** — hybrid semantic + keyword recall for the most relevant memories. Options: `--scope`, `--limit`, `--threshold`. Prints `[similarity%] (kind) title` + content.
- **`insforge memory list`** — the cheap always-load title index for a scope (no embedding/LLM).

All three use the standard `ossFetch` path (project API key → linked project backend), mirroring `db rpc`, and honor the global `--json` flag.

## Why

Gives agents working in a project a way to persist and recall durable knowledge — decisions and their rationale, credential/config locations, gotchas — across sessions, driven from the CLI (no MCP, no SDK wiring needed). The "what/when to remember" judgment is intended to live in the agent skill; these verbs are the mechanism.

## Dependency

Requires the backend route group from **InsForge/InsForge#1502**. Against a backend without it, the commands return 404.

## Verification

- `npm run build` (tsup ESM + DTS) green; `memory --help` and all three subcommands render.
- End-to-end against the companion backend on a local stack: remember (single + `--file` transcript, skips transient lines), `list` shows the title index, recall surfaces exact tokens via the keyword arm, control queries return nothing.
- Note: the remaining `tsc --noEmit` warnings in this repo are pre-existing on `main` (`config/apply.ts`, `metadata.ts`, `payments/*.test.ts`, `prompts.ts`); none are in `commands/memory/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `insforge memory` CLI group to store, recall, and list durable agent memories via `/api/memory`. Includes PostHog telemetry and clearer 404 errors.

- **New Features**
  - `insforge memory remember [content]` — store a memory or extract from a transcript. Options: `--scope`, `--kind`, `--title`, `--source`, `--transcript`, `--file`. `--file` is input only; `--transcript` controls extraction. Prints `ADD`/`UPDATE`/`NOOP`.
  - `insforge memory recall <query>` — hybrid semantic + keyword recall. Options: `--scope`, `--limit`, `--threshold`. Prints similarity, kind, title, and content.
  - `insforge memory list` — list the cheap title index for a scope.
  - Uses `ossFetch`, supports global `--json`, emits PostHog `captureEvent`, and shows a friendly 404 when memory routes are missing.

- **Dependencies**
  - Requires backend memory routes from InsForge/InsForge#1502; older backends return 404.

<sup>Written for commit abeb3ca5b046e0108f17cabb554e7a7718562074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `memory remember`, `memory recall`, and `memory list` CLI commands
> - Adds three subcommands under a new `memory` namespace in [src/index.ts](https://github.com/InsForge/CLI/pull/164/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80): `remember`, `recall`, and `list`.
> - `memory remember [content]` POSTs to `/api/memory/remember` and supports direct content, `--file`, or `--transcript` input modes, printing per-item action outcomes.
> - `memory recall <query>` POSTs to `/api/memory/recall` with `--limit` (default 5) and optional `--threshold`, displaying results with similarity percentage, kind, title, and content.
> - `memory list` POSTs to `/api/memory/index` and renders a scoped memory index as a `(kind) title` list with a summary count.
> - All commands support `--scope` (default `'default'`), `--json` output, and route errors through `handleError`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #164 opened
>
> - Changed `registerMemoryRememberCommand` to require explicit `--transcript` flag for transcript mode, allowing `--file` alone to store a single memory with `--kind` and `--title` parameters [abeb3ca]
> - Replaced `reportCliUsage` with analytics integration in `registerMemoryRememberCommand`, `registerMemoryRecallCommand`, and `registerMemoryListCommand` commands [abeb3ca]
> - Added route-level 404 error handling for `/api/memory` paths in `ossFetch` utility [abeb3ca]
> - Created test suite for memory commands covering `remember`, `recall`, and `list` operations [abeb3ca]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45e3cbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level memory command group with subcommands to remember, recall, and list durable agent memories.
  * remember: store memories with scope, title, kind, transcript or file input.
  * recall: search memories with scope, limit, and similarity threshold.
  * list: view memories by scope.

* **Bug Fixes**
  * Improved user-facing error when memory storage is unavailable on the backend.

* **Tests**
  * Added tests covering remember, recall, and list CLI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->