### PR TITLE
fix(storage): set content type on CLI uploads instead of octet-stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/storage/upload.test.ts
+++ b/src/commands/storage/upload.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { resolveUploadContentType } from './upload.js';
+
+describe('resolveUploadContentType', () => {
+  it('uses an explicit --content-type over inference', () => {
+    expect(resolveUploadContentType('photo.png', 'image/webp')).toBe('image/webp');
+  });
+
+  it('infers from the file extension when no flag is given', () => {
+    expect(resolveUploadContentType('photo.png')).toBe('image/png');
+    expect(resolveUploadContentType('/tmp/report.pdf')).toBe('application/pdf');
+  });
+
+  it('treats an empty or whitespace flag as not provided', () => {
+    expect(resolveUploadContentType('photo.png', '')).toBe('image/png');
+    expect(resolveUploadContentType('photo.png', '   ')).toBe('image/png');
+  });
+
+  it('falls back to octet-stream for an unknown extension', () => {
+    expect(resolveUploadContentType('archive.unknownext')).toBe('application/octet-stream');
+    expect(resolveUploadContentType('noext')).toBe('application/octet-stream');
+  });
+});

--- a/src/commands/storage/upload.ts
+++ b/src/commands/storage/upload.ts
@@ -5,6 +5,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { mimeTypeFromName } from '../../lib/mime.js';
 
 export function registerStorageUploadCommand(storageCmd: Command): void {
   storageCmd
@@ -12,6 +13,7 @@ export function registerStorageUploadCommand(storageCmd: Command): void {
     .description('Upload a file to a storage bucket')
     .requiredOption('--bucket <name>', 'Target bucket name')
     .option('--key <objectKey>', 'Object key (defaults to filename)')
+    .option('--content-type <type>', 'MIME type to store (defaults to one inferred from the file extension)')
     .action(async (file: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
@@ -28,9 +30,16 @@ export function registerStorageUploadCommand(storageCmd: Command): void {
         const objectKey = opts.key ?? basename(file);
         const bucketName = opts.bucket;
 
-        // Build multipart form data
+        // Resolve the content type: explicit flag wins, then infer from the
+        // file's extension. Without this a typeless Blob is stored as
+        // application/octet-stream regardless of the actual file type.
+        const contentType =
+          opts.contentType ?? mimeTypeFromName(file) ?? 'application/octet-stream';
+
+        // Build multipart form data. The Blob's type becomes the multipart
+        // part's Content-Type, which the backend stores as the object's MIME type.
         const formData = new FormData();
-        const blob = new Blob([fileContent]);
+        const blob = new Blob([fileContent], { type: contentType });
         formData.append('file', blob, objectKey);
 
         // PUT /api/storage/buckets/{bucket}/objects/{key} for named upload

--- a/src/commands/storage/upload.ts
+++ b/src/commands/storage/upload.ts
@@ -7,6 +7,15 @@ import { handleError, getRootOpts, CLIError, ProjectNotLinkedError } from '../..
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { mimeTypeFromName } from '../../lib/mime.js';
 
+/**
+ * Resolve the content type for an upload: an explicit (non-empty) `--content-type`
+ * wins, otherwise infer from the file extension, otherwise fall back to the
+ * storage default. Exported for testing.
+ */
+export function resolveUploadContentType(filePath: string, explicit?: string): string {
+  return explicit?.trim() || mimeTypeFromName(filePath) || 'application/octet-stream';
+}
+
 export function registerStorageUploadCommand(storageCmd: Command): void {
   storageCmd
     .command('upload <file>')
@@ -33,8 +42,7 @@ export function registerStorageUploadCommand(storageCmd: Command): void {
         // Resolve the content type: explicit flag wins, then infer from the
         // file's extension. Without this a typeless Blob is stored as
         // application/octet-stream regardless of the actual file type.
-        const contentType =
-          opts.contentType ?? mimeTypeFromName(file) ?? 'application/octet-stream';
+        const contentType = resolveUploadContentType(file, opts.contentType);
 
         // Build multipart form data. The Blob's type becomes the multipart
         // part's Content-Type, which the backend stores as the object's MIME type.

--- a/src/lib/mime.test.ts
+++ b/src/lib/mime.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mimeTypeFromName } from './mime.js';
+
+describe('mimeTypeFromName', () => {
+  it('infers common types from the extension', () => {
+    expect(mimeTypeFromName('photo.png')).toBe('image/png');
+    expect(mimeTypeFromName('a.jpeg')).toBe('image/jpeg');
+    expect(mimeTypeFromName('report.pdf')).toBe('application/pdf');
+    expect(mimeTypeFromName('data.json')).toBe('application/json');
+    expect(mimeTypeFromName('clip.mp4')).toBe('video/mp4');
+  });
+
+  it('is case-insensitive and handles full paths', () => {
+    expect(mimeTypeFromName('IMG.PNG')).toBe('image/png');
+    expect(mimeTypeFromName('/tmp/sub dir/cover.JPG')).toBe('image/jpeg');
+    expect(mimeTypeFromName('archive.tar.gz')).toBe('application/gzip');
+  });
+
+  it('returns undefined for unknown or missing extensions', () => {
+    expect(mimeTypeFromName('file.unknownext')).toBeUndefined();
+    expect(mimeTypeFromName('noext')).toBeUndefined();
+    expect(mimeTypeFromName('trailingdot.')).toBeUndefined();
+    expect(mimeTypeFromName('.gitignore')).toBeUndefined();
+  });
+});

--- a/src/lib/mime.test.ts
+++ b/src/lib/mime.test.ts
@@ -16,6 +16,12 @@ describe('mimeTypeFromName', () => {
     expect(mimeTypeFromName('archive.tar.gz')).toBe('application/gzip');
   });
 
+  it('ignores dots in parent directories (basename only)', () => {
+    expect(mimeTypeFromName('/home/user.name/photo.png')).toBe('image/png');
+    expect(mimeTypeFromName('/home/user.name/datafile')).toBeUndefined();
+    expect(mimeTypeFromName('C:\\Users\\a.b\\report.pdf')).toBe('application/pdf');
+  });
+
   it('returns undefined for unknown or missing extensions', () => {
     expect(mimeTypeFromName('file.unknownext')).toBeUndefined();
     expect(mimeTypeFromName('noext')).toBeUndefined();

--- a/src/lib/mime.ts
+++ b/src/lib/mime.ts
@@ -1,0 +1,82 @@
+/**
+ * Minimal extension → MIME type lookup for storage uploads.
+ *
+ * The CLI reads raw bytes off disk, so unlike a browser `File` there is no
+ * `type` to read — without inference every upload would be stored as
+ * `application/octet-stream`. We infer from the filename extension (the same
+ * approach `aws s3 cp` uses). Unknown extensions fall back to octet-stream,
+ * which is the server's default anyway, so this is strictly an improvement.
+ */
+
+const EXTENSION_MIME_TYPES: Record<string, string> = {
+  // Images
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  avif: 'image/avif',
+  heic: 'image/heic',
+  heif: 'image/heif',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+  // Documents
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  // Text / data
+  txt: 'text/plain',
+  csv: 'text/csv',
+  md: 'text/markdown',
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  json: 'application/json',
+  xml: 'application/xml',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+  // Archives
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+  rar: 'application/vnd.rar',
+  '7z': 'application/x-7z-compressed',
+  // Audio
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  m4a: 'audio/mp4',
+  flac: 'audio/flac',
+  aac: 'audio/aac',
+  // Video
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  // Fonts
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+};
+
+/**
+ * Infer a MIME type from a filename/path extension. Returns `undefined` when the
+ * extension is missing or unrecognized.
+ */
+export function mimeTypeFromName(name: string): string | undefined {
+  const lastDot = name.lastIndexOf('.');
+  if (lastDot < 0 || lastDot === name.length - 1) return undefined;
+  const ext = name.slice(lastDot + 1).toLowerCase();
+  return EXTENSION_MIME_TYPES[ext];
+}

--- a/src/lib/mime.ts
+++ b/src/lib/mime.ts
@@ -75,8 +75,11 @@ const EXTENSION_MIME_TYPES: Record<string, string> = {
  * extension is missing or unrecognized.
  */
 export function mimeTypeFromName(name: string): string | undefined {
-  const lastDot = name.lastIndexOf('.');
-  if (lastDot < 0 || lastDot === name.length - 1) return undefined;
-  const ext = name.slice(lastDot + 1).toLowerCase();
+  // Strip any directory portion first so a dot in a parent directory
+  // (e.g. "/home/user.name/datafile") can't be mistaken for an extension.
+  const base = name.slice(Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\')) + 1);
+  const lastDot = base.lastIndexOf('.');
+  if (lastDot < 0 || lastDot === base.length - 1) return undefined;
+  const ext = base.slice(lastDot + 1).toLowerCase();
   return EXTENSION_MIME_TYPES[ext];
 }


### PR DESCRIPTION
## Why

Linear [INS-358](https://linear.app/insforge/issue/INS-358): storage uploads default to `application/octet-stream` instead of the actual file type.

Verified against source that the **CLI is the affected path, on every upload**. `storage upload` built the body with `new Blob([fileContent])` and never set a type ([`src/commands/storage/upload.ts:33`](https://github.com/InsForge/CLI/blob/main/src/commands/storage/upload.ts)). A typeless `Blob` serializes its multipart part as `application/octet-stream`, and the backend trusts the client's value — it stores `file.mimetype || null` and the S3 provider falls back to `application/octet-stream`; it never infers from the extension. So every CLI-uploaded object got the wrong MIME type.

## What

- Infer the MIME type from the file's extension and set it on the blob, so it reaches the server via the multipart part. This is the right place to infer — the CLI reads a real file off disk (same approach `aws s3 cp` uses).
- Add a `--content-type <type>` flag to override the inferred value.
- New `src/lib/mime.ts` helper (small self-contained lookup, no new runtime dependency) + unit tests.
- Unknown extensions still fall back to `application/octet-stream`, so there is **no regression**.

```
storage upload ./cover.png --bucket images                  # → image/png
storage upload ./data.bin  --bucket files --content-type application/json
```

## Test

- `vitest run src/lib/mime.test.ts` ✅ (case-insensitivity, paths, unknown/missing extensions)
- `npm run lint` ✅ (0 errors) · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CLI storage uploads now send the correct MIME type instead of always `application/octet-stream`, fixing INS-358. Also bumps `@insforge/cli` to 0.1.91.

- **Bug Fixes**
  - Infer type from the basename’s extension and set it on the multipart Blob; fall back to `application/octet-stream` for unknown/missing extensions.
  - Enforce precedence: override > inferred > fallback; ignore empty/whitespace `--content-type`.

- **New Features**
  - Adds `--content-type <type>` to override the inferred type.
  - Introduces `src/lib/mime.ts` and `resolveUploadContentType` with unit tests; no new runtime dependencies.

<sup>Written for commit 5ca75b3d09ed1560796fb9e5f28580511c4bc278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set MIME content type on `storage upload` CLI command based on file extension
> - Adds a `--content-type` flag to the `storage upload` command; if omitted, the type is inferred from the file extension via a new `mimeTypeFromName` utility in [mime.ts](https://github.com/InsForge/CLI/pull/168/files#diff-53bf5ead157b92bb4808bad227054fbe0d6d503f08054423cb77683e583c97d5), falling back to `application/octet-stream`.
> - `mimeTypeFromName` covers common extensions across images, documents, text/data, archives, audio, video, and fonts.
> - The resolved type is passed to the `Blob` constructor so the multipart `file` part carries the correct `Content-Type` instead of always sending `application/octet-stream`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #168 opened
>
> - Modified `mimeTypeFromName` utility to extract file extensions from the basename only [77bb5bc]
> - Introduced `resolveUploadContentType` utility and integrated it into storage upload command [77bb5bc]
> - Added test coverage for content type resolution and MIME type inference [77bb5bc]
> - Bumped package version from 0.1.90 to 0.1.91 [5ca75b3]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0742071.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--content-type` flag for storage uploads, allowing explicit MIME type specification or automatic detection from file extension, with `application/octet-stream` as fallback.

* **Chores**
  * Version updated to 0.1.91.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->