### PR TITLE
test: remove all explicit `any` types from test files

### DIFF
--- a/src/commands/branch/create.test.ts
+++ b/src/commands/branch/create.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { Command } from 'commander';
 import { registerBranchCreateCommand } from './create.js';
 
@@ -70,18 +70,18 @@ describe('branch create', () => {
 
   it('rejects when no project linked', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue(null);
+    (getProjectConfig as Mock).mockReturnValue(null);
     const program = new Command().exitOverride();
     program.option('--json').option('--api-url <url>').option('-y, --yes');
     registerBranchCreateCommand(program);
     let exitCode: number | undefined;
     const origExit = process.exit;
-    (process.exit as any) = (code?: number) => {
+    process.exit = ((code?: number) => {
       exitCode = code;
       throw new Error('__exit__');
-    };
+    }) as typeof process.exit;
     const origStderr = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
     try {
       await program
         .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch', '--json'], {
@@ -97,7 +97,7 @@ describe('branch create', () => {
 
   it('rejects an invalid --mode value before any API call', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -107,12 +107,12 @@ describe('branch create', () => {
     registerBranchCreateCommand(program);
     let exitCode: number | undefined;
     const origExit = process.exit;
-    (process.exit as any) = (code?: number) => {
+    process.exit = ((code?: number) => {
       exitCode = code;
       throw new Error('__exit__');
-    };
+    }) as typeof process.exit;
     const origStderr = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
     try {
       await program
         .parseAsync(['create', 'feat-x', '--mode', 'bogus', '--no-switch', '--json'], {
@@ -130,7 +130,7 @@ describe('branch create', () => {
 
   it('happy path with --json: posts then prints branch payload', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -168,7 +168,7 @@ describe('branch create', () => {
 
   it('happy path without --no-switch invokes runBranchSwitch', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -205,7 +205,7 @@ describe('branch create', () => {
 
   it('switch failure after a successful create reports "switch failed", not "creation failed"', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -215,19 +215,19 @@ describe('branch create', () => {
       oss_host: 'https://p1ky.us-east.insforge.app',
     });
     const { runBranchSwitch } = await import('./switch.js');
-    (runBranchSwitch as any).mockRejectedValueOnce(new Error('network down'));
+    (runBranchSwitch as Mock).mockRejectedValueOnce(new Error('network down'));
 
     const program = new Command().exitOverride();
     program.option('--json').option('--api-url <url>').option('-y, --yes');
     registerBranchCreateCommand(program);
     let exitCode: number | undefined;
     const origExit = process.exit;
-    (process.exit as any) = (code?: number) => {
+    process.exit = ((code?: number) => {
       exitCode = code;
       throw new Error('__exit__');
-    };
+    }) as typeof process.exit;
     const origStderr = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
     try {
       await program
         .parseAsync(['create', 'feat-x', '--mode', 'full'], { from: 'user' })
@@ -249,7 +249,7 @@ describe('branch create', () => {
 
   it('non-JSON path drives the spinner and keeps it active through switch', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',

--- a/src/commands/branch/delete.test.ts
+++ b/src/commands/branch/delete.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { Command } from 'commander';
 import { registerBranchDeleteCommand } from './delete.js';
 
@@ -59,7 +59,7 @@ describe('branch delete', () => {
 
   it('happy path with --yes calls deleteBranchApi and captures analytics', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -75,7 +75,7 @@ describe('branch delete', () => {
 
   it('errors when the named branch does not exist', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -90,7 +90,7 @@ describe('branch delete', () => {
 
   it('auto-switches back to parent when deleting the currently active branch', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b1',
       project_name: 'feat-x',
       org_id: 'o1',
@@ -112,7 +112,7 @@ describe('branch delete', () => {
 
   it('does not auto-switch when the deleted branch is not the currently active one', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -125,14 +125,14 @@ describe('branch delete', () => {
 
   it('does not abort the delete command when post-delete switch-back fails', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b1',
       project_name: 'feat-x',
       org_id: 'o1',
       branched_from: { project_id: 'p1', project_name: 'parent' },
     });
     const { runBranchSwitch } = await import('./switch.js');
-    (runBranchSwitch as any).mockRejectedValueOnce(new Error('no parent backup'));
+    (runBranchSwitch as Mock).mockRejectedValueOnce(new Error('no parent backup'));
     const program = makeProgram();
     await runSilently(program, ['delete', 'feat-x', '--yes', '--json']);
     // Delete still went through despite the switch-back failure.
@@ -142,7 +142,7 @@ describe('branch delete', () => {
 
   it('json mode reports switched_back=true when the active branch was deleted', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b1',
       project_name: 'feat-x',
       org_id: 'o1',

--- a/src/commands/branch/list.test.ts
+++ b/src/commands/branch/list.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { Command } from 'commander';
 import { registerBranchListCommand } from './list.js';
 
@@ -69,7 +69,7 @@ describe('branch list', () => {
 
   it('lists siblings against project_id when not on a branch', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -86,7 +86,7 @@ describe('branch list', () => {
 
   it('lists siblings against branched_from.project_id when currently switched onto a branch', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b1',
       project_name: 'feat-x',
       org_id: 'o1',
@@ -104,7 +104,7 @@ describe('branch list', () => {
 
   it('json mode emits a single JSON document with the branches array', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -119,7 +119,7 @@ describe('branch list', () => {
 
   it('table mode marks the current branch with `*`', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b1',
       project_name: 'feat-x',
       org_id: 'o1',
@@ -143,7 +143,7 @@ describe('branch list', () => {
 
   it('does not mark any branch when currently on the parent', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -159,13 +159,13 @@ describe('branch list', () => {
 
   it('prints "No branches." when the API returns an empty list', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
     });
     const { listBranchesApi } = await import('../../lib/api/platform.js');
-    (listBranchesApi as any).mockResolvedValueOnce([]);
+    (listBranchesApi as Mock).mockResolvedValueOnce([]);
     const program = makeProgram();
     const logs = await runWithCapturedLog(program, ['list']);
     expect(logs.join('\n')).toContain('No branches.');

--- a/src/commands/branch/merge.test.ts
+++ b/src/commands/branch/merge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { Command } from 'commander';
 import { registerBranchMergeCommand } from './merge.js';
 
@@ -143,7 +143,7 @@ describe('branch merge', () => {
 
   it('conflict path exits with code 2 and prints per-conflict summary', async () => {
     const { mergeBranchDryRunApi } = await import('../../lib/api/platform.js');
-    (mergeBranchDryRunApi as any).mockResolvedValueOnce({
+    (mergeBranchDryRunApi as Mock).mockResolvedValueOnce({
       summary: { added: 0, modified: 0, conflicts: 1 },
       rendered_sql: '-- ⚠️ MERGE BLOCKED: 1 conflict(s) detected.',
       changes: [],
@@ -167,14 +167,14 @@ describe('branch merge', () => {
     // overwrite the meaningful first exit. The first call is what the user sees.
     let exitCode: number | undefined;
     const origExit = process.exit;
-    (process.exit as any) = (code?: number) => {
+    process.exit = ((code?: number) => {
       if (exitCode === undefined) exitCode = code;
       throw new Error('__exit__');
-    };
+    }) as typeof process.exit;
     const origLog = console.log;
     console.log = () => {};
     const origStderr = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
     try {
       await program
         .parseAsync(['merge', 'feat-x', '--dry-run'], { from: 'user' })

--- a/src/commands/branch/switch.test.ts
+++ b/src/commands/branch/switch.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { runBranchSwitch } from './switch.js';
+import type { ProjectConfig } from '../../types.js';
 
-const saveCalls: any[] = [];
+const saveCalls: ProjectConfig[] = [];
 
 vi.mock('../../lib/config.js', () => ({
   getProjectConfig: vi.fn(),
-  saveProjectConfig: vi.fn((c: any) => saveCalls.push(c)),
+  saveProjectConfig: vi.fn((c: ProjectConfig) => saveCalls.push(c)),
   getProjectConfigFile: () => '/tmp/_test_/.insforge/project.json',
   getParentBackupFile: () => '/tmp/_test_/.insforge/project.parent.json',
   buildOssHost: (appkey: string, region: string) => `https://${appkey}.${region}.insforge.app`,
@@ -59,7 +60,7 @@ describe('runBranchSwitch', () => {
 
   it('switches from parent to a branch and creates parent.json backup', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'p1',
       project_name: 'parent',
       org_id: 'o1',
@@ -86,7 +87,7 @@ describe('runBranchSwitch', () => {
 
   it('preserves parent backup when switching branch -> branch', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b0',
       project_name: 'feat-y',
       org_id: 'o1',
@@ -107,9 +108,9 @@ describe('runBranchSwitch', () => {
 
   it('refuses to switch to a branch not in ready state', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({ project_id: 'p1', project_name: 'parent', org_id: 'o1' });
+    (getProjectConfig as Mock).mockReturnValue({ project_id: 'p1', project_name: 'parent', org_id: 'o1' });
     const { listBranchesApi } = await import('../../lib/api/platform.js');
-    (listBranchesApi as any).mockResolvedValueOnce([
+    (listBranchesApi as Mock).mockResolvedValueOnce([
       {
         id: 'b1',
         name: 'feat-x',
@@ -129,7 +130,7 @@ describe('runBranchSwitch', () => {
 
   it('--parent restores from backup and removes the backup file', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b1',
       project_name: 'feat-x',
       org_id: 'o1',
@@ -148,7 +149,7 @@ describe('runBranchSwitch', () => {
 
   it('rejects passing both a branch name and --parent', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({
+    (getProjectConfig as Mock).mockReturnValue({
       project_id: 'b1',
       project_name: 'feat-x',
       org_id: 'o1',
@@ -161,7 +162,7 @@ describe('runBranchSwitch', () => {
 
   it('--parent fails clearly when no backup exists', async () => {
     const { getProjectConfig } = await import('../../lib/config.js');
-    (getProjectConfig as any).mockReturnValue({ project_id: 'b1', project_name: 'feat-x', org_id: 'o1' });
+    (getProjectConfig as Mock).mockReturnValue({ project_id: 'b1', project_name: 'feat-x', org_id: 'o1' });
     fsMock.existsSync.mockReturnValueOnce(false);
     await expect(
       runBranchSwitch({ toParent: true, apiUrl: undefined, json: true }),

--- a/src/commands/memory/memory.test.ts
+++ b/src/commands/memory/memory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { Command } from 'commander';
 import { registerMemoryCommands } from './index.js';
 
@@ -49,13 +49,13 @@ describe('memory commands', () => {
 
   it('remember stores a single fact (not transcript) and honors --kind/--title', async () => {
     const { ossFetch } = await import('../../lib/api/oss.js');
-    (ossFetch as any).mockResolvedValue(mockResponse({ results: [{ action: 'ADD', title: 'T' }] }));
+    (ossFetch as Mock).mockResolvedValue(mockResponse({ results: [{ action: 'ADD', title: 'T' }] }));
 
     await run(['memory', 'remember', 'some content', '--scope', 's', '--kind', 'decision', '--title', 'T']);
 
-    const [path, opts] = (ossFetch as any).mock.calls[0];
+    const [path, opts] = (ossFetch as Mock).mock.calls[0];
     expect(path).toBe('/api/memory/remember');
-    const body = JSON.parse(opts.body);
+    const body = JSON.parse(opts?.body as string);
     expect(body).toMatchObject({ scope: 's', kind: 'decision', title: 'T', content: 'some content' });
     expect(body.transcript).toBeUndefined();
 
@@ -65,32 +65,32 @@ describe('memory commands', () => {
 
   it('remember --transcript sends transcript mode', async () => {
     const { ossFetch } = await import('../../lib/api/oss.js');
-    (ossFetch as any).mockResolvedValue(mockResponse({ results: [] }));
+    (ossFetch as Mock).mockResolvedValue(mockResponse({ results: [] }));
 
     await run(['memory', 'remember', 'a long transcript', '--transcript', '--scope', 's']);
 
-    const body = JSON.parse((ossFetch as any).mock.calls[0][1].body);
+    const body = JSON.parse((ossFetch as Mock).mock.calls[0][1]?.body as string);
     expect(body.transcript).toBe('a long transcript');
     expect(body.content).toBeUndefined();
   });
 
   it('recall posts the query to the recall endpoint', async () => {
     const { ossFetch } = await import('../../lib/api/oss.js');
-    (ossFetch as any).mockResolvedValue(mockResponse({ memories: [] }));
+    (ossFetch as Mock).mockResolvedValue(mockResponse({ memories: [] }));
 
     await run(['memory', 'recall', 'where is the secret', '--scope', 's', '--limit', '3']);
 
-    const [path, opts] = (ossFetch as any).mock.calls[0];
+    const [path, opts] = (ossFetch as Mock).mock.calls[0];
     expect(path).toBe('/api/memory/recall');
-    expect(JSON.parse(opts.body)).toMatchObject({ scope: 's', query: 'where is the secret', limit: 3 });
+    expect(JSON.parse(opts?.body as string)).toMatchObject({ scope: 's', query: 'where is the secret', limit: 3 });
   });
 
   it('list hits the index endpoint', async () => {
     const { ossFetch } = await import('../../lib/api/oss.js');
-    (ossFetch as any).mockResolvedValue(mockResponse({ entries: [] }));
+    (ossFetch as Mock).mockResolvedValue(mockResponse({ entries: [] }));
 
     await run(['memory', 'list', '--scope', 's']);
 
-    expect((ossFetch as any).mock.calls[0][0]).toBe('/api/memory/index');
+    expect((ossFetch as Mock).mock.calls[0][0]).toBe('/api/memory/index');
   });
 });


### PR DESCRIPTION
## Summary
Removes all 47 `@typescript-eslint/no-explicit-any` warnings in the repo. Every one was confined to 6 test files (`branch` command tests + `memory` test); production `src/` code was already `any`-free.

The `any`s fell into three patterns, each replaced with a real type:

| Pattern | Before | After |
|---|---|---|
| Mock method calls | `(getProjectConfig as any).mockReturnValue(...)` | `(getProjectConfig as Mock).mockReturnValue(...)` |
| Node global stubs | `(process.exit as any) = (code?) => {...}` | `process.exit = ((code?) => {...}) as typeof process.exit` |
| Typed fixtures | `const saveCalls: any[]` / `(c: any) =>` | `ProjectConfig[]` / `(c: ProjectConfig) =>` |

## Notes
- Uses vitest's real `Mock` type (imported via `type Mock`) instead of `any`. The stricter `vi.mocked()` was tried first, but it forces every `getProjectConfig` mock to supply a complete `ProjectConfig`; these tests deliberately use minimal partial fixtures, so `as Mock` keeps them readable without reintroducing `any`.
- For `process.exit` / `process.stderr.write`, casting to the property's own type (`as typeof process.exit`) keeps the assigned stub shape-checked rather than untyped.

## Verification
- `npx eslint src/` → **0** `no-explicit-any` (0 other problems)
- `npm run lint` (full CI: vitest + eslint) → **516 passed**, 13 skipped, clean
- `tsc --noEmit` introduces no new errors in the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove all explicit `any` from test files, replacing them with real types to clear `@typescript-eslint/no-explicit-any` warnings. No production code changes; ESLint is clean and tests pass.

- **Refactors**
  - Use `vitest` `Mock` for mocked functions instead of `as any`.
  - Cast Node global stubs to their own types (e.g., `process.exit` as `typeof process.exit`, `process.stderr.write`).
  - Type fixtures and callbacks with `ProjectConfig`; adjust tests to read typed request bodies in memory command tests.

<sup>Written for commit 808a4c1b77f8dc034d9b8805dc7fcc3037f1f488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove explicit `any` type casts from test files
> Replaces `as any` casts with `as Mock` (imported from vitest) when accessing mock methods on stubbed functions across branch and memory command test files. Also tightens typings for temporary `process.exit` and `process.stderr.write` overrides using `typeof` casts. No changes to test logic or assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 808a4c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved TypeScript type safety in test files by strengthening type assertions for mocked functions across branch and memory command tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->