### PR TITLE
fix(compute): default CLI fly.toml stub to scale-to-zero

### DIFF
--- a/src/lib/flyctl.test.ts
+++ b/src/lib/flyctl.test.ts
@@ -351,6 +351,10 @@ describe('flyctlBuildAndPush', () => {
     expect(body).toContain('app = "my-svc-proj-abc123"');
     expect(body).toContain('primary_region = "iad"');
     expect(body).toContain('internal_port = 8080');
+    // Default scale-to-zero — consistent with the cloud Machines-API path.
+    expect(body).toContain('auto_stop_machines = "stop"');
+    expect(body).toContain('min_machines_running = 0');
+    expect(body).not.toContain('auto_stop_machines = false');
     expect(unlinkSyncMock).toHaveBeenCalledWith('/tmp/app/fly.toml');
   });
 

--- a/src/lib/flyctl.ts
+++ b/src/lib/flyctl.ts
@@ -60,12 +60,16 @@ function ensureFlyTomlStub(opts: { dir: string; appId: string; region: string; p
       /* user owns the file — leave as-is */
     };
   }
+  // Default to scale-to-zero (`auto_stop_machines = "stop"`), matching both the
+  // cloud Machines-API provisioning path and Fly's own `fly launch` default —
+  // idle machines stop instead of billing 24/7. Users who need always-on
+  // supply their own fly.toml (the existsSync check above leaves it untouched).
   const serviceBlock =
     opts.protocol === 'tcp'
       ? `[[services]]\n` +
         `  internal_port = ${opts.port}\n` +
         `  protocol = "tcp"\n` +
-        `  auto_stop_machines = false\n` +
+        `  auto_stop_machines = "stop"\n` +
         `  auto_start_machines = true\n` +
         `  min_machines_running = 0\n` +
         `\n` +
@@ -74,7 +78,7 @@ function ensureFlyTomlStub(opts: { dir: string; appId: string; region: string; p
       : `[http_service]\n` +
         `  internal_port = ${opts.port}\n` +
         `  force_https = true\n` +
-        `  auto_stop_machines = false\n` +
+        `  auto_stop_machines = "stop"\n` +
         `  auto_start_machines = true\n` +
         `  min_machines_running = 0\n`;
   const stub =


### PR DESCRIPTION
## Problem

The CLI's compute-deploy path auto-generates a stub `fly.toml` (only when the user doesn't already have one, in `ensureFlyTomlStub`). That stub set **`auto_stop_machines = false`** — i.e. **always-on**.

This is inconsistent two ways:
- vs the **cloud Machines-API provisioning path** (`insforge-cloud-backend` PR #675), which now defaults machines to **scale-to-zero**.
- vs **Fly's own `fly launch` default**, which is `auto_stop_machines = "stop"`.

Result: machines deployed through the CLI flyctl path bill 24/7 even when idle.

## Change

Default the generated stub to **`auto_stop_machines = "stop"`** (both the `[[services]]` TCP and `[http_service]` HTTP branches). Idle machines now stop instead of running continuously — consistent with the cloud path and Fly's default.

**Escape hatch unchanged:** the stub is only written when the user has **no** `fly.toml`. Anyone who needs always-on (or any custom scaling) supplies their own `fly.toml` and the CLI leaves it untouched (the `existsSync` guard).

## Tests

- Extended the existing stub test to assert the generated body now contains `auto_stop_machines = "stop"` + `min_machines_running = 0`, and no longer contains `auto_stop_machines = false`.
- `vitest run flyctl.test.ts` → **18 passed**. `tsc` clean for `flyctl`. eslint clean. `tsup` build succeeds.

## Related

Companion to `insforge-cloud-backend` #675 (scale-to-zero on the Machines-API path). Together they make CLI-deployed and cloud-provisioned compute behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the CLI-generated `fly.toml` stub to scale-to-zero by default. Idle machines now stop instead of running 24/7, matching the cloud Machines-API path and Fly’s `fly launch` default.

- **Bug Fixes**
  - Stub now sets `auto_stop_machines = "stop"` in both `[[services]]` and `[http_service]`, with `min_machines_running = 0`.
  - Updated tests; stub still only writes when no `fly.toml` exists, so custom always-on configs are respected.

<sup>Written for commit b005f556422424db4dc5398c62fbb11af821fb3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `auto_stop_machines` to `"stop"` in generated `fly.toml` stubs
> Changes `ensureFlyTomlStub` in [flyctl.ts](https://github.com/InsForge/CLI/pull/171/files#diff-ad8a1a639faf939c154d49e7f48ae5bd9b8d414cb2a1e91687bf8829c72d87df) to set `auto_stop_machines = "stop"` instead of `false` for both HTTP and TCP service blocks, enabling scale-to-zero by default. Adds test assertions in [flyctl.test.ts](https://github.com/InsForge/CLI/pull/171/files#diff-1c4e2ab2047371606003a749403aa70f1df6eaea05dcb54a06c7fa3fd586be2b) to verify the new defaults are present and the old `false` value is absent. Behavioral Change: any app deployed using the generated stub will now stop idle machines by default rather than keeping them running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b005f55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Machine idle handling now defaults to automatic scale-to-zero, stopping idle machines to optimize costs. Existing configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->