### PR TITLE
feat(compute): show service ID column in `compute list`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/compute/list.ts
+++ b/src/commands/compute/list.ts
@@ -27,7 +27,9 @@ export function registerComputeListCommand(computeCmd: Command): void {
             return;
           }
           outputTable(
-            ['Name', 'Status', 'Image', 'CPU', 'Memory', 'Endpoint'],
+            // ID first: it's the value `compute get/update/stop/delete <id>`
+            // expect, so it should be the easiest column to copy out of `list`.
+            ['ID', 'Name', 'Status', 'Image', 'CPU', 'Memory', 'Endpoint'],
             services.map((s) => {
               // For TCP services the backend's endpointUrl is still https:// (no
               // listener answers there). Show the usable host:port form so users
@@ -37,6 +39,7 @@ export function registerComputeListCommand(computeCmd: Command): void {
                   ? `${String(s.endpointUrl).replace(/^https?:\/\//, '')}:${s.port}`
                   : String(s.endpointUrl ?? '-');
               return [
+                String(s.id ?? '-'),
                 String(s.name ?? '-'),
                 String(s.status ?? '-'),
                 String(s.imageUrl ?? '-'),


### PR DESCRIPTION
## Problem

`compute get/update/stop/delete` all take the service **UUID**, but `compute list`'s table only showed `Name / Status / Image / CPU / Memory / Endpoint` — there was no way to get a usable id from the table. Running `compute get <name>` fails:

```
Error: invalid input syntax for type uuid: "firth-control-plane"
```

Reported in Slack; users had to fall back to `compute list --json | jq .id`.

## Fix

Add an **ID** column (placed first, so it's the easiest value to copy) sourced from the same `s.id` field the `--json` output and `compute get` already render.

```
┌──────────────────────────────────────┬─────────────────────┬─────────┬ ...
│ ID                                   │ Name                │ Status  │ ...
├──────────────────────────────────────┼─────────────────────┼─────────┼ ...
│ 0662c2ef-202a-4feb-8267-5501b3b60037 │ firth-control-plane │ running │ ...
```

Table-only change; `--json` output is unaffected (it already includes `id`), so the integration tests (which use `--json`) are unchanged.

Closes INS-382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an ID (UUID) column to `compute list`, shown first, so you can copy a valid service ID for `compute get/update/stop/delete`. Addresses INS-382; `--json` output already includes `id` and is unchanged.

- **Dependencies**
  - Bump `@insforge/cli` version to 0.1.92.

<sup>Written for commit d429a2ca2e481904e6bd41b6721bc8b69a2eb016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add service ID as first column in `compute list` tabular output
> Adds an `ID` column as the first column in the human-readable table printed by `compute list` in [list.ts](https://github.com/InsForge/CLI/pull/172/files#diff-fe702231a88602491294eba1fa168764ff95c85be393e7ec377caa6a74831626). JSON output is unaffected.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #172 opened
>
> - Updated package version [d429a2c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba0e47e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `compute list` command table output now includes a leading **ID** column, showing each service’s unique identifier first (using `-` when an ID is unavailable), followed by the service name.
* **Chores**
  * Bumped the package version to `0.1.92`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->