### PR TITLE
Docs: fix readme global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ All commands support the following flags:
 | Flag                | Description                                              |
 | ------------------- | -------------------------------------------------------- |
 | `--json`            | Output in JSON format (useful for scripts and AI agents) |
-| `--project-id <id>` | Override the linked project ID                           |
 | `--api-url <url>`   | Override the Platform API URL                            |
 | `-y, --yes`         | Skip confirmation prompts                                |
+
+The `--project-id <id>` flag is command-specific and is supported by `link`
+when you want to link a directory directly to a known project.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Fetch backend container logs.
 npx @insforge/cli logs <source> [options]
 ```
 
-**Sources:** `insforge.logs`, `postgREST.logs`, `postgres.logs`, `function.logs`
+**Sources:** `insforge.logs`, `PostgREST.logs`, `postgres.logs`, `function.logs`
 
 **Options:**
 

--- a/docs/specs/2026-03-27-diagnose-command-design.md
+++ b/docs/specs/2026-03-27-diagnose-command-design.md
@@ -45,7 +45,7 @@ Comprehensive health report. Fetches all 4 data sources in parallel via `Promise
 │    Dead tuples: 2,060   Locks waiting: 0        │
 ├─────────────────────────────────────────────────┤
 │  Recent Errors (last 100 logs per source)       │
-│    insforge.logs: 0  postgREST.logs: 2          │
+│    insforge.logs: 0  PostgREST.logs: 2          │
 │    postgres.logs: 0  function.logs: 1           │
 └─────────────────────────────────────────────────┘
 ```
@@ -134,7 +134,7 @@ Latest = last data point. Avg/Max computed from `MetricSeries.data[]`. Network v
 | `--source` | string | all 4 sources | Log source name |
 | `--limit` | number | 100 | Entries per source |
 
-**Log sources:** `insforge.logs`, `postgREST.logs`, `postgres.logs`, `function.logs`
+**Log sources:** `insforge.logs`, `PostgREST.logs`, `postgres.logs`, `function.logs`
 
 **API:** `GET /api/logs/{source}?limit={n}` for each source.
 

--- a/docs/specs/2026-03-27-diagnose-implementation-plan.md
+++ b/docs/specs/2026-03-27-diagnose-implementation-plan.md
@@ -560,7 +560,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
 
-const LOG_SOURCES = ['insforge.logs', 'postgREST.logs', 'postgres.logs', 'function.logs'] as const;
+const LOG_SOURCES = ['insforge.logs', 'PostgREST.logs', 'postgres.logs', 'function.logs'] as const;
 
 const ERROR_PATTERN = /\b(error|fatal|panic)\b/i;
 


### PR DESCRIPTION
This pull request updates documentation and implementation details to standardize the casing of log source names, specifically changing `postgREST.logs` to `PostgREST.logs` for consistent with actual CLI behavior. It also clarifies the usage of the `--project-id` flag in the CLI documentation.

Standardization of log source names:

* Updated all references of `postgREST.logs` to `PostgREST.logs` in the CLI documentation (`README.md`), design spec (`docs/specs/2026-03-27-diagnose-command-design.md`), and implementation plan (`docs/specs/2026-03-27-diagnose-implementation-plan.md`) to ensure consistent casing across the project. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L165-R167) [[2]](diffhunk://#diff-02fa8dc8df76a9abe2036234413014493e640ccfd88d381c2f962662f47cd048L48-R48) [[3]](diffhunk://#diff-02fa8dc8df76a9abe2036234413014493e640ccfd88d381c2f962662f47cd048L137-R137) [[4]](diffhunk://#diff-e1866534f7f8ce6317533f0317a25bbc998b153d46f9f8b7203f8bedabf77614L563-R563)

Documentation improvements:

* Clarified that the `--project-id` flag is command-specific and is only supported by the `link` command in the CLI documentation (`README.md`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized log source casing in docs from `postgREST.logs` to `PostgREST.logs` to match the CLI, and clarified that `--project-id` is only supported by the `link` command.

<sup>Written for commit d9e7cb5ea4669850165d70a2a25923af6e47a9e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix README global options table and standardize `PostgREST.logs` casing in docs
> - Removes `--project-id <id>` from the global flags table in [README.md](https://github.com/InsForge/CLI/pull/173/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and adds a note clarifying it is command-specific, supported by the `link` command.
> - Standardizes the log source name from `postgREST.logs` to `PostgREST.logs` across [README.md](https://github.com/InsForge/CLI/pull/173/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [diagnose-command-design.md](https://github.com/InsForge/CLI/pull/173/files#diff-02fa8dc8df76a9abe2036234413014493e640ccfd88d381c2f962662f47cd048), and [diagnose-implementation-plan.md](https://github.com/InsForge/CLI/pull/173/files#diff-e1866534f7f8ce6317533f0317a25bbc998b153d46f9f8b7203f8bedabf77614).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9e7cb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Global Options documentation: the `--project-id` flag is now documented as command-specific to the `link` command for direct project linking, rather than as a global flag.
  * Corrected capitalization of the PostgREST log source name (PostgREST.logs) in documentation and specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->