### PR TITLE
feat(cli): project, billing, org, backup & key management commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/backups/index.ts
+++ b/src/commands/backups/index.ts
@@ -1,0 +1,201 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import {
+  listBackups,
+  getLatestBackup,
+  createBackup,
+  renameBackup,
+  deleteBackup,
+  restoreBackup,
+} from '../../lib/api/platform.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
+import { getProjectId } from '../../lib/config.js';
+import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
+import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
+import type { Backup } from '../../types.js';
+
+function resolveProjectId(opts: { project?: string }): string {
+  const id = getProjectId(opts.project);
+  if (!id) {
+    throw new CLIError('No project specified. Pass --project <id> or run `insforge link` first.');
+  }
+  return id;
+}
+
+function formatBytes(n: number | null): string {
+  if (!n) return '-';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(n) / Math.log(1024)), units.length - 1);
+  return `${(n / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 2)} ${units[i]}`;
+}
+
+function backupRow(b: Backup): string[] {
+  return [
+    b.id,
+    b.name ?? '-',
+    b.status,
+    b.trigger_source,
+    formatBytes(b.size_bytes),
+    new Date(b.created_at).toLocaleString(),
+  ];
+}
+
+const BACKUP_HEADERS = ['ID', 'Name', 'Status', 'Source', 'Size', 'Created'];
+
+export function registerBackupsCommands(backupsCmd: Command): void {
+  backupsCmd
+    .command('list')
+    .description('List project backups')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+        const backups = await listBackups(projectId, apiUrl);
+        if (json) {
+          outputJson(backups);
+        } else if (!backups.length) {
+          outputInfo('No backups found.');
+        } else {
+          outputTable(BACKUP_HEADERS, backups.map(backupRow));
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  backupsCmd
+    .command('latest')
+    .description('Show the most recent backup')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+        const backup = await getLatestBackup(projectId, apiUrl);
+        if (json) {
+          outputJson(backup);
+        } else if (!backup) {
+          outputInfo('No backups found.');
+        } else {
+          outputTable(BACKUP_HEADERS, [backupRow(backup)]);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  backupsCmd
+    .command('create')
+    .description('Create a new backup')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .option('--name <name>', 'Backup name (1–64 characters)')
+    .option('--wait', 'Wait for the backup to finish instead of returning while it is queued')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+        const result = await createBackup(projectId, opts.name, !!opts.wait, apiUrl);
+        captureEvent(projectId, 'cli_backup_create', { named: !!opts.name });
+        if (json) {
+          outputJson(result);
+        } else {
+          outputSuccess(result.message);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+
+  backupsCmd
+    .command('rename <backupId> <name>')
+    .description('Rename a backup (pass "" to clear the name)')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (backupId: string, name: string, opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+        const result = await renameBackup(projectId, backupId, name === '' ? null : name, apiUrl);
+        if (json) {
+          outputJson(result);
+        } else {
+          outputSuccess(`Backup ${backupId} renamed to "${result.name ?? ''}".`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  backupsCmd
+    .command('delete <backupId>')
+    .description('Delete a backup')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (backupId: string, opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+
+        if (!yes && !json) {
+          const confirmed = await clack.confirm({ message: `Delete backup ${backupId}?` });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        await deleteBackup(projectId, backupId, apiUrl);
+        captureEvent(projectId, 'cli_backup_delete', {});
+        if (json) {
+          outputJson({ deleted: true, backup_id: backupId });
+        } else {
+          outputSuccess(`Backup ${backupId} deleted.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+
+  backupsCmd
+    .command('restore <backupId>')
+    .description('Restore the project from a backup (overwrites current data)')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (backupId: string, opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+
+        if (!yes && !json) {
+          const confirmed = await clack.confirm({
+            message: `Restore from backup ${backupId}? This OVERWRITES the project's current database and storage.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        await restoreBackup(projectId, backupId, apiUrl);
+        captureEvent(projectId, 'cli_backup_restore', {});
+        if (json) {
+          outputJson({ restored: true, backup_id: backupId });
+        } else {
+          outputSuccess(`Restore from backup ${backupId} initiated.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+}

--- a/src/commands/backups/index.ts
+++ b/src/commands/backups/index.ts
@@ -76,13 +76,15 @@ export function registerBackupsCommands(backupsCmd: Command): void {
       try {
         await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
-        const backup = await getLatestBackup(projectId, apiUrl);
+        const latest = await getLatestBackup(projectId, apiUrl);
         if (json) {
-          outputJson(backup);
-        } else if (!backup) {
+          outputJson(latest);
+        } else if (!latest) {
           outputInfo('No backups found.');
         } else {
-          outputTable(BACKUP_HEADERS, [backupRow(backup)]);
+          outputInfo(`File:     ${latest.file}`);
+          outputInfo(`Size:     ${formatBytes(latest.size_bytes)}`);
+          outputInfo(`Download: ${latest.download_url}`);
         }
       } catch (err) {
         handleError(err, json);

--- a/src/commands/backups/index.ts
+++ b/src/commands/backups/index.ts
@@ -24,7 +24,8 @@ function resolveProjectId(opts: { project?: string }): string {
 }
 
 function formatBytes(n: number | null): string {
-  if (!n) return '-';
+  if (n === null) return '-';
+  if (n === 0) return '0 B';
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.min(Math.floor(Math.log(n) / Math.log(1024)), units.length - 1);
   return `${(n / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 2)} ${units[i]}`;
@@ -126,7 +127,11 @@ export function registerBackupsCommands(backupsCmd: Command): void {
         if (json) {
           outputJson(result);
         } else {
-          outputSuccess(`Backup ${backupId} renamed to "${result.name ?? ''}".`);
+          outputSuccess(
+            result.name
+              ? `Backup ${backupId} renamed to "${result.name}".`
+              : `Backup ${backupId} name cleared.`,
+          );
         }
       } catch (err) {
         handleError(err, json);

--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -1,0 +1,68 @@
+import type { Command } from 'commander';
+import { getSubscriptionStatus, getCredits } from '../../lib/api/platform.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { resolveOrgId } from '../../lib/resolve-org.js';
+import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
+
+export function registerBillingCommands(billingCmd: Command): void {
+  billingCmd
+    .command('status')
+    .description('Show the organization subscription / current plan')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const sub = await getSubscriptionStatus(orgId, apiUrl);
+
+        if (json) {
+          outputJson(sub);
+        } else {
+          outputTable(
+            ['Field', 'Value'],
+            [
+              ['Plan', sub.plan],
+              ['Status', sub.status],
+              ['Current period end', sub.currentPeriodEnd ? new Date(sub.currentPeriodEnd).toLocaleString() : '-'],
+              ['Cancels at period end', sub.cancelAtPeriodEnd ? 'yes' : 'no'],
+            ],
+          );
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  billingCmd
+    .command('credits')
+    .description('Show the organization credit balance')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const credits = await getCredits(orgId, apiUrl);
+
+        if (json) {
+          outputJson(credits);
+        } else {
+          outputInfo(`Credit balance: ${credits.creditBalanceFormatted}`);
+          if (credits.transactions.length) {
+            outputTable(
+              ['Date', 'Amount', 'Description'],
+              credits.transactions.map((t) => [
+                new Date(t.created).toLocaleDateString(),
+                `${(t.amountCents / 100).toFixed(2)}`,
+                t.description,
+              ]),
+            );
+          }
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/orgs/manage.ts
+++ b/src/commands/orgs/manage.ts
@@ -1,0 +1,196 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import {
+  createOrganization,
+  updateOrganization,
+  listMembers,
+  inviteMember,
+  removeMember,
+  updateMemberRole,
+} from '../../lib/api/platform.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
+import { resolveOrgId } from '../../lib/resolve-org.js';
+import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
+import type { MemberRole } from '../../types.js';
+
+const ORG_TYPES = ['personal', 'team', 'company'];
+const MEMBER_ROLES: MemberRole[] = ['administrator', 'developer'];
+
+function assertRole(role: string): MemberRole {
+  if (!MEMBER_ROLES.includes(role as MemberRole)) {
+    throw new CLIError(`Invalid role "${role}". Valid roles: ${MEMBER_ROLES.join(', ')}.`);
+  }
+  return role as MemberRole;
+}
+
+export function registerOrgsManageCommands(orgsCmd: Command): void {
+  orgsCmd
+    .command('create <name>')
+    .description('Create a new organization')
+    .option('--type <type>', `Organization type (${ORG_TYPES.join(' | ')})`, 'team')
+    .action(async (name: string, opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        if (!ORG_TYPES.includes(opts.type)) {
+          throw new CLIError(`Invalid --type "${opts.type}". Valid types: ${ORG_TYPES.join(', ')}.`);
+        }
+        const org = await createOrganization({ name, type: opts.type }, apiUrl);
+        if (json) {
+          outputJson(org);
+        } else {
+          outputSuccess(`Organization "${org.name}" created (${org.id}).`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  orgsCmd
+    .command('update')
+    .description('Update an organization (name and/or type)')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .option('--name <name>', 'New organization name (min 2 characters)')
+    .option('--type <type>', `Organization type (${ORG_TYPES.join(' | ')})`)
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+
+        const body: { name?: string; type?: string } = {};
+        if (opts.name) body.name = opts.name;
+        if (opts.type) {
+          if (!ORG_TYPES.includes(opts.type)) {
+            throw new CLIError(`Invalid --type "${opts.type}". Valid types: ${ORG_TYPES.join(', ')}.`);
+          }
+          body.type = opts.type;
+        }
+        if (Object.keys(body).length === 0) {
+          throw new CLIError('Nothing to update. Pass --name and/or --type.');
+        }
+
+        const org = await updateOrganization(orgId, body, apiUrl);
+        if (json) {
+          outputJson(org);
+        } else {
+          outputSuccess(`Organization "${org.name}" updated.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  const membersCmd = orgsCmd.command('members').description('Manage organization members');
+
+  membersCmd
+    .command('list')
+    .description('List members and pending invitations')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const { members, invitations } = await listMembers(orgId, apiUrl);
+
+        if (json) {
+          outputJson({ members, invitations });
+          return;
+        }
+        if (!members.length) {
+          outputInfo('No members found.');
+        } else {
+          outputTable(
+            ['Member ID', 'Name', 'Email', 'Role'],
+            members.map((m) => [m.id, m.name ?? '-', m.email ?? '-', m.role]),
+          );
+        }
+        const pending = invitations.filter((i) => i.status === 'pending');
+        if (pending.length) {
+          outputInfo('\nPending invitations:');
+          outputTable(
+            ['Email', 'Role', 'Expires'],
+            pending.map((i) => [i.email, i.role, new Date(i.expires_at).toLocaleDateString()]),
+          );
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  membersCmd
+    .command('invite <email>')
+    .description('Invite a member by email')
+    .option('--role <role>', `Member role (${MEMBER_ROLES.join(' | ')})`, 'developer')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (email: string, opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const role = assertRole(opts.role);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const invitation = await inviteMember(orgId, email, role, apiUrl);
+        if (json) {
+          outputJson(invitation);
+        } else {
+          outputSuccess(`Invited ${email} as ${invitation.role}.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  membersCmd
+    .command('remove <memberId>')
+    .description('Remove a member from the organization')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (memberId: string, opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+
+        if (!yes && !json) {
+          const confirmed = await clack.confirm({
+            message: `Remove member ${memberId} from the organization?`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        await removeMember(orgId, memberId, apiUrl);
+        if (json) {
+          outputJson({ removed: true, member_id: memberId });
+        } else {
+          outputSuccess(`Member ${memberId} removed.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  membersCmd
+    .command('role <memberId> <role>')
+    .description(`Change a member's role (${MEMBER_ROLES.join(' | ')})`)
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (memberId: string, role: string, opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const validRole = assertRole(role);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const member = await updateMemberRole(orgId, memberId, validRole, apiUrl);
+        if (json) {
+          outputJson(member);
+        } else {
+          outputSuccess(`Member ${memberId} is now ${member.role}.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/projects/manage.ts
+++ b/src/commands/projects/manage.ts
@@ -1,0 +1,270 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import {
+  getProject,
+  updateProject,
+  deleteProject,
+  restoreProject,
+  upgradeInstance,
+  restartProjectVersion,
+  getLatestInsforgeVersion,
+} from '../../lib/api/platform.js';
+import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { getProjectId } from '../../lib/config.js';
+import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
+import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
+
+/**
+ * Resolve which project a lifecycle command targets. Honors --project / the
+ * INSFORGE_PROJECT_ID env var / the linked project (in that order). For
+ * destructive cross-project ops the caller can require an explicit id.
+ */
+function resolveProjectId(opts: { project?: string }, requireExplicit = false): string {
+  if (requireExplicit && !opts.project && !process.env.INSFORGE_PROJECT_ID) {
+    throw new CLIError(
+      'Refusing to act on the linked project implicitly. Pass --project <id> to target a project explicitly.',
+    );
+  }
+  const id = getProjectId(opts.project);
+  if (!id) {
+    throw new CLIError('No project specified. Pass --project <id> or run `insforge link` first.');
+  }
+  return id;
+}
+
+/** Instance classes the CLI offers, smallest → largest. xl is the ceiling. */
+const INSTANCE_TYPES = ['nano', 'micro', 'small', 'medium', 'large', 'xl'];
+
+export function registerProjectManageCommands(projectsCmd: Command): void {
+  projectsCmd
+    .command('get')
+    .description('Show a project\'s current status and details')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+        const project = await getProject(projectId, apiUrl);
+
+        if (json) {
+          outputJson(project);
+        } else {
+          outputInfo(`Name:       ${project.name}`);
+          outputInfo(`ID:         ${project.id}`);
+          outputInfo(`Status:     ${project.status}${project.operation_status ? ` (${project.operation_status})` : ''}`);
+          outputInfo(`Region:     ${project.region}`);
+          outputInfo(`Instance:   ${project.instance_type}`);
+          outputInfo(`Version:    ${project.service_version ?? 'unknown'}`);
+          if (project.customized_domain) outputInfo(`Domain:     ${project.customized_domain}`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  projectsCmd
+    .command('update')
+    .description('Update project settings (rename, custom domain, storage size)')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .option('--name <name>', 'New project name (min 2 characters)')
+    .option('--domain <domain>', 'Custom domain')
+    .option('--storage-size <gib>', 'Storage disk size in GiB (min 8)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+
+        const body: { name?: string; customizedDomain?: string; storageDiskSize?: number } = {};
+        if (opts.name) body.name = opts.name;
+        if (opts.domain) body.customizedDomain = opts.domain;
+        if (opts.storageSize !== undefined) {
+          const size = Number(opts.storageSize);
+          if (!Number.isInteger(size) || size < 8) {
+            throw new CLIError('--storage-size must be an integer >= 8 (GiB).');
+          }
+          body.storageDiskSize = size;
+        }
+        if (Object.keys(body).length === 0) {
+          throw new CLIError('Nothing to update. Pass --name, --domain, or --storage-size.');
+        }
+
+        const project = await updateProject(projectId, body, apiUrl);
+        captureEvent(projectId, 'cli_project_update', { fields: Object.keys(body) });
+
+        if (json) {
+          outputJson(project);
+        } else {
+          outputSuccess(`Project "${project.name}" updated.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+
+  projectsCmd
+    .command('delete')
+    .description('Permanently delete a project')
+    .option('--project <id>', 'Project ID (required — will not default to the linked project)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts, true);
+
+        if (!yes && !json) {
+          const project = await getProject(projectId, apiUrl).catch(() => null);
+          const label = project ? `"${project.name}" (${projectId})` : projectId;
+          const confirmed = await clack.confirm({
+            message: `Permanently delete project ${label}? This destroys its database, storage, and all resources.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        await deleteProject(projectId, apiUrl);
+        captureEvent(projectId, 'cli_project_delete', {});
+
+        if (json) {
+          outputJson({ deleted: true, project_id: projectId });
+        } else {
+          outputSuccess(`Project ${projectId} deleted.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+
+  projectsCmd
+    .command('restore')
+    .description('Restore a paused project (brings it back online)')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+
+        const project = await restoreProject(projectId, apiUrl);
+        captureEvent(projectId, 'cli_project_restore', {});
+
+        if (json) {
+          outputJson(project);
+        } else {
+          outputSuccess(`Project "${project.name}" restore initiated (status: ${project.status}).`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+
+  projectsCmd
+    .command('update-version')
+    .description('Update the project to the latest InsForge backend version (restarts the instance)')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .option('--wait', 'Wait for the restart to finish instead of returning while it is queued')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+
+        // Resolve the latest version explicitly — the same contract the
+        // dashboard uses. An unpinned restart is NOT a reliable "go to latest"
+        // (it keeps whatever tag the instance .env already has), so we always
+        // pass the resolved version.
+        const latest = await getLatestInsforgeVersion(apiUrl);
+        const project = await getProject(projectId, apiUrl).catch(() => null);
+        const current = project?.service_version ?? null;
+
+        if (current && current === latest) {
+          if (json) {
+            outputJson({ updated: false, current_version: current, latest_version: latest });
+          } else {
+            outputInfo(`Project is already on the latest version (${latest}).`);
+          }
+          return;
+        }
+
+        if (!yes && !json) {
+          const from = current ? `from ${current} ` : '';
+          const confirmed = await clack.confirm({
+            message: `Update the project ${from}to the latest InsForge version (${latest})? There will be a brief downtime.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        const updated = await restartProjectVersion(projectId, latest, !!opts.wait, apiUrl);
+        captureEvent(projectId, 'cli_project_update_version', { version: latest, wait: !!opts.wait });
+
+        if (json) {
+          outputJson(updated);
+        } else if (opts.wait) {
+          outputSuccess(`Project "${updated.name}" updated to ${latest}.`);
+        } else {
+          outputSuccess(`Project "${updated.name}" is updating to ${latest} (queued). Re-run with --wait to block until done.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+
+  projectsCmd
+    .command('upgrade-instance <instanceType>')
+    .description(`Change the project instance type (${INSTANCE_TYPES.join(' | ')})`)
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (instanceType: string, opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+
+        if (!INSTANCE_TYPES.includes(instanceType)) {
+          throw new CLIError(
+            `Invalid instance type "${instanceType}". Valid types: ${INSTANCE_TYPES.join(', ')}.`,
+          );
+        }
+
+        if (!yes && !json) {
+          const confirmed = await clack.confirm({
+            message: `Change the instance type to "${instanceType}"? This restarts the project and may change your bill.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        const result = await upgradeInstance(projectId, { instanceType }, apiUrl);
+        captureEvent(projectId, 'cli_project_upgrade_instance', { instanceType });
+
+        if (json) {
+          outputJson(result);
+        } else {
+          outputSuccess(result.message);
+          if (result.previousInstanceType !== result.newInstanceType) {
+            outputInfo(`Instance: ${result.previousInstanceType} → ${result.newInstanceType}`);
+          }
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+}

--- a/src/commands/projects/manage.ts
+++ b/src/commands/projects/manage.ts
@@ -16,17 +16,24 @@ import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
 import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 
 /**
- * Resolve which project a lifecycle command targets. Honors --project / the
- * INSFORGE_PROJECT_ID env var / the linked project (in that order). For
- * destructive cross-project ops the caller can require an explicit id.
+ * Resolve which project a lifecycle command targets. An explicit `--project`
+ * always wins over the INSFORGE_PROJECT_ID env var and the linked project.
+ * When `requireExplicit` is set (destructive cross-project ops like delete),
+ * only `--project` is accepted — env/linked fallbacks are refused so a stray
+ * ambient value can't silently point a destructive op at the wrong project.
  */
 function resolveProjectId(opts: { project?: string }, requireExplicit = false): string {
-  if (requireExplicit && !opts.project && !process.env.INSFORGE_PROJECT_ID) {
-    throw new CLIError(
-      'Refusing to act on the linked project implicitly. Pass --project <id> to target a project explicitly.',
-    );
+  if (requireExplicit) {
+    if (!opts.project) {
+      throw new CLIError(
+        'Refusing to act on a project implicitly. Pass --project <id> to target a project explicitly.',
+      );
+    }
+    return opts.project;
   }
-  const id = getProjectId(opts.project);
+  // `opts.project ?? getProjectId()` keeps the explicit flag ahead of the env
+  // var (getProjectId resolves env → linked when called with no override).
+  const id = opts.project ?? getProjectId();
   if (!id) {
     throw new CLIError('No project specified. Pass --project <id> or run `insforge link` first.');
   }

--- a/src/commands/projects/manage.ts
+++ b/src/commands/projects/manage.ts
@@ -194,7 +194,11 @@ export function registerProjectManageCommands(projectsCmd: Command): void {
         const project = await getProject(projectId, apiUrl).catch(() => null);
         const current = project?.service_version ?? null;
 
-        if (current && current === latest) {
+        // service_version is stored without the `v` prefix (e.g. "2.2.2") while
+        // the latest-version endpoint returns it with one ("v2.2.2"); normalize
+        // both so an already-current project is detected as a no-op.
+        const norm = (v: string): string => v.replace(/^v/i, '');
+        if (current && norm(current) === norm(latest)) {
           if (json) {
             outputJson({ updated: false, current_version: current, latest_version: latest });
           } else {

--- a/src/commands/secrets/rotate.ts
+++ b/src/commands/secrets/rotate.ts
@@ -1,0 +1,60 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import { rotateApiKey, rotateAnonKey } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
+import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+const KEYS = ['api-key', 'anon-key'];
+
+export function registerSecretsRotateCommand(secretsCmd: Command): void {
+  secretsCmd
+    .command('rotate <key>')
+    .description(`Rotate a project key (${KEYS.join(' | ')})`)
+    .option('--grace-hours <n>', 'Hours the old key stays valid (server default applies if omitted)')
+    .action(async (key: string, opts, cmd) => {
+      const { json, yes } = getRootOpts(cmd);
+      try {
+        if (!KEYS.includes(key)) {
+          throw new CLIError(`Invalid key "${key}". Valid keys: ${KEYS.join(', ')}.`);
+        }
+        await requireAuth();
+
+        let graceHours: number | undefined;
+        if (opts.graceHours !== undefined) {
+          graceHours = Number(opts.graceHours);
+          if (!Number.isInteger(graceHours) || graceHours < 0) {
+            throw new CLIError('--grace-hours must be a non-negative integer.');
+          }
+        }
+
+        if (!yes && !json) {
+          const confirmed = await clack.confirm({
+            message: `Rotate the ${key}? The current key keeps working only during the grace period.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        const result = key === 'api-key'
+          ? await rotateApiKey(graceHours)
+          : await rotateAnonKey(graceHours);
+        const newKey = result.apiKey ?? result.anonKey ?? '';
+
+        if (json) {
+          outputJson(result);
+        } else {
+          outputSuccess(result.message);
+          outputInfo(`\nNew ${key} (shown once — store it now):\n${newKey}`);
+          outputInfo(`\nOld key stops working at: ${new Date(result.oldKeyExpiresAt).toLocaleString()}`);
+        }
+        await reportCliUsage('cli.secrets.rotate', true);
+      } catch (err) {
+        await reportCliUsage('cli.secrets.rotate', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/storage/s3-keys.ts
+++ b/src/commands/storage/s3-keys.ts
@@ -1,0 +1,96 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import { listS3AccessKeys, createS3AccessKey, deleteS3AccessKey } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
+import { reportCliUsage } from '../../lib/skills.js';
+
+export function registerStorageS3KeysCommand(storageCmd: Command): void {
+  const s3Cmd = storageCmd
+    .command('s3-keys')
+    .description('Manage S3-compatible access keys for storage');
+
+  s3Cmd
+    .command('list')
+    .description('List S3 access keys (secrets are not shown)')
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+        const keys = await listS3AccessKeys();
+        if (json) {
+          outputJson(keys);
+        } else if (!keys.length) {
+          outputInfo('No S3 access keys found.');
+        } else {
+          outputTable(
+            ['ID', 'Access Key ID', 'Description', 'Last Used', 'Created'],
+            keys.map((k) => [
+              k.id,
+              k.accessKeyId,
+              k.description ?? '-',
+              k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleString() : 'never',
+              new Date(k.createdAt).toLocaleString(),
+            ]),
+          );
+        }
+        await reportCliUsage('cli.storage.s3-keys.list', true);
+      } catch (err) {
+        await reportCliUsage('cli.storage.s3-keys.list', false);
+        handleError(err, json);
+      }
+    });
+
+  s3Cmd
+    .command('create')
+    .description('Create an S3 access key (secret shown once)')
+    .option('--description <text>', 'Label for the key (max 200 chars)')
+    .action(async (opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+        const key = await createS3AccessKey(opts.description);
+        if (json) {
+          outputJson(key);
+        } else {
+          outputSuccess('S3 access key created (secret shown once — store it now):');
+          outputInfo(`\nAccess Key ID:     ${key.accessKeyId}`);
+          outputInfo(`Secret Access Key: ${key.secretAccessKey}`);
+        }
+        await reportCliUsage('cli.storage.s3-keys.create', true);
+      } catch (err) {
+        await reportCliUsage('cli.storage.s3-keys.create', false);
+        handleError(err, json);
+      }
+    });
+
+  s3Cmd
+    .command('delete <id>')
+    .description('Delete an S3 access key')
+    .action(async (id: string, _opts, cmd) => {
+      const { json, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth();
+        if (!yes && !json) {
+          const confirmed = await clack.confirm({
+            message: `Delete S3 access key ${id}? Tools using it will stop working.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+        await deleteS3AccessKey(id);
+        if (json) {
+          outputJson({ deleted: true, id });
+        } else {
+          outputSuccess(`S3 access key ${id} deleted.`);
+        }
+        await reportCliUsage('cli.storage.s3-keys.delete', true);
+      } catch (err) {
+        await reportCliUsage('cli.storage.s3-keys.delete', false);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/usage/index.ts
+++ b/src/commands/usage/index.ts
@@ -1,0 +1,62 @@
+import type { Command } from 'commander';
+import { getOrgUsage } from '../../lib/api/platform.js';
+import { requireAuth } from '../../lib/credentials.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { resolveOrgId } from '../../lib/resolve-org.js';
+import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
+
+/** Render a byte count as a human-readable size. */
+function formatBytes(n: number): string {
+  if (!n) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(n) / Math.log(1024)), units.length - 1);
+  return `${(n / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 2)} ${units[i]}`;
+}
+
+const BYTE_METRICS = new Set(['database_bytes', 'storage_bytes', 'egress_bytes']);
+
+function formatMetric(key: string, value: number): string {
+  return BYTE_METRICS.has(key) ? formatBytes(value) : String(value);
+}
+
+export function registerUsageCommand(program: Command): void {
+  program
+    .command('usage')
+    .description('Show organization usage for the current billing period')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const usage = await getOrgUsage(orgId, apiUrl);
+
+        if (json) {
+          outputJson(usage);
+          return;
+        }
+
+        outputInfo(`Organization: ${usage.organization.name} (plan: ${usage.organization.price_plan})\n`);
+        outputTable(
+          ['Metric', 'Value'],
+          Object.entries(usage.usage_summary).map(([k, v]) => [k, formatMetric(k, v)]),
+        );
+
+        if (usage.projects.length) {
+          outputInfo('\nPer project:');
+          outputTable(
+            ['Project', 'Status', 'DB', 'Storage', 'Egress'],
+            usage.projects.map((p) => [
+              p.name,
+              p.status,
+              formatBytes(Number(p.database_bytes ?? 0)),
+              formatBytes(Number(p.storage_bytes ?? 0)),
+              formatBytes(Number(p.egress_bytes ?? 0)),
+            ]),
+          );
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/usage/index.ts
+++ b/src/commands/usage/index.ts
@@ -16,7 +16,10 @@ function formatBytes(n: number): string {
 const BYTE_METRICS = new Set(['database_bytes', 'storage_bytes', 'egress_bytes']);
 
 function formatMetric(key: string, value: number): string {
-  return BYTE_METRICS.has(key) ? formatBytes(value) : String(value);
+  if (BYTE_METRICS.has(key)) return formatBytes(value);
+  // Counts stay as integers; fractional metrics (e.g. ai_credits) round to 2dp
+  // so we don't surface float noise like 69.82999999999998.
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
 }
 
 export function registerUsageCommand(program: Command): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ import { registerLoginCommand } from './commands/login.js';
 import { registerLogoutCommand } from './commands/logout.js';
 import { registerWhoamiCommand } from './commands/whoami.js';
 import { registerOrgsCommands } from './commands/orgs/list.js';
+import { registerOrgsManageCommands } from './commands/orgs/manage.js';
 import { registerProjectsCommands } from './commands/projects/list.js';
+import { registerProjectManageCommands } from './commands/projects/manage.js';
+import { registerBillingCommands } from './commands/billing/index.js';
+import { registerUsageCommand } from './commands/usage/index.js';
+import { registerBackupsCommands } from './commands/backups/index.js';
 import { registerBranchCommands } from './commands/branch/index.js';
 import { registerProjectLinkCommand } from './commands/projects/link.js';
 import { registerDbCommands } from './commands/db/query.js';
@@ -53,6 +58,8 @@ import { registerSecretsGetCommand } from './commands/secrets/get.js';
 import { registerSecretsAddCommand } from './commands/secrets/add.js';
 import { registerSecretsUpdateCommand } from './commands/secrets/update.js';
 import { registerSecretsDeleteCommand } from './commands/secrets/delete.js';
+import { registerSecretsRotateCommand } from './commands/secrets/rotate.js';
+import { registerStorageS3KeysCommand } from './commands/storage/s3-keys.js';
 
 import { registerSchedulesListCommand } from './commands/schedules/list.js';
 import { registerSchedulesGetCommand } from './commands/schedules/get.js';
@@ -125,13 +132,15 @@ registerListCommand(program);
 registerDocsCommand(program);
 registerProjectLinkCommand(program);
 
-// Orgs commands (hidden — use `insforge list` instead)
-const orgsCmd = program.command('orgs', { hidden: true }).description('Manage organizations');
+// Orgs commands
+const orgsCmd = program.command('orgs').description('Manage organizations and members');
 registerOrgsCommands(orgsCmd);
+registerOrgsManageCommands(orgsCmd);
 
-// Projects commands (hidden — use `insforge list` instead)
-const projectsCmd = program.command('projects', { hidden: true }).description('Manage projects');
+// Projects commands
+const projectsCmd = program.command('projects').description('Manage projects');
 registerProjectsCommands(projectsCmd);
+registerProjectManageCommands(projectsCmd);
 
 // Branch commands
 registerBranchCommands(program);
@@ -173,6 +182,7 @@ registerStorageDeleteBucketCommand(storageCmd);
 registerStorageListObjectsCommand(storageCmd);
 registerStorageUploadCommand(storageCmd);
 registerStorageDownloadCommand(storageCmd);
+registerStorageS3KeysCommand(storageCmd);
 
 // Deployments commands
 const deploymentsCmd = program.command('deployments').description('Deploy and manage frontend sites');
@@ -192,6 +202,7 @@ registerSecretsGetCommand(secretsCmd);
 registerSecretsAddCommand(secretsCmd);
 registerSecretsUpdateCommand(secretsCmd);
 registerSecretsDeleteCommand(secretsCmd);
+registerSecretsRotateCommand(secretsCmd);
 
 // Logs command
 registerLogsCommand(program);
@@ -206,6 +217,17 @@ registerDiagnoseCommands(diagnoseCmd);
 // Payments commands
 const paymentsCmd = program.command('payments').description('Manage payments');
 registerPaymentsCommands(paymentsCmd);
+
+// Billing commands (platform subscription / credits)
+const billingCmd = program.command('billing').description('Inspect subscription, plan, and credits');
+registerBillingCommands(billingCmd);
+
+// Usage command (organization consumption)
+registerUsageCommand(program);
+
+// Backups commands (project backups)
+const backupsCmd = program.command('backups').description('Manage project backups');
+registerBackupsCommands(backupsCmd);
 
 // Compute commands
 const computeCmd = program.command('compute').description('Manage compute services (Docker containers on Fly.io)');

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -1,6 +1,11 @@
 import { getProjectConfig } from '../config.js';
 import { CLIError, ProjectNotLinkedError } from '../errors.js';
-import type { ProjectConfig } from '../../types.js';
+import type {
+  ProjectConfig,
+  RotateKeyResponse,
+  S3AccessKey,
+  S3AccessKeyWithSecret,
+} from '../../types.js';
 
 function requireProjectConfig(): ProjectConfig {
   const config = getProjectConfig();
@@ -108,6 +113,48 @@ export async function getDatabaseConnectionString(): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+// --- Secrets rotation ---
+
+/**
+ * Rotate the project API key or anon key. The old key keeps working for
+ * `gracePeriodHours` (server default applies when omitted) so deployed
+ * clients don't break instantly. The new plaintext key is returned once.
+ */
+export async function rotateApiKey(gracePeriodHours?: number): Promise<RotateKeyResponse> {
+  const res = await ossFetch('/api/secrets/api-key/rotate', {
+    method: 'POST',
+    body: JSON.stringify(gracePeriodHours === undefined ? {} : { gracePeriodHours }),
+  });
+  return await res.json() as RotateKeyResponse;
+}
+
+export async function rotateAnonKey(gracePeriodHours?: number): Promise<RotateKeyResponse> {
+  const res = await ossFetch('/api/secrets/anon-key/rotate', {
+    method: 'POST',
+    body: JSON.stringify(gracePeriodHours === undefined ? {} : { gracePeriodHours }),
+  });
+  return await res.json() as RotateKeyResponse;
+}
+
+// --- S3 access keys ---
+
+export async function listS3AccessKeys(): Promise<S3AccessKey[]> {
+  const res = await ossFetch('/api/storage/s3/access-keys');
+  return await res.json() as S3AccessKey[];
+}
+
+export async function createS3AccessKey(description?: string): Promise<S3AccessKeyWithSecret> {
+  const res = await ossFetch('/api/storage/s3/access-keys', {
+    method: 'POST',
+    body: JSON.stringify(description ? { description } : {}),
+  });
+  return await res.json() as S3AccessKeyWithSecret;
+}
+
+export async function deleteS3AccessKey(id: string): Promise<void> {
+  await ossFetch(`/api/storage/s3/access-keys/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
 export async function ossFetch(

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -3,14 +3,25 @@ import { AuthError, CLIError, formatFetchError } from '../errors.js';
 import { refreshAccessToken } from '../credentials.js';
 import type {
   ApiKeyResponse,
+  Backup,
   Branch,
   BranchMode,
+  CreditBalance,
   DiffResult,
+  LatestVersionResponse,
   LoginResponse,
+  Member,
+  MemberRole,
+  MembersResponse,
   MergeConflictResponse,
   MergeExecuteResponse,
   Organization,
+  OrgUsage,
   Project,
+  SubscriptionStatus,
+  UpdateProjectBody,
+  UpgradeInstanceBody,
+  UpgradeInstanceResult,
   User,
 } from '../../types.js';
 
@@ -283,6 +294,235 @@ export async function createProject(
   }, apiUrl);
   const data = await res.json() as { project?: Project };
   return data.project ?? (data as unknown as Project);
+}
+
+// --- Project lifecycle ---
+
+export async function updateProject(
+  projectId: string,
+  body: UpdateProjectBody,
+  apiUrl?: string,
+): Promise<Project> {
+  const res = await platformFetch(`/projects/v1/${projectId}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  }, apiUrl);
+  const data = await res.json() as { project?: Project };
+  return data.project ?? (data as unknown as Project);
+}
+
+export async function deleteProject(projectId: string, apiUrl?: string): Promise<void> {
+  await platformFetch(`/projects/v1/${projectId}`, { method: 'DELETE' }, apiUrl);
+}
+
+export async function restoreProject(projectId: string, apiUrl?: string): Promise<Project> {
+  const res = await platformFetch(
+    `/projects/v1/${projectId}/restore`,
+    { method: 'POST' },
+    apiUrl,
+  );
+  const data = await res.json() as { project?: Project };
+  return data.project ?? (data as unknown as Project);
+}
+
+export async function upgradeInstance(
+  projectId: string,
+  body: UpgradeInstanceBody,
+  apiUrl?: string,
+): Promise<UpgradeInstanceResult> {
+  const res = await platformFetch(`/projects/v1/${projectId}/upgrade-instance`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }, apiUrl);
+  return await res.json() as UpgradeInstanceResult;
+}
+
+/**
+ * The current latest InsForge OSS version. Resolved by the platform from the
+ * default tag in the OSS docker-compose.yml. Public endpoint, but we reuse
+ * platformFetch (the auth header is harmless) since callers are authenticated.
+ */
+export async function getLatestInsforgeVersion(apiUrl?: string): Promise<string> {
+  const res = await platformFetch('/platform/insforge/latest-version', {}, apiUrl);
+  const data = await res.json() as LatestVersionResponse;
+  return data.version;
+}
+
+/**
+ * Update a project to a specific InsForge OSS version. The platform has no
+ * dedicated "update version" route — restart with an explicit
+ * `insforgeOssVersion` pins the tag in the instance `.env` and redeploys
+ * (the `generateUpdateCommands` path). This mirrors the dashboard's
+ * "update to latest" button, which always passes the resolved version
+ * explicitly rather than relying on the unpinned-restart fallback.
+ *
+ * `wait=true` sets `waitForCompletion` so the call blocks until the restart
+ * job finishes instead of returning while it's still queued.
+ */
+export async function restartProjectVersion(
+  projectId: string,
+  insforgeOssVersion: string,
+  wait: boolean,
+  apiUrl?: string,
+): Promise<Project> {
+  const params = new URLSearchParams({ insforgeOssVersion });
+  if (wait) params.set('waitForCompletion', 'true');
+  const res = await platformFetch(
+    `/projects/v1/${projectId}/restart?${params.toString()}`,
+    { method: 'POST' },
+    apiUrl,
+  );
+  const data = await res.json() as { project?: Project };
+  return data.project ?? (data as unknown as Project);
+}
+
+// --- Billing / usage ---
+
+export async function getSubscriptionStatus(orgId: string, apiUrl?: string): Promise<SubscriptionStatus> {
+  const res = await platformFetch(`/organizations/v1/${orgId}/subscription-status`, {}, apiUrl);
+  return await res.json() as SubscriptionStatus;
+}
+
+export async function getCredits(orgId: string, apiUrl?: string): Promise<CreditBalance> {
+  const res = await platformFetch(`/billing/v1/${orgId}/credits`, {}, apiUrl);
+  return await res.json() as CreditBalance;
+}
+
+export async function getOrgUsage(orgId: string, apiUrl?: string): Promise<OrgUsage> {
+  const res = await platformFetch(`/usage/v1/organizations/${orgId}`, {}, apiUrl);
+  return await res.json() as OrgUsage;
+}
+
+// --- Organization management ---
+
+export async function createOrganization(
+  body: { name: string; type: string },
+  apiUrl?: string,
+): Promise<Organization> {
+  const res = await platformFetch('/organizations/v1', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }, apiUrl);
+  const data = await res.json() as { organization?: Organization };
+  return data.organization ?? (data as unknown as Organization);
+}
+
+export async function updateOrganization(
+  orgId: string,
+  body: { name?: string; type?: string },
+  apiUrl?: string,
+): Promise<Organization> {
+  const res = await platformFetch(`/organizations/v1/${orgId}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  }, apiUrl);
+  const data = await res.json() as { organization?: Organization };
+  return data.organization ?? (data as unknown as Organization);
+}
+
+export async function listMembers(orgId: string, apiUrl?: string): Promise<MembersResponse> {
+  const res = await platformFetch(`/organizations/v1/${orgId}/members`, {}, apiUrl);
+  const data = await res.json() as Partial<MembersResponse>;
+  return { members: data.members ?? [], invitations: data.invitations ?? [] };
+}
+
+export async function inviteMember(
+  orgId: string,
+  email: string,
+  role: MemberRole | undefined,
+  apiUrl?: string,
+): Promise<{ id: string; email: string; role: MemberRole; expires_at: string }> {
+  const body: Record<string, string> = { email };
+  if (role) body.role = role;
+  const res = await platformFetch(`/organizations/v1/${orgId}/members/invite`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }, apiUrl);
+  const data = await res.json() as { invitation: { id: string; email: string; role: MemberRole; expires_at: string } };
+  return data.invitation;
+}
+
+export async function removeMember(orgId: string, memberId: string, apiUrl?: string): Promise<void> {
+  await platformFetch(
+    `/organizations/v1/${orgId}/members/${memberId}`,
+    { method: 'DELETE' },
+    apiUrl,
+  );
+}
+
+export async function updateMemberRole(
+  orgId: string,
+  memberId: string,
+  role: MemberRole,
+  apiUrl?: string,
+): Promise<Member> {
+  const res = await platformFetch(`/organizations/v1/${orgId}/members/${memberId}/role`, {
+    method: 'PUT',
+    body: JSON.stringify({ role }),
+  }, apiUrl);
+  const data = await res.json() as { member: Member };
+  return data.member;
+}
+
+// --- Backups ---
+
+export async function listBackups(projectId: string, apiUrl?: string): Promise<Backup[]> {
+  const res = await platformFetch(`/projects/v1/${projectId}/backups`, {}, apiUrl);
+  const data = await res.json() as { backups?: Backup[] };
+  return data.backups ?? [];
+}
+
+export async function getLatestBackup(projectId: string, apiUrl?: string): Promise<Backup | null> {
+  const res = await platformFetch(
+    `/projects/v1/${projectId}/backup/latest`,
+    { passThroughStatuses: [404] },
+    apiUrl,
+  );
+  if (res.status === 404) return null;
+  return await res.json() as Backup;
+}
+
+export async function createBackup(
+  projectId: string,
+  name: string | undefined,
+  wait: boolean,
+  apiUrl?: string,
+): Promise<{ message: string; project: { id: string; name: string; status: string } }> {
+  const query = wait ? '?waitForCompletion=true' : '';
+  const res = await platformFetch(`/projects/v1/${projectId}/backup${query}`, {
+    method: 'POST',
+    body: JSON.stringify(name ? { name } : {}),
+  }, apiUrl);
+  return await res.json() as { message: string; project: { id: string; name: string; status: string } };
+}
+
+export async function renameBackup(
+  projectId: string,
+  backupId: string,
+  name: string | null,
+  apiUrl?: string,
+): Promise<{ id: string; name: string | null }> {
+  const res = await platformFetch(`/projects/v1/${projectId}/backups/${backupId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ name }),
+  }, apiUrl);
+  return await res.json() as { id: string; name: string | null };
+}
+
+export async function deleteBackup(projectId: string, backupId: string, apiUrl?: string): Promise<void> {
+  await platformFetch(
+    `/projects/v1/${projectId}/backups/${backupId}`,
+    { method: 'DELETE' },
+    apiUrl,
+  );
+}
+
+export async function restoreBackup(projectId: string, backupId: string, apiUrl?: string): Promise<void> {
+  await platformFetch(
+    `/projects/v1/${projectId}/backups/${backupId}/restore`,
+    { method: 'POST' },
+    apiUrl,
+  );
 }
 
 // --- Branching ---

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -8,6 +8,7 @@ import type {
   BranchMode,
   CreditBalance,
   DiffResult,
+  LatestBackup,
   LatestVersionResponse,
   LoginResponse,
   Member,
@@ -473,14 +474,14 @@ export async function listBackups(projectId: string, apiUrl?: string): Promise<B
   return data.backups ?? [];
 }
 
-export async function getLatestBackup(projectId: string, apiUrl?: string): Promise<Backup | null> {
+export async function getLatestBackup(projectId: string, apiUrl?: string): Promise<LatestBackup | null> {
   const res = await platformFetch(
     `/projects/v1/${projectId}/backup/latest`,
     { passThroughStatuses: [404] },
     apiUrl,
   );
   if (res.status === 404) return null;
-  return await res.json() as Backup;
+  return await res.json() as LatestBackup;
 }
 
 export async function createBackup(

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -462,8 +462,8 @@ export async function updateMemberRole(
     method: 'PUT',
     body: JSON.stringify({ role }),
   }, apiUrl);
-  const data = await res.json() as { member: Member };
-  return data.member;
+  const data = await res.json() as { member?: Member };
+  return data.member ?? (data as unknown as Member);
 }
 
 // --- Backups ---

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -438,8 +438,9 @@ export async function inviteMember(
     method: 'POST',
     body: JSON.stringify(body),
   }, apiUrl);
-  const data = await res.json() as { invitation: { id: string; email: string; role: MemberRole; expires_at: string } };
-  return data.invitation;
+  type Invite = { id: string; email: string; role: MemberRole; expires_at: string };
+  const data = await res.json() as { invitation?: Invite };
+  return data.invitation ?? (data as unknown as Invite);
 }
 
 export async function removeMember(orgId: string, memberId: string, apiUrl?: string): Promise<void> {

--- a/src/lib/guard/risk-registry.ts
+++ b/src/lib/guard/risk-registry.ts
@@ -236,6 +236,78 @@ const REGISTRY: Record<string, (ctx: OperationContext) => RiskAssessment> = {
     blastRadius: 'Functions/services reading this secret lose access at next run.',
     risk: 'Can break running workloads that depend on the value.',
   }),
+
+  'projects delete': (ctx) => ({
+    severity: 'critical',
+    kind: 'project.delete',
+    title: 'Delete a project',
+    whatHappens: `Permanently deletes project "${(ctx.opts.project as string) ?? '(linked)'}" and all of its resources.`,
+    blastRadius: 'The database, storage buckets, edge functions, and every backend resource are destroyed.',
+    risk: 'Irreversible. Every app and integration pointing at this project breaks immediately.',
+  }),
+
+  'projects restore': () => ({
+    severity: 'high',
+    kind: 'project.restore',
+    title: 'Restore a project',
+    whatHappens: 'Brings a paused/deleted project back online, re-provisioning its instance.',
+    blastRadius: 'The project transitions state and may incur billing for the restored instance.',
+    risk: 'Changes live infrastructure state. Verify you mean to bring this project back.',
+  }),
+
+  'projects update-version': () => ({
+    severity: 'high',
+    kind: 'project.update_version',
+    title: 'Update the backend version',
+    whatHappens: 'Restarts the project onto the latest InsForge version.',
+    blastRadius: 'The instance restarts — brief downtime, and a version change can alter behavior.',
+    risk: 'Live traffic is interrupted during the restart. Roll-back means restarting again.',
+  }),
+
+  'projects upgrade-instance': (ctx) => ({
+    severity: 'high',
+    kind: 'project.upgrade_instance',
+    title: 'Change instance type',
+    whatHappens: `Changes the project instance type to "${ctx.args[0] ?? '?'}", restarting it.`,
+    blastRadius: 'Brief downtime during the restart, and the change affects your bill.',
+    risk: 'Verify the target instance type — a larger class costs more.',
+  }),
+
+  'backups restore': (ctx) => ({
+    severity: 'critical',
+    kind: 'backup.restore',
+    title: 'Restore project from a backup',
+    whatHappens: `Overwrites the project's current data with backup "${ctx.args[0] ?? '?'}".`,
+    blastRadius: 'The current database and storage are replaced by the backup snapshot.',
+    risk: 'Any data written since that backup is lost. Irreversible without another backup.',
+  }),
+
+  'backups delete': (ctx) => ({
+    severity: 'high',
+    kind: 'backup.delete',
+    title: 'Delete a backup',
+    whatHappens: `Removes backup "${ctx.args[0] ?? '?'}".`,
+    blastRadius: 'That restore point is gone.',
+    risk: 'You can no longer restore the project to this snapshot.',
+  }),
+
+  'orgs members remove': (ctx) => ({
+    severity: 'high',
+    kind: 'org.member_remove',
+    title: 'Remove an organization member',
+    whatHappens: `Removes member "${ctx.args[0] ?? '?'}" from the organization.`,
+    blastRadius: 'That user loses access to all projects in the organization.',
+    risk: 'They must be re-invited to regain access.',
+  }),
+
+  'secrets rotate': (ctx) => ({
+    severity: 'high',
+    kind: 'secrets.rotate',
+    title: 'Rotate a project key',
+    whatHappens: `Rotates the ${ctx.args[0] ?? 'key'} — the old value stops working after the grace period.`,
+    blastRadius: 'Clients still using the old key fail once the grace period ends.',
+    risk: 'Update every consumer of the old key before the grace window closes.',
+  }),
 };
 
 /**

--- a/src/lib/resolve-org.ts
+++ b/src/lib/resolve-org.ts
@@ -1,0 +1,48 @@
+import * as prompts from './prompts.js';
+import { listOrganizations } from './api/platform.js';
+import { getGlobalConfig, getProjectConfig } from './config.js';
+import { CLIError } from './errors.js';
+
+/**
+ * Resolve the organization to operate on, in priority order:
+ *   1. explicit --org-id flag
+ *   2. INSFORGE_ORG_ID env var
+ *   3. the linked project's org_id (.insforge/project.json)
+ *   4. the configured default_org_id
+ *   5. auto-select if the account has exactly one org
+ *   6. interactive prompt (TTY, non-JSON) — otherwise error
+ *
+ * Mirrors how `projects list` resolves an org, extended to also honor the
+ * linked project so org-scoped commands "just work" inside a project dir.
+ */
+export async function resolveOrgId(
+  flagOrgId: string | undefined,
+  json: boolean,
+  apiUrl?: string,
+): Promise<string> {
+  let orgId =
+    flagOrgId ??
+    process.env.INSFORGE_ORG_ID ??
+    getProjectConfig()?.org_id ??
+    getGlobalConfig().default_org_id;
+
+  if (orgId) return orgId;
+
+  const orgs = await listOrganizations(apiUrl);
+  if (orgs.length === 0) {
+    throw new CLIError('No organizations found. Create one with `insforge orgs create`.');
+  }
+  if (orgs.length === 1) return orgs[0].id;
+
+  if (json) {
+    throw new CLIError('Multiple organizations found. Specify --org-id.');
+  }
+
+  const selected = await prompts.select<string>({
+    message: 'Select an organization:',
+    options: orgs.map((o) => ({ value: o.id, label: o.name })),
+  });
+  if (prompts.isCancel(selected)) process.exit(0);
+  orgId = selected;
+  return orgId;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface Project {
   appkey: string;
   region: string;
   status: string;
+  /** In-flight maintenance operation (e.g. restoring, updating_project_version), null when idle. */
+  operation_status?: string | null;
   instance_type: string;
   service_version: string | null;
   customized_domain: string | null;
@@ -213,4 +215,131 @@ export interface FunctionResponse {
     deployedAt: string | null;
   };
   deployment?: FunctionDeploymentResult | null;
+}
+
+// --- Project management (cloud platform) ---
+
+/** Subset of the project body accepted by PUT /projects/v1/:id. */
+export interface UpdateProjectBody {
+  name?: string;
+  customizedDomain?: string;
+  storageDiskSize?: number;
+}
+
+export interface UpgradeInstanceBody {
+  instanceType: string;
+}
+
+/** Response of GET /platform/insforge/latest-version (public). */
+export interface LatestVersionResponse {
+  version: string;
+  cached: boolean;
+}
+
+/** Returned by upgrade-instance — old/new values plus the refreshed project. */
+export interface UpgradeInstanceResult {
+  message: string;
+  project: Project;
+  previousInstanceType: string;
+  newInstanceType: string;
+  previousVolumeSizeGiB: number;
+  newVolumeSizeGiB: number;
+}
+
+// --- Billing / usage (cloud platform) ---
+
+export interface SubscriptionStatus {
+  status: string;
+  plan: string;
+  currentPeriodEnd?: string;
+  cancelAtPeriodEnd?: boolean;
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+}
+
+export interface CreditBalance {
+  creditBalanceCents: number;
+  creditBalanceFormatted: string;
+  transactions: { amountCents: number; description: string; created: string }[];
+}
+
+export interface OrgUsage {
+  organization: { id: string; name: string; price_plan: string };
+  usage_summary: Record<string, number>;
+  projects: { id: string; name: string; status: string; [metric: string]: unknown }[];
+  _meta: { requested_at: string };
+}
+
+// --- Organization members (cloud platform) ---
+
+export type MemberRole = 'administrator' | 'developer';
+
+export interface Member {
+  id: string;
+  organization_id: string;
+  user_id: string;
+  role: MemberRole;
+  invited_by?: string;
+  joined_at: string;
+  name?: string;
+  email?: string;
+  avatar_url?: string;
+}
+
+export interface Invitation {
+  id: string;
+  organization_id: string;
+  email: string;
+  role: MemberRole;
+  status: 'pending' | 'accepted' | 'expired' | 'declined';
+  expires_at: string;
+  created_at: string;
+}
+
+export interface MembersResponse {
+  members: Member[];
+  invitations: Invitation[];
+}
+
+// --- Backups (cloud platform) ---
+
+export interface Backup {
+  id: string;
+  project_id: string;
+  organization_id: string;
+  plan: string;
+  status: 'running' | 'completed' | 'failed';
+  trigger_source: 'manual' | 'scheduled';
+  error_message: string | null;
+  triggered_at: string | null;
+  created_at: string;
+  name: string | null;
+  size_bytes: number | null;
+  created_by: string | null;
+}
+
+// --- Secrets rotation (OSS backend) ---
+
+export interface RotateKeyResponse {
+  success: true;
+  message: string;
+  /** New plaintext key — shown once. `apiKey` for api-key rotate, `anonKey` for anon-key. */
+  apiKey?: string;
+  anonKey?: string;
+  oldKeyExpiresAt: string;
+}
+
+// --- S3 access keys (OSS backend) ---
+
+export interface S3AccessKey {
+  id: string;
+  accessKeyId: string;
+  description: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface S3AccessKeyWithSecret extends S3AccessKey {
+  /** Plaintext secret — returned only at creation, never again. */
+  secretAccessKey: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,17 @@ export interface Backup {
   created_by: string | null;
 }
 
+/**
+ * GET /projects/v1/:id/backup/latest returns a pointer to the most recent
+ * dump FILE (with a presigned download URL) — NOT a Backup record. Distinct
+ * shape from the `backups` list endpoint.
+ */
+export interface LatestBackup {
+  file: string;
+  download_url: string;
+  size_bytes: number;
+}
+
 // --- Secrets rotation (OSS backend) ---
 
 export interface RotateKeyResponse {


### PR DESCRIPTION
## Summary

Expands the CLI to cover the management actions a human performs in the InsForge dashboard. Previously the cloud platform surface (`src/lib/api/platform.ts`) was limited to list/get/create project + branches; this fills in project lifecycle, billing, usage, org/member management, and backups, plus two OSS per-project actions (secrets rotation, S3 access keys).

## New commands

**Projects** (cloud lifecycle)
- `projects get` — current status + `operation_status` (poll async ops)
- `projects update` — `--name` / `--domain` / `--storage-size`
- `projects delete` — requires explicit `--project` (won't default to linked)
- `projects restore` — paused projects only
- `projects update-version [--wait]` — resolves & pins the **latest** version explicitly (mirrors the dashboard; an unpinned restart doesn't reliably upgrade)
- `projects upgrade-instance <type>` — capped at `xl`; no volume resize

**Billing / usage** (cloud)
- `billing status`, `billing credits`
- `usage [--org-id]`

**Orgs** (cloud)
- `orgs create`, `orgs update`
- `orgs members list / invite / remove / role`

**Backups** (cloud)
- `backups list / latest / create [--wait] / rename / delete / restore`

**OSS per-project**
- `secrets rotate <api-key|anon-key> [--grace-hours]`
- `storage s3-keys list / create / delete`

## Notes for reviewers
- **Resolution**: org-scoped commands resolve via `--org-id` → `INSFORGE_ORG_ID` → linked project's `org_id` → default org → prompt (`src/lib/resolve-org.ts`). Project-scoped commands use `--project` → `INSFORGE_PROJECT_ID` → linked project.
- **Guard**: destructive ops are registered in `risk-registry.ts` — `projects delete` and `backups restore` are `critical`; restore/update-version/upgrade-instance/backup delete/member remove/secrets rotate are `high` (these verbs aren't in the destructive-verb fallback, so explicit entries were required).
- **Secret-once**: `secrets rotate` and `s3-keys create` print the secret a single time.
- Contracts verified against `insforge-cloud-backend@master`. No version bump (those are separate chore commits).

## Test plan
- [x] `npm run build` green
- [x] `npm run lint` green (0 errors)
- [x] `--help` verified for every new command
- [ ] Manual smoke against a live project/org (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full project lifecycle, billing, org/member, backups, and key/credential management to the CLI to mirror the InsForge dashboard. Improves safety and output clarity with stricter targeting for destructive commands.

- **New Features**
  - Projects: get, update (name/domain/storage), delete (explicit), restore, update-version [--wait] (pins latest), upgrade-instance.
  - Billing/Usage: org plan/status, credits, and usage for the current period.
  - Orgs: create/update; members list/invite/remove/role.
  - Backups: list/latest/create [--wait]/rename/delete/restore.
  - OSS per-project: secrets rotate `api-key|anon-key` [--grace-hours]; storage `s3-keys` list/create/delete.

- **Bug Fixes**
  - Project resolution: explicit `--project` now always wins; destructive ops accept only `--project` (env/linked values are ignored).
  - Backups: fixed byte formatting and corrected `latest` response shape; clearer messaging when clearing a name.
  - Update-version/usage: detect already-latest across the `v` prefix; round fractional usage metrics to 2dp (keep integers as integers).
  - Org members: invite and role update responses now handle unwrapped API shapes.

<sup>Written for commit 676f8563757f46c3e6a8ab0e087f3efeaf22efa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add project, billing, org, backup, and key management commands to the CLI
> - Adds `backups` command group: list, latest, create (with `--wait`), rename, delete, and restore, all with confirmation prompts and JSON output support.
> - Adds `billing` command group: `status` (subscription plan) and `credits` (balance and transactions) for an organization.
> - Adds `orgs` management subcommands: create, update, and a `members` group for list, invite, remove, and role changes.
> - Adds `projects` management subcommands: get, update, delete (with safeguards), restore, `update-version` (pins to latest with optional `--wait`), and `upgrade-instance`.
> - Adds `secrets rotate` for API/anon key rotation with optional `--grace-hours` and one-time secret display, and `storage s3-keys` for list/create/delete of S3-compatible access keys.
> - Adds a `usage` command showing aggregated org-level metrics for the current billing period.
> - Adds new API wrappers in [platform.ts](https://github.com/InsForge/CLI/pull/175/files#diff-d73ae485f47b95b83b8cd3130a1529f8f4aa252cbcf402373078648162812f9d) and [oss.ts](https://github.com/InsForge/CLI/pull/175/files#diff-f58ac4bae1c6cb74276f4a22539113c6ae034fbc1c2d789895c67e2d946725bc), a `resolveOrgId` helper, risk registry entries for all destructive commands, and exposes previously hidden `orgs` and `projects` groups publicly.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #175 opened
>
> - Modified `resolveProjectId` helper to enforce explicit project specification when `requireExplicit` is true [90f4f81]
> - Changed `formatBytes` utility and `backups rename` command output handling [90f4f81]
> - Relaxed `inviteMember` API function response parsing to handle multiple response shapes [90f4f81]
> - Changed the latest backup API response structure from a full Backup record to a simplified LatestBackup pointer object [9953392]
> - Normalized version comparison in `registerProjectManageCommands` project update action handler to treat versions with and without leading 'v' prefixes as equal [635d9b7]
> - Updated `formatMetric` utility to display non-byte fractional metrics rounded to two decimal places [635d9b7]
> - Modified `updateMemberRole` API client function to handle both wrapped and bare `Member` response formats [8716f25]
> - Bumped package version in `package.json` [676f856]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f612d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `backups` CLI commands (list, latest, create, rename, delete, restore) with optional JSON output and confirmation/overwrite prompts.
  * Added `billing` commands for subscription status and credits (table or JSON).
  * Added `orgs manage` commands (create/update, member list/invite/remove, role updates) with interactive org selection.
  * Added `projects manage` commands (get/update/delete/restore, update backend version, upgrade instance type) with confirmations and optional wait.
  * Added `secrets rotate` (API/anonymous keys) with optional grace period.
  * Added `storage s3-keys` commands (list, create, delete).
  * Added `usage` reporting for org totals and per-project metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->