### PR TITLE
feat(cli): billing management + project transfer

### DIFF
--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -9,11 +9,18 @@ import {
   createPortalSession,
 } from '../../lib/api/platform.js';
 import { requireAuth } from '../../lib/credentials.js';
-import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
 import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
 
+// Shown in help only. Not used to validate — the backend owns the plan enum,
+// so a hard-coded allowlist here could reject a newly added plan.
 const BILLING_PLANS = ['free', 'starter', 'pro', 'team', 'enterprise'];
+
+/** Render a backend date-only string (YYYY-MM-DD) without UTC→local day shift. */
+function formatCalendarDate(d: string): string {
+  return new Date(`${d.slice(0, 10)}T00:00:00`).toLocaleDateString();
+}
 
 export function registerBillingCommands(billingCmd: Command): void {
   billingCmd
@@ -122,10 +129,9 @@ export function registerBillingCommands(billingCmd: Command): void {
         if (json) {
           outputJson(cycles);
         } else {
-          const fmt = (d: string): string => new Date(d).toLocaleDateString();
-          const rows = [['current', `${fmt(cycles.current.start_date)} → ${fmt(cycles.current.end_date)}`]];
+          const rows = [['current', `${formatCalendarDate(cycles.current.start_date)} → ${formatCalendarDate(cycles.current.end_date)}`]];
           if (cycles.previous) {
-            rows.push(['previous', `${fmt(cycles.previous.start_date)} → ${fmt(cycles.previous.end_date)}`]);
+            rows.push(['previous', `${formatCalendarDate(cycles.previous.start_date)} → ${formatCalendarDate(cycles.previous.end_date)}`]);
           }
           outputTable(['Cycle', 'Window'], rows);
         }
@@ -142,9 +148,7 @@ export function registerBillingCommands(billingCmd: Command): void {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
         await requireAuth(apiUrl);
-        if (!BILLING_PLANS.includes(plan)) {
-          throw new CLIError(`Invalid plan "${plan}". Valid plans: ${BILLING_PLANS.join(', ')}.`);
-        }
+        // Plan is validated server-side against the canonical billing enum.
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const session = await createCheckoutSession(orgId, plan, apiUrl);
 

--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -1,9 +1,21 @@
 import type { Command } from 'commander';
-import { getSubscriptionStatus, getCredits } from '../../lib/api/platform.js';
+import open from 'open';
+import {
+  getSubscriptionStatus,
+  getCredits,
+  getPaymentHistory,
+  getBillingCycles,
+  createCheckoutSession,
+  createPortalSession,
+  redeemPromo,
+  getReferralLink,
+} from '../../lib/api/platform.js';
 import { requireAuth } from '../../lib/credentials.js';
-import { handleError, getRootOpts } from '../../lib/errors.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
-import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
+import { outputJson, outputTable, outputInfo, outputSuccess } from '../../lib/output.js';
+
+const BILLING_PLANS = ['free', 'starter', 'pro', 'team', 'enterprise'];
 
 export function registerBillingCommands(billingCmd: Command): void {
   billingCmd
@@ -60,6 +72,158 @@ export function registerBillingCommands(billingCmd: Command): void {
               ]),
             );
           }
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  billingCmd
+    .command('history')
+    .description('Show payment / invoice history')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const payments = await getPaymentHistory(orgId, apiUrl);
+
+        if (json) {
+          outputJson(payments);
+        } else if (!payments.length) {
+          outputInfo('No payments found.');
+        } else {
+          outputTable(
+            ['Date', 'Amount', 'Currency', 'Status', 'Description'],
+            payments.map((p) => [
+              new Date(p.created_at).toLocaleDateString(),
+              p.amount_display,
+              (p.currency ?? '').toUpperCase(),
+              p.status,
+              p.description ?? '-',
+            ]),
+          );
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  billingCmd
+    .command('cycles')
+    .description('Show the current and previous billing cycle windows')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const cycles = await getBillingCycles(orgId, apiUrl);
+
+        if (json) {
+          outputJson(cycles);
+        } else {
+          const fmt = (d: string): string => new Date(d).toLocaleDateString();
+          const rows = [['current', `${fmt(cycles.current.start_date)} → ${fmt(cycles.current.end_date)}`]];
+          if (cycles.previous) {
+            rows.push(['previous', `${fmt(cycles.previous.start_date)} → ${fmt(cycles.previous.end_date)}`]);
+          }
+          outputTable(['Cycle', 'Window'], rows);
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  billingCmd
+    .command('upgrade <plan>')
+    .description(`Start a checkout to change the plan (${BILLING_PLANS.join(' | ')})`)
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (plan: string, opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        if (!BILLING_PLANS.includes(plan)) {
+          throw new CLIError(`Invalid plan "${plan}". Valid plans: ${BILLING_PLANS.join(', ')}.`);
+        }
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const session = await createCheckoutSession(orgId, plan, apiUrl);
+
+        if (json) {
+          outputJson(session);
+        } else {
+          outputInfo(`Complete the upgrade to "${plan}" in your browser:`);
+          outputInfo(session.checkoutUrl);
+          await open(session.checkoutUrl).catch(() => { /* headless: URL already printed */ });
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  billingCmd
+    .command('manage')
+    .description('Open the Stripe customer portal (manage subscription / payment method)')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const session = await createPortalSession(orgId, apiUrl);
+
+        if (json) {
+          outputJson(session);
+        } else {
+          outputInfo('Manage billing in your browser:');
+          outputInfo(session.portalUrl);
+          await open(session.portalUrl).catch(() => { /* headless: URL already printed */ });
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  billingCmd
+    .command('redeem <code>')
+    .description('Redeem a promo code for account credit')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (code: string, opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const result = await redeemPromo(orgId, code, apiUrl);
+
+        if (json) {
+          outputJson(result);
+        } else {
+          outputSuccess(
+            `Redeemed ${(result.creditAmountCents / 100).toFixed(2)} in credit. New balance: ${(result.creditBalanceCents / 100).toFixed(2)}.`,
+          );
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+
+  billingCmd
+    .command('referral')
+    .description('Show your organization referral link (administrator only)')
+    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
+        const referral = await getReferralLink(orgId, apiUrl);
+
+        if (json) {
+          outputJson(referral);
+        } else {
+          outputInfo(`Referral link: ${referral.url}`);
+          outputInfo(`Redemptions:   ${referral.redemptionCount}`);
         }
       } catch (err) {
         handleError(err, json);

--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -7,13 +7,11 @@ import {
   getBillingCycles,
   createCheckoutSession,
   createPortalSession,
-  redeemPromo,
-  getReferralLink,
 } from '../../lib/api/platform.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
-import { outputJson, outputTable, outputInfo, outputSuccess } from '../../lib/output.js';
+import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
 
 const BILLING_PLANS = ['free', 'starter', 'pro', 'team', 'enterprise'];
 
@@ -179,51 +177,6 @@ export function registerBillingCommands(billingCmd: Command): void {
           outputInfo('Manage billing in your browser:');
           outputInfo(session.portalUrl);
           await open(session.portalUrl).catch(() => { /* headless: URL already printed */ });
-        }
-      } catch (err) {
-        handleError(err, json);
-      }
-    });
-
-  billingCmd
-    .command('redeem <code>')
-    .description('Redeem a promo code for account credit')
-    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
-    .action(async (code: string, opts, cmd) => {
-      const { json, apiUrl } = getRootOpts(cmd);
-      try {
-        await requireAuth(apiUrl);
-        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
-        const result = await redeemPromo(orgId, code, apiUrl);
-
-        if (json) {
-          outputJson(result);
-        } else {
-          outputSuccess(
-            `Redeemed ${(result.creditAmountCents / 100).toFixed(2)} in credit. New balance: ${(result.creditBalanceCents / 100).toFixed(2)}.`,
-          );
-        }
-      } catch (err) {
-        handleError(err, json);
-      }
-    });
-
-  billingCmd
-    .command('referral')
-    .description('Show your organization referral link (administrator only)')
-    .option('--org-id <id>', 'Organization ID (defaults to linked project / default org)')
-    .action(async (opts, cmd) => {
-      const { json, apiUrl } = getRootOpts(cmd);
-      try {
-        await requireAuth(apiUrl);
-        const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
-        const referral = await getReferralLink(orgId, apiUrl);
-
-        if (json) {
-          outputJson(referral);
-        } else {
-          outputInfo(`Referral link: ${referral.url}`);
-          outputInfo(`Redemptions:   ${referral.redemptionCount}`);
         }
       } catch (err) {
         handleError(err, json);

--- a/src/commands/projects/manage.ts
+++ b/src/commands/projects/manage.ts
@@ -4,6 +4,7 @@ import {
   getProject,
   updateProject,
   deleteProject,
+  transferProject,
   restoreProject,
   upgradeInstance,
   restartProjectVersion,
@@ -142,6 +143,43 @@ export function registerProjectManageCommands(projectsCmd: Command): void {
           outputJson({ deleted: true, project_id: projectId });
         } else {
           outputSuccess(`Project ${projectId} deleted.`);
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+
+  projectsCmd
+    .command('transfer <targetOrgId>')
+    .description('Transfer the project to another organization')
+    .option('--project <id>', 'Project ID (defaults to the linked project)')
+    .action(async (targetOrgId: string, opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const projectId = resolveProjectId(opts);
+
+        if (!yes && !json) {
+          const project = await getProject(projectId, apiUrl).catch(() => null);
+          const label = project ? `"${project.name}"` : projectId;
+          const confirmed = await clack.confirm({
+            message: `Transfer project ${label} to organization ${targetOrgId}? Billing and access move to the target org.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        const project = await transferProject(projectId, targetOrgId, apiUrl);
+        captureEvent(projectId, 'cli_project_transfer', { target_org_id: targetOrgId });
+
+        if (json) {
+          outputJson(project);
+        } else {
+          outputSuccess(`Project "${project.name}" transferred to org ${targetOrgId}.`);
         }
       } catch (err) {
         handleError(err, json);

--- a/src/commands/projects/manage.ts
+++ b/src/commands/projects/manage.ts
@@ -159,7 +159,9 @@ export function registerProjectManageCommands(projectsCmd: Command): void {
       const { json, apiUrl, yes } = getRootOpts(cmd);
       try {
         await requireAuth(apiUrl);
-        const projectId = resolveProjectId(opts);
+        // Require an explicit --project: transfer moves billing/access to
+        // another org, so it must never act on an ambient linked/env project.
+        const projectId = resolveProjectId(opts, true);
 
         if (!yes && !json) {
           const project = await getProject(projectId, apiUrl).catch(() => null);

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -12,8 +12,6 @@ import type {
   DiffResult,
   PaymentRecord,
   PortalSession,
-  RedeemResult,
-  ReferralLink,
   LatestBackup,
   LatestVersionResponse,
   LoginResponse,
@@ -443,20 +441,6 @@ export async function createPortalSession(orgId: string, apiUrl?: string): Promi
     body: JSON.stringify({ organizationId: orgId }),
   }, apiUrl);
   return await res.json() as PortalSession;
-}
-
-export async function redeemPromo(orgId: string, code: string, apiUrl?: string): Promise<RedeemResult> {
-  const res = await platformFetch('/billing/v1/promo/redeem', {
-    method: 'POST',
-    body: JSON.stringify({ organizationId: orgId, code }),
-  }, apiUrl);
-  return await res.json() as RedeemResult;
-}
-
-/** Generate (or fetch) the org's referral link. Administrator only. */
-export async function getReferralLink(orgId: string, apiUrl?: string): Promise<ReferralLink> {
-  const res = await platformFetch(`/billing/v1/${orgId}/referral-link`, { method: 'POST' }, apiUrl);
-  return await res.json() as ReferralLink;
 }
 
 export async function getOrgUsage(orgId: string, apiUrl?: string): Promise<OrgUsage> {

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -4,10 +4,16 @@ import { refreshAccessToken } from '../credentials.js';
 import type {
   ApiKeyResponse,
   Backup,
+  BillingCycles,
   Branch,
   BranchMode,
+  CheckoutSession,
   CreditBalance,
   DiffResult,
+  PaymentRecord,
+  PortalSession,
+  RedeemResult,
+  ReferralLink,
   LatestBackup,
   LatestVersionResponse,
   LoginResponse,
@@ -316,6 +322,19 @@ export async function deleteProject(projectId: string, apiUrl?: string): Promise
   await platformFetch(`/projects/v1/${projectId}`, { method: 'DELETE' }, apiUrl);
 }
 
+export async function transferProject(
+  projectId: string,
+  targetOrganizationId: string,
+  apiUrl?: string,
+): Promise<Project> {
+  const res = await platformFetch(`/projects/v1/${projectId}/transfer`, {
+    method: 'POST',
+    body: JSON.stringify({ targetOrganizationId }),
+  }, apiUrl);
+  const data = await res.json() as { project?: Project };
+  return data.project ?? (data as unknown as Project);
+}
+
 export async function restoreProject(projectId: string, apiUrl?: string): Promise<Project> {
   const res = await platformFetch(
     `/projects/v1/${projectId}/restore`,
@@ -387,6 +406,57 @@ export async function getSubscriptionStatus(orgId: string, apiUrl?: string): Pro
 export async function getCredits(orgId: string, apiUrl?: string): Promise<CreditBalance> {
   const res = await platformFetch(`/billing/v1/${orgId}/credits`, {}, apiUrl);
   return await res.json() as CreditBalance;
+}
+
+export async function getPaymentHistory(orgId: string, apiUrl?: string): Promise<PaymentRecord[]> {
+  const res = await platformFetch(`/organizations/v1/${orgId}/payment-history`, {}, apiUrl);
+  const data = await res.json() as { payments?: PaymentRecord[] };
+  return data.payments ?? [];
+}
+
+export async function getBillingCycles(orgId: string, apiUrl?: string): Promise<BillingCycles> {
+  const res = await platformFetch(`/organizations/v1/${orgId}/billing-cycles`, {}, apiUrl);
+  return await res.json() as BillingCycles;
+}
+
+/**
+ * Create a Stripe Checkout session to upgrade an existing org to `plan`.
+ * Returns a hosted checkout URL the caller opens in a browser to complete
+ * payment. Requires the caller to be an org administrator.
+ */
+export async function createCheckoutSession(
+  orgId: string,
+  plan: string,
+  apiUrl?: string,
+): Promise<CheckoutSession> {
+  const res = await platformFetch('/billing/v1/stripe/checkout-session', {
+    method: 'POST',
+    body: JSON.stringify({ organizationId: orgId, plan }),
+  }, apiUrl);
+  return await res.json() as CheckoutSession;
+}
+
+/** Create a Stripe customer-portal session (manage subscription / payment method). */
+export async function createPortalSession(orgId: string, apiUrl?: string): Promise<PortalSession> {
+  const res = await platformFetch('/billing/v1/stripe/portal-session', {
+    method: 'POST',
+    body: JSON.stringify({ organizationId: orgId }),
+  }, apiUrl);
+  return await res.json() as PortalSession;
+}
+
+export async function redeemPromo(orgId: string, code: string, apiUrl?: string): Promise<RedeemResult> {
+  const res = await platformFetch('/billing/v1/promo/redeem', {
+    method: 'POST',
+    body: JSON.stringify({ organizationId: orgId, code }),
+  }, apiUrl);
+  return await res.json() as RedeemResult;
+}
+
+/** Generate (or fetch) the org's referral link. Administrator only. */
+export async function getReferralLink(orgId: string, apiUrl?: string): Promise<ReferralLink> {
+  const res = await platformFetch(`/billing/v1/${orgId}/referral-link`, { method: 'POST' }, apiUrl);
+  return await res.json() as ReferralLink;
 }
 
 export async function getOrgUsage(orgId: string, apiUrl?: string): Promise<OrgUsage> {

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -408,8 +408,10 @@ export async function getCredits(orgId: string, apiUrl?: string): Promise<Credit
 
 export async function getPaymentHistory(orgId: string, apiUrl?: string): Promise<PaymentRecord[]> {
   const res = await platformFetch(`/organizations/v1/${orgId}/payment-history`, {}, apiUrl);
-  const data = await res.json() as { payments?: PaymentRecord[] };
-  return data.payments ?? [];
+  const data = await res.json() as { payments?: PaymentRecord[] } | PaymentRecord[];
+  // Tolerate either the documented `{ payments: [...] }` shape or a bare array,
+  // without silently emptying on shape drift.
+  return Array.isArray(data) ? data : data.payments ?? [];
 }
 
 export async function getBillingCycles(orgId: string, apiUrl?: string): Promise<BillingCycles> {

--- a/src/lib/guard/risk-registry.ts
+++ b/src/lib/guard/risk-registry.ts
@@ -264,6 +264,15 @@ const REGISTRY: Record<string, (ctx: OperationContext) => RiskAssessment> = {
     risk: 'Live traffic is interrupted during the restart. Roll-back means restarting again.',
   }),
 
+  'projects transfer': (ctx) => ({
+    severity: 'high',
+    kind: 'project.transfer',
+    title: 'Transfer a project to another organization',
+    whatHappens: `Moves the project to organization "${ctx.args[0] ?? '?'}".`,
+    blastRadius: 'Billing, membership, and access all move to the target org.',
+    risk: 'Members of the current org may lose access. Verify the target org id.',
+  }),
+
   'projects upgrade-instance': (ctx) => ({
     severity: 'high',
     kind: 'project.upgrade_instance',

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,44 @@ export interface SubscriptionStatus {
   stripeSubscriptionId?: string;
 }
 
+export interface PaymentRecord {
+  stripe_invoice_id?: string;
+  amount_cents: number;
+  amount_display: string;
+  currency: string;
+  status: string;
+  description: string | null;
+  invoice_pdf_url: string | null;
+  created_at: string;
+}
+
+export interface BillingCycles {
+  current: { start_date: string; end_date: string };
+  previous?: { start_date: string; end_date: string };
+}
+
+export interface CheckoutSession {
+  checkoutUrl: string;
+  sessionId: string;
+}
+
+export interface PortalSession {
+  portalUrl: string;
+}
+
+export interface RedeemResult {
+  success: boolean;
+  message?: string;
+  creditAmountCents: number;
+  creditBalanceCents: number;
+}
+
+export interface ReferralLink {
+  code: string;
+  url: string;
+  redemptionCount: number;
+}
+
 export interface CreditBalance {
   creditBalanceCents: number;
   creditBalanceFormatted: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -282,19 +282,6 @@ export interface PortalSession {
   portalUrl: string;
 }
 
-export interface RedeemResult {
-  success: boolean;
-  message?: string;
-  creditAmountCents: number;
-  creditBalanceCents: number;
-}
-
-export interface ReferralLink {
-  code: string;
-  url: string;
-  redemptionCount: number;
-}
-
 export interface CreditBalance {
   creditBalanceCents: number;
   creditBalanceFormatted: string;


### PR DESCRIPTION
## Summary

Rounds out the **billing** surface (the original "inspect billing, upgrade plans" goal) and adds **cross-org project transfer**. Follows the patterns established in #175 — `platformFetch` wrappers, shared `resolveOrgId`, guard registration for destructive ops.

## New commands

**Billing**
- `billing history` — payment / invoice history (date, amount, status, description)
- `billing cycles` — current + previous billing-cycle windows
- `billing upgrade <plan>` — Stripe checkout to change plan; opens the hosted URL in a browser (`free|starter|pro|team|enterprise`)
- `billing manage` — Stripe customer portal (manage subscription / payment method); opens in browser

**Projects**
- `projects transfer <targetOrgId>` — move a project to another organization

## Notes for reviewers
- `upgrade`/`manage` create a Stripe session server-side and open the returned `checkoutUrl`/`portalUrl`; with `--json` the URL is printed instead of opened (headless/CI friendly). No charge happens until the user completes checkout in the browser.
- `upgrade` validates the plan against the billing enum; the backend enforces the actual allowed transitions and admin role.
- `projects transfer` is registered with the human-in-the-loop guard (**high** — billing/membership/access move to the target org) and confirms interactively.
- All billing commands resolve the org via the shared order: `--org-id` → `INSFORGE_ORG_ID` → linked project → default org → prompt.
- `redeem` and `referral` were dropped per review — deferred for now.

## Test plan
- [x] `npm run build` + `npm run lint` green
- [x] `--help` verified for all new commands
- [x] Live read-only smoke test: `billing history` and `billing cycles` against a real org render correctly
- [ ] Stripe-triggering commands (`upgrade`/`manage`) and `transfer` not run automatically (real side effects) — reviewer to exercise

Contracts verified against `insforge-cloud-backend@master`. Follows #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add billing management and project transfer commands to the CLI
> - Adds four new `billing` subcommands: `history` (payment history table), `cycles` (billing cycle windows), `upgrade <plan>` (opens a Stripe checkout session), and `manage` (opens the Stripe customer portal).
> - Adds a `projects transfer <targetOrgId>` command that transfers a project to another organization, with an optional confirmation prompt and analytics tracking.
> - Backs both features with new platform API calls in [platform.ts](https://github.com/InsForge/CLI/pull/176/files#diff-d73ae485f47b95b83b8cd3130a1529f8f4aa252cbcf402373078648162812f9d) for payment history, billing cycles, Stripe checkout/portal sessions, and project transfer.
> - Registers `projects transfer` as a high-severity operation in the risk registry so it triggers warnings where the registry is consulted.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #176 opened
>
> - Fixed calendar date rendering in billing cycles to prevent timezone-induced day shifts [09952fc]
> - Removed client-side plan validation from billing upgrade command [09952fc]
> - Required explicit project selection for project transfer operations [09952fc]
> - Fixed payment history API parsing to handle bare array responses [09952fc]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7cbffe.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added billing command suite to view payment history and billing cycles, upgrade plans, and open the customer billing portal (supports JSON or table output).
  * Added `projects transfer <targetOrgId>` to transfer a project to another organization with confirmation, and surfaces success details and relevant transfer links.
* **Security & Compliance**
  * Updated the risk classification for the `projects transfer` command path to reflect high severity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->