### PR TITLE
feat(cli): add PostHog tracking coverage to every command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -12,6 +12,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
 import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 // Shown in help only. Not used to validate — the backend owns the plan enum,
 // so a hard-coded allowlist here could reject a newly added plan.
@@ -34,6 +35,8 @@ export function registerBillingCommands(billingCmd: Command): void {
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const sub = await getSubscriptionStatus(orgId, apiUrl);
 
+        await trackCommandUsage('billing', 'status', true);
+
         if (json) {
           outputJson(sub);
         } else {
@@ -48,6 +51,7 @@ export function registerBillingCommands(billingCmd: Command): void {
           );
         }
       } catch (err) {
+        await trackCommandUsage('billing', 'status', false, {}, err);
         handleError(err, json);
       }
     });
@@ -62,6 +66,8 @@ export function registerBillingCommands(billingCmd: Command): void {
         await requireAuth(apiUrl);
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const credits = await getCredits(orgId, apiUrl);
+
+        await trackCommandUsage('billing', 'credits', true);
 
         if (json) {
           outputJson(credits);
@@ -79,6 +85,7 @@ export function registerBillingCommands(billingCmd: Command): void {
           }
         }
       } catch (err) {
+        await trackCommandUsage('billing', 'credits', false, {}, err);
         handleError(err, json);
       }
     });
@@ -93,6 +100,8 @@ export function registerBillingCommands(billingCmd: Command): void {
         await requireAuth(apiUrl);
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const payments = await getPaymentHistory(orgId, apiUrl);
+
+        await trackCommandUsage('billing', 'history', true, { result_count: payments.length });
 
         if (json) {
           outputJson(payments);
@@ -111,6 +120,7 @@ export function registerBillingCommands(billingCmd: Command): void {
           );
         }
       } catch (err) {
+        await trackCommandUsage('billing', 'history', false, {}, err);
         handleError(err, json);
       }
     });
@@ -126,6 +136,8 @@ export function registerBillingCommands(billingCmd: Command): void {
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const cycles = await getBillingCycles(orgId, apiUrl);
 
+        await trackCommandUsage('billing', 'cycles', true);
+
         if (json) {
           outputJson(cycles);
         } else {
@@ -136,6 +148,7 @@ export function registerBillingCommands(billingCmd: Command): void {
           outputTable(['Cycle', 'Window'], rows);
         }
       } catch (err) {
+        await trackCommandUsage('billing', 'cycles', false, {}, err);
         handleError(err, json);
       }
     });
@@ -152,6 +165,8 @@ export function registerBillingCommands(billingCmd: Command): void {
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const session = await createCheckoutSession(orgId, plan, apiUrl);
 
+        await trackCommandUsage('billing', 'upgrade', true);
+
         if (json) {
           outputJson(session);
         } else {
@@ -160,6 +175,7 @@ export function registerBillingCommands(billingCmd: Command): void {
           await open(session.checkoutUrl).catch(() => { /* headless: URL already printed */ });
         }
       } catch (err) {
+        await trackCommandUsage('billing', 'upgrade', false, {}, err);
         handleError(err, json);
       }
     });
@@ -175,6 +191,8 @@ export function registerBillingCommands(billingCmd: Command): void {
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const session = await createPortalSession(orgId, apiUrl);
 
+        await trackCommandUsage('billing', 'manage', true);
+
         if (json) {
           outputJson(session);
         } else {
@@ -183,6 +201,7 @@ export function registerBillingCommands(billingCmd: Command): void {
           await open(session.portalUrl).catch(() => { /* headless: URL already printed */ });
         }
       } catch (err) {
+        await trackCommandUsage('billing', 'manage', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/delete.ts
+++ b/src/commands/compute/delete.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerComputeDeleteCommand(computeCmd: Command): void {
   computeCmd
@@ -19,6 +20,8 @@ export function registerComputeDeleteCommand(computeCmd: Command): void {
         });
         const data = await res.json() as Record<string, unknown>;
 
+        await trackCommandUsage('compute', 'delete', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -27,6 +30,7 @@ export function registerComputeDeleteCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.delete', true);
       } catch (err) {
         await reportCliUsage('cli.compute.delete', false);
+        await trackCommandUsage('compute', 'delete', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -6,6 +6,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 import { parseEnvFile } from '../../lib/env-file.js';
 import {
   ensureFlyctlAvailable,
@@ -146,6 +147,8 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
           }
           const service = (await res.json()) as Record<string, unknown>;
 
+          await trackCommandUsage('compute', 'deploy', true);
+
           if (json) {
             outputJson(service);
           } else {
@@ -283,6 +286,8 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
         );
         const service = (await finalRes.json()) as Record<string, unknown>;
 
+        await trackCommandUsage('compute', 'deploy', true);
+
         if (json) {
           outputJson(service);
         } else {
@@ -303,6 +308,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.deploy', true);
       } catch (err) {
         await reportCliUsage('cli.compute.deploy', false);
+        await trackCommandUsage('compute', 'deploy', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/events.ts
+++ b/src/commands/compute/events.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 // `compute events <id>` returns Fly machine lifecycle events (start/stop/exit/
 // restart) — not container stdout/stderr. The previous name `compute logs`
@@ -25,6 +26,10 @@ export function registerComputeEventsCommand(computeCmd: Command): void {
         );
         const events = await res.json() as { timestamp: number; message: string }[];
 
+        await trackCommandUsage('compute', 'events', true, {
+          result_count: Array.isArray(events) ? events.length : 0,
+        });
+
         if (json) {
           outputJson(events);
         } else {
@@ -41,6 +46,7 @@ export function registerComputeEventsCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.events', true);
       } catch (err) {
         await reportCliUsage('cli.compute.events', false);
+        await trackCommandUsage('compute', 'events', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/get.ts
+++ b/src/commands/compute/get.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputInfo } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerComputeGetCommand(computeCmd: Command): void {
   computeCmd
@@ -16,6 +17,8 @@ export function registerComputeGetCommand(computeCmd: Command): void {
 
         const res = await ossFetch(`/api/compute/services/${encodeURIComponent(id)}`);
         const service = await res.json() as Record<string, unknown>;
+
+        await trackCommandUsage('compute', 'get', true);
 
         if (json) {
           outputJson(service);
@@ -40,6 +43,7 @@ export function registerComputeGetCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.get', true);
       } catch (err) {
         await reportCliUsage('cli.compute.get', false);
+        await trackCommandUsage('compute', 'get', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/list.ts
+++ b/src/commands/compute/list.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerComputeListCommand(computeCmd: Command): void {
   computeCmd
@@ -17,6 +18,10 @@ export function registerComputeListCommand(computeCmd: Command): void {
         const res = await ossFetch('/api/compute/services');
         const raw = await res.json();
         const services: Record<string, unknown>[] = Array.isArray(raw) ? raw : [];
+
+        await trackCommandUsage('compute', 'list', true, {
+          result_count: services.length,
+        });
 
         if (json) {
           outputJson(services);
@@ -53,6 +58,7 @@ export function registerComputeListCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.list', true);
       } catch (err) {
         await reportCliUsage('cli.compute.list', false);
+        await trackCommandUsage('compute', 'list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/start.ts
+++ b/src/commands/compute/start.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerComputeStartCommand(computeCmd: Command): void {
   computeCmd
@@ -19,6 +20,8 @@ export function registerComputeStartCommand(computeCmd: Command): void {
         });
         const service = await res.json() as Record<string, unknown>;
 
+        await trackCommandUsage('compute', 'start', true);
+
         if (json) {
           outputJson(service);
         } else {
@@ -30,6 +33,7 @@ export function registerComputeStartCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.start', true);
       } catch (err) {
         await reportCliUsage('cli.compute.start', false);
+        await trackCommandUsage('compute', 'start', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/stop.ts
+++ b/src/commands/compute/stop.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerComputeStopCommand(computeCmd: Command): void {
   computeCmd
@@ -19,6 +20,8 @@ export function registerComputeStopCommand(computeCmd: Command): void {
         });
         const service = await res.json() as Record<string, unknown>;
 
+        await trackCommandUsage('compute', 'stop', true);
+
         if (json) {
           outputJson(service);
         } else {
@@ -27,6 +30,7 @@ export function registerComputeStopCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.stop', true);
       } catch (err) {
         await reportCliUsage('cli.compute.stop', false);
+        await trackCommandUsage('compute', 'stop', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/compute/update.ts
+++ b/src/commands/compute/update.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 const ENV_KEY_REGEX = /^[A-Z_][A-Z0-9_]*$/;
 
@@ -127,6 +128,8 @@ export function registerComputeUpdateCommand(computeCmd: Command): void {
         });
         const service = await res.json() as Record<string, unknown>;
 
+        await trackCommandUsage('compute', 'update', true);
+
         if (json) {
           outputJson(service);
         } else {
@@ -137,6 +140,7 @@ export function registerComputeUpdateCommand(computeCmd: Command): void {
         await reportCliUsage('cli.compute.update', true);
       } catch (err) {
         await reportCliUsage('cli.compute.update', false);
+        await trackCommandUsage('compute', 'update', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/connection-string.ts
+++ b/src/commands/db/connection-string.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbConnectionStringCommand(dbCmd: Command): void {
   dbCmd
@@ -17,6 +18,7 @@ export function registerDbConnectionStringCommand(dbCmd: Command): void {
         if (!url) {
           throw new CLIError('Could not fetch the database connection string. This command requires a cloud project (self-hosted instances expose Postgres directly via your docker-compose).');
         }
+        await trackCommandUsage('db', 'connection-string', true);
         if (json) {
           outputJson({ connectionURL: url });
         } else {
@@ -25,6 +27,7 @@ export function registerDbConnectionStringCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.connection-string', true);
       } catch (err) {
         await reportCliUsage('cli.db.connection-string', false);
+        await trackCommandUsage('db', 'connection-string', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/export.ts
+++ b/src/commands/db/export.ts
@@ -43,8 +43,6 @@ export function registerDbExportCommand(dbCmd: Command): void {
 
         const raw = await res.text();
 
-        await trackCommandUsage('db', 'export', true);
-
         // API may return JSON wrapper { format, content, tables } or raw SQL/JSON text
         let content: string;
         let meta: { format?: string; tables?: string[] } | null = null;
@@ -62,6 +60,7 @@ export function registerDbExportCommand(dbCmd: Command): void {
 
         if (json) {
           outputJson(meta ?? { content });
+          await trackCommandUsage('db', 'export', true);
           return;
         }
 
@@ -73,6 +72,7 @@ export function registerDbExportCommand(dbCmd: Command): void {
         } else {
           console.log(content);
         }
+        await trackCommandUsage('db', 'export', true);
       } catch (err) {
         await trackCommandUsage('db', 'export', false, {}, err);
         handleError(err, json);

--- a/src/commands/db/export.ts
+++ b/src/commands/db/export.ts
@@ -4,6 +4,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbExportCommand(dbCmd: Command): void {
   dbCmd
@@ -42,6 +43,8 @@ export function registerDbExportCommand(dbCmd: Command): void {
 
         const raw = await res.text();
 
+        await trackCommandUsage('db', 'export', true);
+
         // API may return JSON wrapper { format, content, tables } or raw SQL/JSON text
         let content: string;
         let meta: { format?: string; tables?: string[] } | null = null;
@@ -71,6 +74,7 @@ export function registerDbExportCommand(dbCmd: Command): void {
           console.log(content);
         }
       } catch (err) {
+        await trackCommandUsage('db', 'export', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/functions.ts
+++ b/src/commands/db/functions.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { DatabaseFunctionsResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbFunctionsCommand(dbCmd: Command): void {
   dbCmd
@@ -21,6 +22,8 @@ export function registerDbFunctionsCommand(dbCmd: Command): void {
           ? raw
           : (raw as DatabaseFunctionsResponse).functions ?? [];
 
+        await trackCommandUsage('db', 'functions', true, { result_count: functions.length });
+
         if (json) {
           outputJson(raw);
         } else {
@@ -36,6 +39,7 @@ export function registerDbFunctionsCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.functions', true);
       } catch (err) {
         await reportCliUsage('cli.db.functions', false);
+        await trackCommandUsage('db', 'functions', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/import.ts
+++ b/src/commands/db/import.ts
@@ -5,6 +5,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbImportCommand(dbCmd: Command): void {
   dbCmd
@@ -42,12 +43,15 @@ export function registerDbImportCommand(dbCmd: Command): void {
 
         const data = await res.json() as { filename: string; fileSize: number; tables: string[]; rowsImported: number };
 
+        await trackCommandUsage('db', 'import', true, { result_count: data.rowsImported });
+
         if (json) {
           outputJson(data);
         } else {
           outputSuccess(`Imported ${data.filename} (${data.tables.length} tables, ${data.rowsImported} rows)`);
         }
       } catch (err) {
+        await trackCommandUsage('db', 'import', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/indexes.ts
+++ b/src/commands/db/indexes.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { DatabaseIndexesResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbIndexesCommand(dbCmd: Command): void {
   dbCmd
@@ -20,6 +21,8 @@ export function registerDbIndexesCommand(dbCmd: Command): void {
         const indexes: DatabaseIndexesResponse['indexes'] = Array.isArray(raw)
           ? raw
           : (raw as DatabaseIndexesResponse).indexes ?? [];
+
+        await trackCommandUsage('db', 'indexes', true, { result_count: indexes.length });
 
         if (json) {
           outputJson(raw);
@@ -42,6 +45,7 @@ export function registerDbIndexesCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.indexes', true);
       } catch (err) {
         await reportCliUsage('cli.db.indexes', false);
+        await trackCommandUsage('db', 'indexes', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/migrations.ts
+++ b/src/commands/db/migrations.ts
@@ -20,6 +20,7 @@ import {
 } from '../../lib/migrations.js';
 import { outputJson, outputSuccess, outputTable } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 import type {
   CreateMigrationRequest,
   CreateMigrationResponse,
@@ -111,6 +112,8 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
 
         const migrations = await fetchRemoteMigrations();
 
+        await trackCommandUsage('db', 'migrations list', true, { result_count: migrations.length });
+
         if (json) {
           outputJson({ migrations });
         } else if (migrations.length === 0) {
@@ -129,6 +132,7 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.migrations.list', true);
       } catch (err) {
         await reportCliUsage('cli.db.migrations.list', false);
+        await trackCommandUsage('db', 'migrations list', false, {}, err);
         handleError(err, json);
       }
     });
@@ -176,6 +180,8 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
           existingLocalVersions.add(migration.version);
         }
 
+        await trackCommandUsage('db', 'migrations fetch', true, { result_count: createdFiles.length });
+
         if (json) {
           outputJson({
             directory: migrationsDir,
@@ -194,6 +200,7 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.migrations.fetch', true);
       } catch (err) {
         await reportCliUsage('cli.db.migrations.fetch', false);
+        await trackCommandUsage('db', 'migrations fetch', false, {}, err);
         handleError(err, json);
       }
     });
@@ -228,6 +235,8 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
           throw error;
         }
 
+        await trackCommandUsage('db', 'migrations new', true);
+
         if (json) {
           outputJson({ filename, path: filePath, version: nextVersion });
         } else {
@@ -237,6 +246,7 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.migrations.new', true);
       } catch (err) {
         await reportCliUsage('cli.db.migrations.new', false);
+        await trackCommandUsage('db', 'migrations new', false, {}, err);
         handleError(err, json);
       }
     });
@@ -347,6 +357,7 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
               outputSuccess('No pending local migrations to apply.');
             }
 
+            await trackCommandUsage('db', 'migrations up', true, { result_count: 0 });
             await reportCliUsage('cli.db.migrations.up', true);
             return;
           }
@@ -401,6 +412,8 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
           }
         }
 
+        await trackCommandUsage('db', 'migrations up', true, { result_count: appliedMigrations.length });
+
         if (json) {
           outputJson({ appliedMigrations });
         } else {
@@ -413,6 +426,7 @@ export function registerDbMigrationsCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.migrations.up', true);
       } catch (err) {
         await reportCliUsage('cli.db.migrations.up', false);
+        await trackCommandUsage('db', 'migrations up', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/policies.ts
+++ b/src/commands/db/policies.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { DatabasePoliciesResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbPoliciesCommand(dbCmd: Command): void {
   dbCmd
@@ -20,6 +21,8 @@ export function registerDbPoliciesCommand(dbCmd: Command): void {
         const policies: DatabasePoliciesResponse['policies'] = Array.isArray(raw)
           ? raw
           : (raw as DatabasePoliciesResponse).policies ?? [];
+
+        await trackCommandUsage('db', 'policies', true, { result_count: policies.length });
 
         if (json) {
           outputJson(raw);
@@ -43,6 +46,7 @@ export function registerDbPoliciesCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.policies', true);
       } catch (err) {
         await reportCliUsage('cli.db.policies', false);
+        await trackCommandUsage('db', 'policies', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/query.ts
+++ b/src/commands/db/query.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbCommands(dbCmd: Command): void {
   dbCmd
@@ -16,6 +17,8 @@ export function registerDbCommands(dbCmd: Command): void {
         await requireAuth();
 
         const { rows, raw } = await runRawSql(sql, !!opts.unrestricted);
+
+        await trackCommandUsage('db', 'query', true, { result_count: rows.length });
 
         if (json) {
           outputJson(raw);
@@ -37,6 +40,7 @@ export function registerDbCommands(dbCmd: Command): void {
         await reportCliUsage('cli.db.query', true);
       } catch (err) {
         await reportCliUsage('cli.db.query', false);
+        await trackCommandUsage('db', 'query', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/rpc.ts
+++ b/src/commands/db/rpc.ts
@@ -34,6 +34,7 @@ export function registerDbRpcCommand(dbCmd: Command): void {
         }
         await reportCliUsage('cli.db.rpc', true);
       } catch (err) {
+        await reportCliUsage('cli.db.rpc', false);
         await trackCommandUsage('db', 'rpc', false, {}, err);
         handleError(err, json);
       }

--- a/src/commands/db/rpc.ts
+++ b/src/commands/db/rpc.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbRpcCommand(dbCmd: Command): void {
   dbCmd
@@ -24,6 +25,8 @@ export function registerDbRpcCommand(dbCmd: Command): void {
 
         const result = await res.json() as unknown;
 
+        await trackCommandUsage('db', 'rpc', true);
+
         if (json) {
           outputJson(result);
         } else {
@@ -31,6 +34,7 @@ export function registerDbRpcCommand(dbCmd: Command): void {
         }
         await reportCliUsage('cli.db.rpc', true);
       } catch (err) {
+        await trackCommandUsage('db', 'rpc', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/tables.ts
+++ b/src/commands/db/tables.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbTablesCommand(dbCmd: Command): void {
   dbCmd
@@ -16,6 +17,8 @@ export function registerDbTablesCommand(dbCmd: Command): void {
 
         const res = await ossFetch('/api/database/tables');
         const tables = await res.json() as string[];
+
+        await trackCommandUsage('db', 'tables', true, { result_count: tables.length });
 
         if (json) {
           outputJson(tables);
@@ -32,6 +35,7 @@ export function registerDbTablesCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.tables', true);
       } catch (err) {
         await reportCliUsage('cli.db.tables', false);
+        await trackCommandUsage('db', 'tables', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/db/triggers.ts
+++ b/src/commands/db/triggers.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { DatabaseTriggersResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerDbTriggersCommand(dbCmd: Command): void {
   dbCmd
@@ -20,6 +21,8 @@ export function registerDbTriggersCommand(dbCmd: Command): void {
         const triggers: DatabaseTriggersResponse['triggers'] = Array.isArray(raw)
           ? raw
           : (raw as DatabaseTriggersResponse).triggers ?? [];
+
+        await trackCommandUsage('db', 'triggers', true, { result_count: triggers.length });
 
         if (json) {
           outputJson(raw);
@@ -44,6 +47,7 @@ export function registerDbTriggersCommand(dbCmd: Command): void {
         await reportCliUsage('cli.db.triggers', true);
       } catch (err) {
         await reportCliUsage('cli.db.triggers', false);
+        await trackCommandUsage('db', 'triggers', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -29,16 +29,17 @@ Examples:
         await requireAuth();
 
         await reportCliUsage('cli.docs', true);
-        await trackTopLevelUsage('docs', true);
         // No args → list all docs
         if (!feature) {
           await listDocs(json);
+          await trackTopLevelUsage('docs', true);
           return;
         }
 
         // Single arg → legacy doc type (e.g. "instructions")
         if (!language) {
           await fetchDoc(`/api/docs/${encodeURIComponent(feature)}`, feature, json);
+          await trackTopLevelUsage('docs', true);
           return;
         }
 
@@ -48,6 +49,7 @@ Examples:
           `${feature}/${language}`,
           json,
         );
+        await trackTopLevelUsage('docs', true);
       } catch (err) {
         await trackTopLevelUsage('docs', false, {}, err);
         handleError(err, json);

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../lib/credentials.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import { outputJson, outputTable } from '../lib/output.js';
 import { reportCliUsage } from '../lib/skills.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 
 const FEATURES = ['db', 'storage', 'functions', 'auth', 'ai', 'realtime'] as const;
 const LANGUAGES = ['typescript', 'swift', 'kotlin', 'rest-api'] as const;
@@ -28,6 +29,7 @@ Examples:
         await requireAuth();
 
         await reportCliUsage('cli.docs', true);
+        await trackTopLevelUsage('docs', true);
         // No args → list all docs
         if (!feature) {
           await listDocs(json);
@@ -47,6 +49,7 @@ Examples:
           json,
         );
       } catch (err) {
+        await trackTopLevelUsage('docs', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/functions/code.ts
+++ b/src/commands/functions/code.ts
@@ -29,8 +29,6 @@ export function registerFunctionsCodeCommand(functionsCmd: Command): void {
         const res = await ossFetch(`/api/functions/${encodeURIComponent(slug)}`);
         const fn = await res.json() as FunctionDetails;
 
-        await trackCommandUsage('functions', 'code', true);
-
         if (json) {
           outputJson(fn);
         } else {
@@ -41,6 +39,8 @@ export function registerFunctionsCodeCommand(functionsCmd: Command): void {
           console.log('---');
           console.log(fn.code);
         }
+
+        await trackCommandUsage('functions', 'code', true);
       } catch (err) {
         await trackCommandUsage('functions', 'code', false, {}, err);
         handleError(err, json);

--- a/src/commands/functions/code.ts
+++ b/src/commands/functions/code.ts
@@ -3,6 +3,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 interface FunctionDetails {
   id: string;
@@ -28,6 +29,8 @@ export function registerFunctionsCodeCommand(functionsCmd: Command): void {
         const res = await ossFetch(`/api/functions/${encodeURIComponent(slug)}`);
         const fn = await res.json() as FunctionDetails;
 
+        await trackCommandUsage('functions', 'code', true);
+
         if (json) {
           outputJson(fn);
         } else {
@@ -39,6 +42,7 @@ export function registerFunctionsCodeCommand(functionsCmd: Command): void {
           console.log(fn.code);
         }
       } catch (err) {
+        await trackCommandUsage('functions', 'code', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/functions/delete.ts
+++ b/src/commands/functions/delete.ts
@@ -6,6 +6,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 import type { FunctionResponse } from '../../types.js';
 
 export function registerFunctionsDeleteCommand(functionsCmd: Command): void {
@@ -32,6 +33,8 @@ export function registerFunctionsDeleteCommand(functionsCmd: Command): void {
         });
         const result = await res.json() as FunctionResponse;
 
+        await trackCommandUsage('functions', 'delete', true);
+
         if (json) {
           outputJson(result);
         } else {
@@ -44,6 +47,7 @@ export function registerFunctionsDeleteCommand(functionsCmd: Command): void {
         await reportCliUsage('cli.functions.delete', true);
       } catch (err) {
         await reportCliUsage('cli.functions.delete', false);
+        await trackCommandUsage('functions', 'delete', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/functions/deploy.ts
+++ b/src/commands/functions/deploy.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 import type { FunctionResponse } from '../../types.js';
 
 export function resolveDeployFilePath(opts: { file?: string }): string {
@@ -61,6 +62,10 @@ export function registerFunctionsDeployCommand(functionsCmd: Command): void {
 
         const deployFailed = result.deployment?.status === 'failed';
 
+        if (!deployFailed) {
+          await trackCommandUsage('functions', 'deploy', true);
+        }
+
         if (json) {
           outputJson(result);
         } else {
@@ -85,6 +90,7 @@ export function registerFunctionsDeployCommand(functionsCmd: Command): void {
         await reportCliUsage('cli.functions.deploy', true);
       } catch (err) {
         await reportCliUsage('cli.functions.deploy', false);
+        await trackCommandUsage('functions', 'deploy', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/functions/invoke.ts
+++ b/src/commands/functions/invoke.ts
@@ -3,6 +3,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, ProjectNotLinkedError, CLIError } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerFunctionsInvokeCommand(functionsCmd: Command): void {
   functionsCmd
@@ -41,6 +42,10 @@ export function registerFunctionsInvokeCommand(functionsCmd: Command): void {
         const contentType = res.headers.get('content-type') ?? '';
         const status = res.status;
 
+        if (status < 400) {
+          await trackCommandUsage('functions', 'invoke', true);
+        }
+
         if (contentType.includes('application/json')) {
           const data = await res.json();
           if (json) {
@@ -58,6 +63,7 @@ export function registerFunctionsInvokeCommand(functionsCmd: Command): void {
           throw new CLIError(`HTTP ${status}`, 1, 'HTTP_ERROR');
         }
       } catch (err) {
+        await trackCommandUsage('functions', 'invoke', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/functions/list.ts
+++ b/src/commands/functions/list.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { ListFunctionsResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerFunctionsCommands(functionsCmd: Command): void {
   functionsCmd
@@ -23,6 +24,10 @@ export function registerFunctionsCommands(functionsCmd: Command): void {
           : raw && typeof raw === 'object' && 'functions' in raw
             ? (raw as ListFunctionsResponse).functions ?? []
             : [];
+
+        await trackCommandUsage('functions', 'list', true, {
+          result_count: functions.length,
+        });
 
         if (json) {
           outputJson(raw);
@@ -44,6 +49,7 @@ export function registerFunctionsCommands(functionsCmd: Command): void {
         await reportCliUsage('cli.functions.list', true);
       } catch (err) {
         await reportCliUsage('cli.functions.list', false);
+        await trackCommandUsage('functions', 'list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import { getCredentials, getGlobalConfig, getProjectConfig } from '../lib/config.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import { outputJson } from '../lib/output.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 
 export function registerContextCommand(program: Command): void {
   program
@@ -13,6 +14,8 @@ export function registerContextCommand(program: Command): void {
         const creds = getCredentials();
         const globalConfig = getGlobalConfig();
         const projectConfig = getProjectConfig();
+
+        await trackTopLevelUsage('current', true);
 
         if (json) {
           outputJson({
@@ -53,6 +56,7 @@ export function registerContextCommand(program: Command): void {
 
         console.log('');
       } catch (err) {
+        await trackTopLevelUsage('current', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,6 +3,7 @@ import { listOrganizations, listProjects } from '../lib/api/platform.js';
 import { requireAuth } from '../lib/credentials.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import { outputJson, outputTable } from '../lib/output.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 
 export function registerListCommand(program: Command): void {
   program
@@ -13,6 +14,8 @@ export function registerListCommand(program: Command): void {
       try {
         await requireAuth(apiUrl);
         const orgs = await listOrganizations(apiUrl);
+
+        await trackTopLevelUsage('list', true, { result_count: orgs.length });
 
         if (orgs.length === 0) {
           if (json) {
@@ -70,6 +73,7 @@ export function registerListCommand(program: Command): void {
 
         outputTable(['Organization', 'Project', 'Region', 'Status', 'AppKey'], rows);
       } catch (err) {
+        await trackTopLevelUsage('list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -5,6 +5,7 @@ import { saveCredentials, getPlatformApiUrl } from '../lib/config.js';
 import { login as platformLogin } from '../lib/api/platform.js';
 import { performOAuthLogin } from '../lib/auth.js';
 import { handleError, getRootOpts, CLIError, formatFetchError } from '../lib/errors.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 import type { StoredCredentials, User } from '../types.js';
 
 export function registerLoginCommand(program: Command): void {
@@ -25,10 +26,13 @@ export function registerLoginCommand(program: Command): void {
         } else {
           await loginWithOAuth(json, apiUrl);
         }
+
+        await trackTopLevelUsage('login', true);
       } catch (err) {
         if (err instanceof Error && err.message.includes('cancelled')) {
           process.exit(0);
         }
+        await trackTopLevelUsage('login', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import { clearCredentials } from '../lib/config.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import { outputSuccess, outputJson } from '../lib/output.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 
 export function registerLogoutCommand(program: Command): void {
   program
@@ -11,12 +12,16 @@ export function registerLogoutCommand(program: Command): void {
       const { json } = getRootOpts(cmd);
       try {
         clearCredentials();
+
+        await trackTopLevelUsage('logout', true);
+
         if (json) {
           outputJson({ success: true, message: 'Logged out successfully' });
         } else {
           outputSuccess('Logged out successfully.');
         }
       } catch (err) {
+        await trackTopLevelUsage('logout', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -3,6 +3,7 @@ import { ossFetch } from '../lib/api/oss.js';
 import { requireAuth } from '../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../lib/errors.js';
 import { outputJson } from '../lib/output.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 
 const VALID_SOURCES = ['insforge.logs', 'postgREST.logs', 'postgres.logs', 'function.logs', 'function-deploy.logs'] as const;
 const SOURCE_LOOKUP = new Map(VALID_SOURCES.map((s) => [s.toLowerCase(), s]));
@@ -37,6 +38,8 @@ export function registerLogsCommand(program: Command): void {
         const res = await ossFetch(getLogPath(resolved, limit));
         const data = await res.json();
 
+        await trackTopLevelUsage('logs', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -57,6 +60,7 @@ export function registerLogsCommand(program: Command): void {
           }
         }
       } catch (err) {
+        await trackTopLevelUsage('logs', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/metadata.ts
+++ b/src/commands/metadata.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../lib/credentials.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import { outputJson, outputTable } from '../lib/output.js';
 import { reportCliUsage } from '../lib/skills.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 
 export function registerMetadataCommand(program: Command): void {
   program
@@ -17,6 +18,8 @@ export function registerMetadataCommand(program: Command): void {
 
         const res = await ossFetch('/api/metadata');
         const data = await res.json() as AppMetadataSchema;
+
+        await trackTopLevelUsage('metadata', true);
 
         if (json) {
           outputJson(data);
@@ -98,6 +101,7 @@ export function registerMetadataCommand(program: Command): void {
         await reportCliUsage('cli.metadata', true);
       } catch (err) {
         await reportCliUsage('cli.metadata', false);
+        await trackTopLevelUsage('metadata', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/orgs/list.ts
+++ b/src/commands/orgs/list.ts
@@ -3,6 +3,7 @@ import { listOrganizations } from '../../lib/api/platform.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerOrgsCommands(orgsCmd: Command): void {
   orgsCmd
@@ -13,6 +14,8 @@ export function registerOrgsCommands(orgsCmd: Command): void {
       try {
         await requireAuth(apiUrl);
         const orgs = await listOrganizations(apiUrl);
+
+        await trackCommandUsage('orgs', 'list', true, { result_count: orgs.length });
 
         if (json) {
           outputJson(orgs);
@@ -31,6 +34,7 @@ export function registerOrgsCommands(orgsCmd: Command): void {
           );
         }
       } catch (err) {
+        await trackCommandUsage('orgs', 'list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/orgs/manage.ts
+++ b/src/commands/orgs/manage.ts
@@ -13,6 +13,7 @@ import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
 import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
 import type { MemberRole } from '../../types.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 const ORG_TYPES = ['personal', 'team', 'company'];
 const MEMBER_ROLES: MemberRole[] = ['administrator', 'developer'];
@@ -37,12 +38,14 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
           throw new CLIError(`Invalid --type "${opts.type}". Valid types: ${ORG_TYPES.join(', ')}.`);
         }
         const org = await createOrganization({ name, type: opts.type }, apiUrl);
+        await trackCommandUsage('orgs', 'create', true);
         if (json) {
           outputJson(org);
         } else {
           outputSuccess(`Organization "${org.name}" created (${org.id}).`);
         }
       } catch (err) {
+        await trackCommandUsage('orgs', 'create', false, {}, err);
         handleError(err, json);
       }
     });
@@ -72,12 +75,14 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         }
 
         const org = await updateOrganization(orgId, body, apiUrl);
+        await trackCommandUsage('orgs', 'update', true);
         if (json) {
           outputJson(org);
         } else {
           outputSuccess(`Organization "${org.name}" updated.`);
         }
       } catch (err) {
+        await trackCommandUsage('orgs', 'update', false, {}, err);
         handleError(err, json);
       }
     });
@@ -94,6 +99,8 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         await requireAuth(apiUrl);
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const { members, invitations } = await listMembers(orgId, apiUrl);
+
+        await trackCommandUsage('orgs', 'members list', true, { result_count: members.length });
 
         if (json) {
           outputJson({ members, invitations });
@@ -116,6 +123,7 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
           );
         }
       } catch (err) {
+        await trackCommandUsage('orgs', 'members list', false, {}, err);
         handleError(err, json);
       }
     });
@@ -132,12 +140,14 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         const role = assertRole(opts.role);
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const invitation = await inviteMember(orgId, email, role, apiUrl);
+        await trackCommandUsage('orgs', 'members invite', true);
         if (json) {
           outputJson(invitation);
         } else {
           outputSuccess(`Invited ${email} as ${invitation.role}.`);
         }
       } catch (err) {
+        await trackCommandUsage('orgs', 'members invite', false, {}, err);
         handleError(err, json);
       }
     });
@@ -163,12 +173,14 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         }
 
         await removeMember(orgId, memberId, apiUrl);
+        await trackCommandUsage('orgs', 'members remove', true);
         if (json) {
           outputJson({ removed: true, member_id: memberId });
         } else {
           outputSuccess(`Member ${memberId} removed.`);
         }
       } catch (err) {
+        await trackCommandUsage('orgs', 'members remove', false, {}, err);
         handleError(err, json);
       }
     });
@@ -184,12 +196,14 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         const validRole = assertRole(role);
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const member = await updateMemberRole(orgId, memberId, validRole, apiUrl);
+        await trackCommandUsage('orgs', 'members role', true);
         if (json) {
           outputJson(member);
         } else {
           outputSuccess(`Member ${memberId} is now ${member.role}.`);
         }
       } catch (err) {
+        await trackCommandUsage('orgs', 'members role', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -5,6 +5,7 @@ import { getGlobalConfig } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerProjectsCommands(projectsCmd: Command): void {
   projectsCmd
@@ -45,6 +46,8 @@ export function registerProjectsCommands(projectsCmd: Command): void {
 
         const projects = await listProjects(orgId, apiUrl);
 
+        await trackCommandUsage('projects', 'list', true, { result_count: projects.length });
+
         if (json) {
           outputJson(projects);
         } else {
@@ -58,6 +61,7 @@ export function registerProjectsCommands(projectsCmd: Command): void {
           );
         }
       } catch (err) {
+        await trackCommandUsage('projects', 'list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/records/create.ts
+++ b/src/commands/records/create.ts
@@ -3,6 +3,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerRecordsCreateCommand(recordsCmd: Command): void {
   recordsCmd
@@ -36,6 +37,8 @@ export function registerRecordsCreateCommand(recordsCmd: Command): void {
 
         const data = await res.json() as { data?: unknown[] };
 
+        await trackCommandUsage('records', 'create', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -43,6 +46,7 @@ export function registerRecordsCreateCommand(recordsCmd: Command): void {
           outputSuccess(`Created ${created.length || records.length} record(s) in "${table}".`);
         }
       } catch (err) {
+        await trackCommandUsage('records', 'create', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/records/delete.ts
+++ b/src/commands/records/delete.ts
@@ -3,6 +3,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerRecordsDeleteCommand(recordsCmd: Command): void {
   recordsCmd
@@ -29,6 +30,8 @@ export function registerRecordsDeleteCommand(recordsCmd: Command): void {
 
         const data = await res.json() as { data?: unknown[] };
 
+        await trackCommandUsage('records', 'delete', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -36,6 +39,7 @@ export function registerRecordsDeleteCommand(recordsCmd: Command): void {
           outputSuccess(`Deleted ${deleted.length} record(s) from "${table}".`);
         }
       } catch (err) {
+        await trackCommandUsage('records', 'delete', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/records/list.ts
+++ b/src/commands/records/list.ts
@@ -3,6 +3,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerRecordsCommands(recordsCmd: Command): void {
   recordsCmd
@@ -31,6 +32,10 @@ export function registerRecordsCommands(recordsCmd: Command): void {
         const data = await res.json() as { data?: Record<string, unknown>[] };
         const records = data.data ?? [];
 
+        await trackCommandUsage('records', 'list', true, {
+          result_count: records.length,
+        });
+
         if (json) {
           outputJson(data);
         } else {
@@ -51,6 +56,7 @@ export function registerRecordsCommands(recordsCmd: Command): void {
           console.log(`${records.length} record(s).`);
         }
       } catch (err) {
+        await trackCommandUsage('records', 'list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/records/update.ts
+++ b/src/commands/records/update.ts
@@ -3,6 +3,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerRecordsUpdateCommand(recordsCmd: Command): void {
   recordsCmd
@@ -43,6 +44,8 @@ export function registerRecordsUpdateCommand(recordsCmd: Command): void {
 
         const data = await res.json() as { data?: unknown[] };
 
+        await trackCommandUsage('records', 'update', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -50,6 +53,7 @@ export function registerRecordsUpdateCommand(recordsCmd: Command): void {
           outputSuccess(`Updated ${updated.length} record(s) in "${table}".`);
         }
       } catch (err) {
+        await trackCommandUsage('records', 'update', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/schedules/create.ts
+++ b/src/commands/schedules/create.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import type { CreateScheduleResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSchedulesCreateCommand(schedulesCmd: Command): void {
   schedulesCmd
@@ -52,6 +53,8 @@ export function registerSchedulesCreateCommand(schedulesCmd: Command): void {
         });
         const data = await res.json() as CreateScheduleResponse;
 
+        await trackCommandUsage('schedules', 'create', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -60,6 +63,7 @@ export function registerSchedulesCreateCommand(schedulesCmd: Command): void {
         await reportCliUsage('cli.schedules.create', true);
       } catch (err) {
         await reportCliUsage('cli.schedules.create', false);
+        await trackCommandUsage('schedules', 'create', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/schedules/delete.ts
+++ b/src/commands/schedules/delete.ts
@@ -4,6 +4,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSchedulesDeleteCommand(schedulesCmd: Command): void {
   schedulesCmd
@@ -28,12 +29,15 @@ export function registerSchedulesDeleteCommand(schedulesCmd: Command): void {
         });
         const data = await res.json() as { success: boolean; message: string };
 
+        await trackCommandUsage('schedules', 'delete', true);
+
         if (json) {
           outputJson(data);
         } else {
           outputSuccess(data.message ?? 'Schedule deleted.');
         }
       } catch (err) {
+        await trackCommandUsage('schedules', 'delete', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/schedules/get.ts
+++ b/src/commands/schedules/get.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import type { GetScheduleResponse } from '../../types.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSchedulesGetCommand(schedulesCmd: Command): void {
   schedulesCmd
@@ -16,6 +17,8 @@ export function registerSchedulesGetCommand(schedulesCmd: Command): void {
 
         const res = await ossFetch(`/api/schedules/${encodeURIComponent(id)}`);
         const data = await res.json() as GetScheduleResponse;
+
+        await trackCommandUsage('schedules', 'get', true);
 
         if (json) {
           outputJson(data);
@@ -33,6 +36,7 @@ export function registerSchedulesGetCommand(schedulesCmd: Command): void {
           console.log('');
         }
       } catch (err) {
+        await trackCommandUsage('schedules', 'get', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/schedules/list.ts
+++ b/src/commands/schedules/list.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { ListSchedulesResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSchedulesListCommand(schedulesCmd: Command): void {
   schedulesCmd
@@ -18,6 +19,10 @@ export function registerSchedulesListCommand(schedulesCmd: Command): void {
         const res = await ossFetch('/api/schedules');
         const data = await res.json();
         const schedules: ListSchedulesResponse = data as ListSchedulesResponse;
+
+        await trackCommandUsage('schedules', 'list', true, {
+          result_count: schedules.length,
+        });
 
         if (json) {
           outputJson(schedules);
@@ -42,6 +47,7 @@ export function registerSchedulesListCommand(schedulesCmd: Command): void {
         await reportCliUsage('cli.schedules.list', true);
       } catch (err) {
         await reportCliUsage('cli.schedules.list', false);
+        await trackCommandUsage('schedules', 'list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/schedules/logs.ts
+++ b/src/commands/schedules/logs.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { ListExecutionLogsResponse } from '../../types.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSchedulesLogsCommand(schedulesCmd: Command): void {
   schedulesCmd
@@ -22,6 +23,10 @@ export function registerSchedulesLogsCommand(schedulesCmd: Command): void {
         const res = await ossFetch(`/api/schedules/${encodeURIComponent(id)}/logs?limit=${limit}&offset=${offset}`);
         const data = await res.json() as ListExecutionLogsResponse;
         const logs = data.logs ?? [];
+
+        await trackCommandUsage('schedules', 'logs', true, {
+          result_count: logs.length,
+        });
 
         if (json) {
           outputJson(data);
@@ -44,6 +49,7 @@ export function registerSchedulesLogsCommand(schedulesCmd: Command): void {
           }
         }
       } catch (err) {
+        await trackCommandUsage('schedules', 'logs', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/schedules/update.ts
+++ b/src/commands/schedules/update.ts
@@ -3,6 +3,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSchedulesUpdateCommand(schedulesCmd: Command): void {
   schedulesCmd
@@ -55,12 +56,15 @@ export function registerSchedulesUpdateCommand(schedulesCmd: Command): void {
         });
         const data = await res.json() as { success: boolean; message: string };
 
+        await trackCommandUsage('schedules', 'update', true);
+
         if (json) {
           outputJson(data);
         } else {
           outputSuccess(data.message ?? 'Schedule updated.');
         }
       } catch (err) {
+        await trackCommandUsage('schedules', 'update', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/secrets/add.ts
+++ b/src/commands/secrets/add.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import type { CreateSecretResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSecretsAddCommand(secretsCmd: Command): void {
   secretsCmd
@@ -27,6 +28,8 @@ export function registerSecretsAddCommand(secretsCmd: Command): void {
         });
         const data = await res.json() as CreateSecretResponse;
 
+        await trackCommandUsage('secrets', 'add', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -35,6 +38,7 @@ export function registerSecretsAddCommand(secretsCmd: Command): void {
         await reportCliUsage('cli.secrets.add', true);
       } catch (err) {
         await reportCliUsage('cli.secrets.add', false);
+        await trackCommandUsage('secrets', 'add', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/secrets/delete.ts
+++ b/src/commands/secrets/delete.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import type { DeleteSecretResponse } from '../../types.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSecretsDeleteCommand(secretsCmd: Command): void {
   secretsCmd
@@ -29,12 +30,15 @@ export function registerSecretsDeleteCommand(secretsCmd: Command): void {
         });
         const data = await res.json() as DeleteSecretResponse;
 
+        await trackCommandUsage('secrets', 'delete', true);
+
         if (json) {
           outputJson(data);
         } else {
           outputSuccess(data.message ?? `Secret ${key} deleted.`);
         }
       } catch (err) {
+        await trackCommandUsage('secrets', 'delete', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/secrets/get.ts
+++ b/src/commands/secrets/get.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import type { GetSecretValueResponse } from '../../types.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSecretsGetCommand(secretsCmd: Command): void {
   secretsCmd
@@ -18,12 +19,15 @@ export function registerSecretsGetCommand(secretsCmd: Command): void {
         const data = await res.json();
         const secret = data as GetSecretValueResponse;
 
+        await trackCommandUsage('secrets', 'get', true);
+
         if (json) {
           outputJson(data);
         } else {
           console.log(`${secret.key} = ${secret.value}`);
         }
       } catch (err) {
+        await trackCommandUsage('secrets', 'get', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/secrets/list.ts
+++ b/src/commands/secrets/list.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { ListSecretsResponse } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSecretsListCommand(secretsCmd: Command): void {
   secretsCmd
@@ -23,6 +24,11 @@ export function registerSecretsListCommand(secretsCmd: Command): void {
         if (!opts.all) {
           secrets = secrets.filter((s) => s.isActive !== false);
         }
+
+        await trackCommandUsage('secrets', 'list', true, {
+          result_count: secrets.length,
+          all: !!opts.all,
+        });
 
         if (json) {
           outputJson(opts.all ? data : { secrets });
@@ -51,6 +57,7 @@ export function registerSecretsListCommand(secretsCmd: Command): void {
         await reportCliUsage('cli.secrets.list', true);
       } catch (err) {
         await reportCliUsage('cli.secrets.list', false);
+        await trackCommandUsage('secrets', 'list', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/secrets/rotate.ts
+++ b/src/commands/secrets/rotate.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 const KEYS = ['api-key', 'anon-key'];
 
@@ -44,6 +45,8 @@ export function registerSecretsRotateCommand(secretsCmd: Command): void {
           : await rotateAnonKey(graceHours);
         const newKey = result.apiKey ?? result.anonKey ?? '';
 
+        await trackCommandUsage('secrets', 'rotate', true);
+
         if (json) {
           outputJson(result);
         } else {
@@ -54,6 +57,7 @@ export function registerSecretsRotateCommand(secretsCmd: Command): void {
         await reportCliUsage('cli.secrets.rotate', true);
       } catch (err) {
         await reportCliUsage('cli.secrets.rotate', false);
+        await trackCommandUsage('secrets', 'rotate', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/secrets/update.ts
+++ b/src/commands/secrets/update.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import type { UpdateSecretResponse } from '../../types.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerSecretsUpdateCommand(secretsCmd: Command): void {
   secretsCmd
@@ -34,12 +35,15 @@ export function registerSecretsUpdateCommand(secretsCmd: Command): void {
         });
         const data = await res.json() as UpdateSecretResponse;
 
+        await trackCommandUsage('secrets', 'update', true);
+
         if (json) {
           outputJson(data);
         } else {
           outputSuccess(data.message ?? `Secret ${key} updated.`);
         }
       } catch (err) {
+        await trackCommandUsage('secrets', 'update', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/storage/buckets.ts
+++ b/src/commands/storage/buckets.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { StorageBucketSchema } from '../../types.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerStorageBucketsCommand(storageCmd: Command): void {
   storageCmd
@@ -24,6 +25,10 @@ export function registerStorageBucketsCommand(storageCmd: Command): void {
             ? (raw as { buckets?: StorageBucketSchema[] }).buckets ?? []
             : [];
 
+        await trackCommandUsage('storage', 'buckets', true, {
+          result_count: buckets.length,
+        });
+
         if (json) {
           outputJson(raw);
         } else {
@@ -39,6 +44,7 @@ export function registerStorageBucketsCommand(storageCmd: Command): void {
         await reportCliUsage('cli.storage.buckets', true);
       } catch (err) {
         await reportCliUsage('cli.storage.buckets', false);
+        await trackCommandUsage('storage', 'buckets', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/storage/create-bucket.ts
+++ b/src/commands/storage/create-bucket.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerStorageCreateBucketCommand(storageCmd: Command): void {
   storageCmd
@@ -25,6 +26,8 @@ export function registerStorageCreateBucketCommand(storageCmd: Command): void {
 
         const data = await res.json();
 
+        await trackCommandUsage('storage', 'create-bucket', true);
+
         if (json) {
           outputJson(data);
         } else {
@@ -33,6 +36,7 @@ export function registerStorageCreateBucketCommand(storageCmd: Command): void {
         await reportCliUsage('cli.storage.create-bucket', true);
       } catch (err) {
         await reportCliUsage('cli.storage.create-bucket', false);
+        await trackCommandUsage('storage', 'create-bucket', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/storage/delete-bucket.ts
+++ b/src/commands/storage/delete-bucket.ts
@@ -4,6 +4,7 @@ import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerStorageDeleteBucketCommand(storageCmd: Command): void {
   storageCmd
@@ -29,12 +30,15 @@ export function registerStorageDeleteBucketCommand(storageCmd: Command): void {
 
         const data = await res.json();
 
+        await trackCommandUsage('storage', 'delete-bucket', true);
+
         if (json) {
           outputJson(data);
         } else {
           outputSuccess(`Bucket "${name}" deleted.`);
         }
       } catch (err) {
+        await trackCommandUsage('storage', 'delete-bucket', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/storage/download.ts
+++ b/src/commands/storage/download.ts
@@ -5,6 +5,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerStorageDownloadCommand(storageCmd: Command): void {
   storageCmd
@@ -38,12 +39,15 @@ export function registerStorageDownloadCommand(storageCmd: Command): void {
         const outputPath = opts.output ?? join(process.cwd(), basename(objectKey));
         writeFileSync(outputPath, buffer);
 
+        await trackCommandUsage('storage', 'download', true);
+
         if (json) {
           outputJson({ success: true, path: outputPath, size: buffer.length });
         } else {
           outputSuccess(`Downloaded "${objectKey}" to ${outputPath} (${buffer.length} bytes).`);
         }
       } catch (err) {
+        await trackCommandUsage('storage', 'download', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/storage/list-objects.ts
+++ b/src/commands/storage/list-objects.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 interface StoredFile {
   key: string;
@@ -55,6 +56,10 @@ export function registerStorageListObjectsCommand(storageCmd: Command): void {
           return a.key.localeCompare(b.key);
         });
 
+        await trackCommandUsage('storage', 'list-objects', true, {
+          result_count: objects.length,
+        });
+
         if (json) {
           outputJson(raw);
         } else {
@@ -79,6 +84,7 @@ export function registerStorageListObjectsCommand(storageCmd: Command): void {
         await reportCliUsage('cli.storage.list-objects', true);
       } catch (err) {
         await reportCliUsage('cli.storage.list-objects', false);
+        await trackCommandUsage('storage', 'list-objects', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/storage/s3-keys.ts
+++ b/src/commands/storage/s3-keys.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 export function registerStorageS3KeysCommand(storageCmd: Command): void {
   const s3Cmd = storageCmd
@@ -19,6 +20,9 @@ export function registerStorageS3KeysCommand(storageCmd: Command): void {
       try {
         await requireAuth();
         const keys = await listS3AccessKeys();
+        await trackCommandUsage('storage', 's3-keys list', true, {
+          result_count: keys.length,
+        });
         if (json) {
           outputJson(keys);
         } else if (!keys.length) {
@@ -38,6 +42,7 @@ export function registerStorageS3KeysCommand(storageCmd: Command): void {
         await reportCliUsage('cli.storage.s3-keys.list', true);
       } catch (err) {
         await reportCliUsage('cli.storage.s3-keys.list', false);
+        await trackCommandUsage('storage', 's3-keys list', false, {}, err);
         handleError(err, json);
       }
     });
@@ -51,6 +56,7 @@ export function registerStorageS3KeysCommand(storageCmd: Command): void {
       try {
         await requireAuth();
         const key = await createS3AccessKey(opts.description);
+        await trackCommandUsage('storage', 's3-keys create', true);
         if (json) {
           outputJson(key);
         } else {
@@ -61,6 +67,7 @@ export function registerStorageS3KeysCommand(storageCmd: Command): void {
         await reportCliUsage('cli.storage.s3-keys.create', true);
       } catch (err) {
         await reportCliUsage('cli.storage.s3-keys.create', false);
+        await trackCommandUsage('storage', 's3-keys create', false, {}, err);
         handleError(err, json);
       }
     });
@@ -82,6 +89,7 @@ export function registerStorageS3KeysCommand(storageCmd: Command): void {
           }
         }
         await deleteS3AccessKey(id);
+        await trackCommandUsage('storage', 's3-keys delete', true);
         if (json) {
           outputJson({ deleted: true, id });
         } else {
@@ -90,6 +98,7 @@ export function registerStorageS3KeysCommand(storageCmd: Command): void {
         await reportCliUsage('cli.storage.s3-keys.delete', true);
       } catch (err) {
         await reportCliUsage('cli.storage.s3-keys.delete', false);
+        await trackCommandUsage('storage', 's3-keys delete', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/storage/upload.ts
+++ b/src/commands/storage/upload.ts
@@ -6,6 +6,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { mimeTypeFromName } from '../../lib/mime.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
 /**
  * Resolve the content type for an upload: an explicit (non-empty) `--content-type`
@@ -68,12 +69,15 @@ export function registerStorageUploadCommand(storageCmd: Command): void {
 
         const data = await res.json();
 
+        await trackCommandUsage('storage', 'upload', true);
+
         if (json) {
           outputJson(data);
         } else {
           outputSuccess(`Uploaded "${basename(file)}" to bucket "${bucketName}".`);
         }
       } catch (err) {
+        await trackCommandUsage('storage', 'upload', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/usage/index.ts
+++ b/src/commands/usage/index.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
 import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
+import { trackTopLevelUsage } from '../../lib/command-telemetry.js';
 
 /** Render a byte count as a human-readable size. */
 function formatBytes(n: number): string {
@@ -34,6 +35,8 @@ export function registerUsageCommand(program: Command): void {
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const usage = await getOrgUsage(orgId, apiUrl);
 
+        await trackTopLevelUsage('usage', true);
+
         if (json) {
           outputJson(usage);
           return;
@@ -59,6 +62,7 @@ export function registerUsageCommand(program: Command): void {
           );
         }
       } catch (err) {
+        await trackTopLevelUsage('usage', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -3,6 +3,7 @@ import { getProfile } from '../lib/api/platform.js';
 import { handleError, getRootOpts } from '../lib/errors.js';
 import { outputJson, outputInfo } from '../lib/output.js';
 import { requireAuth } from '../lib/credentials.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 
 export function registerWhoamiCommand(program: Command): void {
   program
@@ -14,6 +15,8 @@ export function registerWhoamiCommand(program: Command): void {
         await requireAuth(apiUrl);
         const profile = await getProfile(apiUrl);
 
+        await trackTopLevelUsage('whoami', true);
+
         if (json) {
           outputJson(profile);
         } else {
@@ -22,6 +25,7 @@ export function registerWhoamiCommand(program: Command): void {
           if (profile.id) outputInfo(`ID: ${profile.id}`);
         }
       } catch (err) {
+        await trackTopLevelUsage('whoami', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -34,6 +34,52 @@ export function trackCommand(command: string, distinctId: string, properties?: R
   });
 }
 
+// Generic per-group command telemetry. Emits `cli_<group>_invoked` with a
+// `subcommand` property — the same event shape as the bespoke
+// trackPayments/trackDeployments/... helpers, but without a hand-written
+// function per group. Use this for command groups that don't already have a
+// dedicated helper. `config` is optional: commands may run before a project is
+// linked (e.g. OSS-only flows), in which case we fall back to FAKE_PROJECT_ID
+// as the distinct ID, matching the convention in trackConfig/trackDomains.
+export function trackGroupCommand(
+  group: string,
+  subcommand: string,
+  config: ProjectConfig | null,
+  properties?: Record<string, unknown>,
+): void {
+  const distinctId = config?.project_id ?? FAKE_PROJECT_ID;
+  captureEvent(distinctId, `cli_${group}_invoked`, {
+    subcommand,
+    project_id: config?.project_id,
+    project_name: config?.project_name,
+    org_id: config?.org_id,
+    region: config?.region,
+    oss_mode: !config || config.project_id === FAKE_PROJECT_ID,
+    ...properties,
+  });
+}
+
+// Top-level standalone commands (login, whoami, list, ...) that don't belong
+// to a group. Emits the shared `cli_command_invoked` event with a `command`
+// property, matching the convention `create`/`link` already use via
+// trackCommand, but additionally attaches project context when available.
+export function trackTopLevelCommand(
+  command: string,
+  config: ProjectConfig | null,
+  properties?: Record<string, unknown>,
+): void {
+  const distinctId = config?.project_id ?? FAKE_PROJECT_ID;
+  captureEvent(distinctId, 'cli_command_invoked', {
+    command,
+    project_id: config?.project_id,
+    project_name: config?.project_name,
+    org_id: config?.org_id,
+    region: config?.region,
+    oss_mode: !config || config.project_id === FAKE_PROJECT_ID,
+    ...properties,
+  });
+}
+
 export function trackDiagnose(subcommand: string, config: ProjectConfig): void {
   captureEvent(config.project_id, 'cli_diagnose_invoked', {
     subcommand,

--- a/src/lib/command-telemetry.test.ts
+++ b/src/lib/command-telemetry.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configMock = vi.hoisted(() => ({
+  getProjectConfig: vi.fn(() => ({
+    project_id: 'p1',
+    project_name: 'Test Project',
+    org_id: 'o1',
+    region: 'us',
+    api_key: 'secret',
+    appkey: 'app',
+    oss_host: 'https://app.us.insforge.app',
+  })),
+}));
+vi.mock('./config.js', () => configMock);
+
+const analyticsMock = vi.hoisted(() => ({
+  trackGroupCommand: vi.fn(),
+  trackTopLevelCommand: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+vi.mock('./analytics.js', () => analyticsMock);
+
+import { CLIError } from './errors.js';
+import {
+  getErrorTelemetry,
+  resetTelemetryOutcomeForTests,
+  sanitizeTelemetry,
+  trackCommandUsage,
+  trackTopLevelUsage,
+} from './command-telemetry.js';
+
+describe('sanitizeTelemetry', () => {
+  it('keeps booleans, finite numbers, and short strings', () => {
+    expect(sanitizeTelemetry({ ok: true, count: 3, label: 'list' })).toEqual({
+      ok: true,
+      count: 3,
+      label: 'list',
+    });
+  });
+
+  it('drops undefined, non-finite numbers, and non-scalar values', () => {
+    const result = sanitizeTelemetry({
+      missing: undefined,
+      notFinite: Number.NaN,
+      infinite: Number.POSITIVE_INFINITY,
+      // Non-scalar values a caller might accidentally pass through.
+      nested: { secret: 'x' } as unknown as string,
+      list: [1, 2, 3] as unknown as number,
+      kept: 7,
+    });
+    expect(result).toEqual({ kept: 7 });
+    expect(result).not.toHaveProperty('missing');
+    expect(result).not.toHaveProperty('notFinite');
+    expect(result).not.toHaveProperty('infinite');
+    expect(result).not.toHaveProperty('nested');
+    expect(result).not.toHaveProperty('list');
+  });
+
+  it('truncates long strings to 80 characters', () => {
+    const long = 'a'.repeat(200);
+    const result = sanitizeTelemetry({ value: long });
+    expect((result.value as string).length).toBe(80);
+  });
+});
+
+describe('getErrorTelemetry', () => {
+  it('extracts code/exit/status from a CLIError', () => {
+    const err = new CLIError('boom', 2, 'SOME_CODE', 409);
+    expect(getErrorTelemetry(err)).toEqual({
+      error_name: 'CLIError',
+      error_code: 'SOME_CODE',
+      exit_code: 2,
+      status_code: 409,
+    });
+  });
+
+  it('reports only the name for a plain Error', () => {
+    expect(getErrorTelemetry(new TypeError('nope'))).toEqual({
+      error_name: 'TypeError',
+    });
+  });
+
+  it('falls back to typeof for a thrown non-Error', () => {
+    expect(getErrorTelemetry('just a string')).toEqual({
+      error_name: 'string',
+    });
+  });
+});
+
+describe('trackCommandUsage', () => {
+  beforeEach(() => {
+    resetTelemetryOutcomeForTests();
+    analyticsMock.trackGroupCommand.mockClear();
+    analyticsMock.shutdownAnalytics.mockClear();
+    configMock.getProjectConfig.mockReturnValue({
+      project_id: 'p1',
+      project_name: 'Test Project',
+      org_id: 'o1',
+      region: 'us',
+      api_key: 'secret',
+      appkey: 'app',
+      oss_host: 'https://app.us.insforge.app',
+    });
+  });
+
+  it('emits a grouped event with sanitized props plus error telemetry, then flushes', async () => {
+    await trackCommandUsage(
+      'db',
+      'query',
+      false,
+      { result_count: 5, secret: { v: 1 } as unknown as string },
+      new CLIError('bad', 1, 'BAD', 400),
+    );
+
+    expect(analyticsMock.trackGroupCommand).toHaveBeenCalledWith(
+      'db',
+      'query',
+      expect.objectContaining({ project_id: 'p1' }),
+      expect.objectContaining({
+        success: false,
+        result_count: 5,
+        error_name: 'CLIError',
+        error_code: 'BAD',
+        exit_code: 1,
+        status_code: 400,
+      }),
+    );
+    const props = analyticsMock.trackGroupCommand.mock.calls[0]?.[3] as Record<string, unknown>;
+    expect(props).not.toHaveProperty('secret');
+    expect(analyticsMock.shutdownAnalytics).toHaveBeenCalledOnce();
+  });
+
+  it('swallows a throwing getProjectConfig and still emits with null config', async () => {
+    configMock.getProjectConfig.mockImplementation(() => {
+      throw new Error('config unreadable');
+    });
+
+    await expect(trackCommandUsage('db', 'query', true)).resolves.toBeUndefined();
+
+    expect(analyticsMock.trackGroupCommand).toHaveBeenCalledWith(
+      'db',
+      'query',
+      null,
+      expect.objectContaining({ success: true }),
+    );
+    expect(analyticsMock.shutdownAnalytics).toHaveBeenCalledOnce();
+  });
+
+  it('records only one outcome per process (suppresses a later failure after success)', async () => {
+    await trackCommandUsage('db', 'query', true);
+    await trackCommandUsage('db', 'query', false, {}, new Error('output blew up'));
+
+    expect(analyticsMock.trackGroupCommand).toHaveBeenCalledOnce();
+    expect(analyticsMock.trackGroupCommand.mock.calls[0]?.[3]).toMatchObject({ success: true });
+  });
+});
+
+describe('trackTopLevelUsage', () => {
+  beforeEach(() => {
+    resetTelemetryOutcomeForTests();
+    analyticsMock.trackTopLevelCommand.mockClear();
+    analyticsMock.shutdownAnalytics.mockClear();
+  });
+
+  it('emits a top-level event and flushes once', async () => {
+    await trackTopLevelUsage('whoami', true);
+    expect(analyticsMock.trackTopLevelCommand).toHaveBeenCalledWith(
+      'whoami',
+      expect.objectContaining({ project_id: 'p1' }),
+      expect.objectContaining({ success: true }),
+    );
+    expect(analyticsMock.shutdownAnalytics).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/command-telemetry.ts
+++ b/src/lib/command-telemetry.ts
@@ -32,7 +32,7 @@ export type CommandTelemetry = Record<
 
 const MAX_STRING_LENGTH = 80;
 
-function sanitizeTelemetry(properties: CommandTelemetry): CommandTelemetry {
+export function sanitizeTelemetry(properties: CommandTelemetry): CommandTelemetry {
   const sanitized: CommandTelemetry = {};
   for (const [key, value] of Object.entries(properties)) {
     if (value === undefined) continue;
@@ -47,7 +47,7 @@ function sanitizeTelemetry(properties: CommandTelemetry): CommandTelemetry {
   return sanitized;
 }
 
-function getErrorTelemetry(error: unknown): CommandTelemetry {
+export function getErrorTelemetry(error: unknown): CommandTelemetry {
   return {
     error_name: error instanceof Error ? error.name : typeof error,
     ...(error instanceof CLIError
@@ -68,6 +68,28 @@ function safeGetProjectConfig() {
   }
 }
 
+// Flushing must never surface as a command error. `shutdownAnalytics` already
+// swallows its own failures today, but guarding here keeps that invariant even
+// if its implementation changes.
+async function flushTelemetry(): Promise<void> {
+  try {
+    await shutdownAnalytics();
+  } catch {
+    // Telemetry shutdown must never affect command behavior.
+  }
+}
+
+// A CLI process handles exactly one command, which should emit exactly one
+// outcome event. Once an outcome is recorded we suppress any further calls, so
+// a failure thrown during output rendering (after the success event already
+// fired) cannot double-emit success + failure for a single invocation.
+let outcomeRecorded = false;
+
+/** Test-only: reset the once-per-process outcome guard between cases. */
+export function resetTelemetryOutcomeForTests(): void {
+  outcomeRecorded = false;
+}
+
 /**
  * Track a grouped subcommand invocation (`cli_<group>_invoked`).
  */
@@ -78,6 +100,8 @@ export async function trackCommandUsage(
   properties: CommandTelemetry = {},
   error?: unknown,
 ): Promise<void> {
+  if (outcomeRecorded) return;
+  outcomeRecorded = true;
   try {
     trackGroupCommand(group, subcommand, safeGetProjectConfig(), {
       success,
@@ -89,7 +113,7 @@ export async function trackCommandUsage(
   } catch {
     // Telemetry should never affect command behavior.
   } finally {
-    await shutdownAnalytics();
+    await flushTelemetry();
   }
 }
 
@@ -102,6 +126,8 @@ export async function trackTopLevelUsage(
   properties: CommandTelemetry = {},
   error?: unknown,
 ): Promise<void> {
+  if (outcomeRecorded) return;
+  outcomeRecorded = true;
   try {
     trackTopLevelCommand(command, safeGetProjectConfig(), {
       success,
@@ -113,6 +139,6 @@ export async function trackTopLevelUsage(
   } catch {
     // Telemetry should never affect command behavior.
   } finally {
-    await shutdownAnalytics();
+    await flushTelemetry();
   }
 }

--- a/src/lib/command-telemetry.ts
+++ b/src/lib/command-telemetry.ts
@@ -1,0 +1,118 @@
+import {
+  shutdownAnalytics,
+  trackGroupCommand,
+  trackTopLevelCommand,
+} from './analytics.js';
+import { getProjectConfig } from './config.js';
+import { CLIError } from './errors.js';
+
+/**
+ * Shared PostHog telemetry helpers for CLI commands.
+ *
+ * Every command should emit exactly one event per invocation:
+ *   - `trackCommandUsage(group, subcommand, success, props?, error?)` for
+ *     commands that live under a group (`cli_<group>_invoked`).
+ *   - `trackTopLevelUsage(command, success, props?, error?)` for standalone
+ *     top-level commands (`cli_command_invoked`).
+ *
+ * Both read the linked project config (falling back to an anonymous distinct
+ * ID when none is linked), sanitize the supplied properties to non-sensitive
+ * scalars, attach error telemetry on failure, and flush PostHog in `finally`.
+ * Telemetry must never affect command behavior, so everything is wrapped in a
+ * try/catch and failures are swallowed.
+ *
+ * IMPORTANT: only pass non-sensitive metadata as `properties` — counts,
+ * booleans, enums, exit/status codes. Never SQL, file contents, credentials,
+ * resource names, or other user-entered free text.
+ */
+export type CommandTelemetry = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+const MAX_STRING_LENGTH = 80;
+
+function sanitizeTelemetry(properties: CommandTelemetry): CommandTelemetry {
+  const sanitized: CommandTelemetry = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value === undefined) continue;
+    if (typeof value === 'string') {
+      sanitized[key] = value.slice(0, MAX_STRING_LENGTH);
+    } else if (typeof value === 'number') {
+      if (Number.isFinite(value)) sanitized[key] = value;
+    } else if (typeof value === 'boolean') {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+function getErrorTelemetry(error: unknown): CommandTelemetry {
+  return {
+    error_name: error instanceof Error ? error.name : typeof error,
+    ...(error instanceof CLIError
+      ? {
+          error_code: error.code,
+          exit_code: error.exitCode,
+          status_code: error.statusCode,
+        }
+      : {}),
+  };
+}
+
+function safeGetProjectConfig() {
+  try {
+    return getProjectConfig();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Track a grouped subcommand invocation (`cli_<group>_invoked`).
+ */
+export async function trackCommandUsage(
+  group: string,
+  subcommand: string,
+  success: boolean,
+  properties: CommandTelemetry = {},
+  error?: unknown,
+): Promise<void> {
+  try {
+    trackGroupCommand(group, subcommand, safeGetProjectConfig(), {
+      success,
+      ...sanitizeTelemetry({
+        ...properties,
+        ...(error !== undefined ? getErrorTelemetry(error) : {}),
+      }),
+    });
+  } catch {
+    // Telemetry should never affect command behavior.
+  } finally {
+    await shutdownAnalytics();
+  }
+}
+
+/**
+ * Track a standalone top-level command invocation (`cli_command_invoked`).
+ */
+export async function trackTopLevelUsage(
+  command: string,
+  success: boolean,
+  properties: CommandTelemetry = {},
+  error?: unknown,
+): Promise<void> {
+  try {
+    trackTopLevelCommand(command, safeGetProjectConfig(), {
+      success,
+      ...sanitizeTelemetry({
+        ...properties,
+        ...(error !== undefined ? getErrorTelemetry(error) : {}),
+      }),
+    });
+  } catch {
+    // Telemetry should never affect command behavior.
+  } finally {
+    await shutdownAnalytics();
+  }
+}


### PR DESCRIPTION
## Summary

Brings PostHog telemetry coverage to **every CLI command**. Previously many commands had no PostHog tracking — some emitted nothing, others only used the legacy OSS `reportCliUsage` path. Now every active command emits exactly one PostHog event per invocation (success or failure).

Re-scanned against the latest `main` (incl. the new `billing`/project-transfer commands).

## Approach

**Shared infrastructure**
- New [`src/lib/command-telemetry.ts`](src/lib/command-telemetry.ts):
  - `trackCommandUsage(group, subcommand, success, props?, error?)` → `cli_<group>_invoked`
  - `trackTopLevelUsage(command, success, props?, error?)` → `cli_command_invoked`
  - Resolves project context (anonymous fallback when unlinked), sanitizes properties to non-sensitive scalars, attaches error telemetry on failure, flushes PostHog in `finally`. Telemetry never affects command behavior.
- New generic emitters `trackGroupCommand` / `trackTopLevelCommand` in [`src/lib/analytics.ts`](src/lib/analytics.ts), consistent with the existing per-group helpers.

**Coverage added** (60 command files, 152 tracking calls)
| Group | Event |
|---|---|
| `db`, `records`, `functions`, `storage`, `secrets`, `schedules`, `compute`, `orgs`, `billing`, `projects` | `cli_<group>_invoked` (per subcommand) |
| `login`, `logout`, `whoami`, `current`, `list`, `logs`, `metadata`, `docs`, `usage` | `cli_command_invoked` |

## Decisions
- **Legacy `reportCliUsage` left intact** — this change is additive; commands on the legacy path now report to both systems.
- **`login`/`logout` are tracked** (anonymous distinct ID, since they run before a project is linked).
- **Excluded** (correctly): pure router `index.ts` files (no `.action`), the `deployments/ignore-file.ts` helper, and `deployments/metadata.ts`/`slug.ts` (commented out / unregistered in `src/index.ts`).

## Privacy
Only non-sensitive scalars are sent (success flag, result counts, booleans, error name/code/exit/status). No SQL, file contents/paths, names, emails, secret values, or free text.

## Verification
- `tsc --noEmit`: error count identical to clean-`main` baseline (11 pre-existing, unrelated); none in any touched file.
- `npm run build` (tsup) succeeds.
- `npm run test`: **516 passed, 13 skipped**.

Version bumped `0.1.93` → `0.1.94`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PostHog telemetry to every CLI command. Each run now emits exactly one event (success or failure), with a guard to prevent double-emits and no behavior changes.

- **New Features**
  - Shared helper `src/lib/command-telemetry.ts` (`trackCommandUsage`, `trackTopLevelUsage`) and generic emitters in `src/lib/analytics.ts` (`trackGroupCommand`, `trackTopLevelCommand`) that resolve project context, sanitize props, attach error info, and flush in finally.
  - Coverage added across groups: db, records, functions, storage, secrets, schedules, compute, orgs, billing, projects; and top-level: login, logout, whoami, current, list, logs, metadata, docs, usage.
  - Legacy `reportCliUsage` kept (additive). Only non-sensitive scalars are sent. Version bumped to `0.1.94`.

- **Bug Fixes**
  - Add a once-per-process outcome guard; also guard `shutdownAnalytics()` in finally.
  - Emit success only after work completes: moved success tracking in `docs` (post fetch), `db export` (post write/output), and `functions code` (post output); ensure `db rpc` reports failure on error alongside PostHog.
  - Add unit tests for sanitization, error telemetry shapes, config read failure, and the outcome guard (`src/lib/command-telemetry.test.ts`).

<sup>Written for commit f48c4a43171598a48e9a18d3917a495b42befdad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PostHog telemetry tracking to all CLI commands
> - Adds `trackCommandUsage` and `trackTopLevelUsage` helpers in [command-telemetry.ts](https://github.com/InsForge/CLI/pull/177/files#diff-10b69a6e2de72955a9cc333ad558da84b6716ee72c4fc2098927a2234d73cef1) that emit PostHog events on success and failure, sanitize properties to scalar types, and always flush analytics via `shutdownAnalytics`.
> - Instruments every CLI command group (`db`, `compute`, `functions`, `storage`, `secrets`, `schedules`, `records`, `billing`, `orgs`, `projects`, `usage`, and top-level commands) with success/failure telemetry calls, including `result_count` metadata where applicable.
> - Error telemetry extracts `error_name`, `error_code`, `exit_code`, and `status_code` from `CLIError` instances via `getErrorTelemetry`.
> - Behavioral Change: every command now awaits an analytics flush before exiting, which adds a small latency to all command completions.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #177 opened
>
> - Added once-per-process outcome guards and error-safe flushing to telemetry tracking functions [f48c4a4]
> - Repositioned success telemetry calls to execute after output generation in database export, documentation, and functions code commands [f48c4a4]
> - Added failure event reporting to database RPC command error handling [f48c4a4]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized affef53.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app version to `0.1.94`.
* **New Features**
  * Expanded usage and outcome tracking across many CLI commands (success/failure plus basic result counts where applicable) to improve insights and diagnostics.
  * Added standardized telemetry support for both top-level and grouped commands.
* **Tests**
  * Added a test suite covering telemetry sanitization, error mapping, and “single outcome” behavior per run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->