### PR TITLE
feat: add datasource apify connect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,29 @@ npx @insforge/cli diagnose metrics --range 6h
 
 ---
 
+### Data Sources — `npx @insforge/cli datasource`
+
+Connect external data-source integrations to the linked InsForge project. Provider-specific commands live under `datasource <provider>` (Apify is the first provider). These commands are intended for developers and agents who want to scrape or pull external data into a project: connect the account once, then let the local agent run the provider's tools using an InsForge-managed token. Runtime data calls should fetch a fresh token from InsForge rather than embedding a personal key.
+
+#### `npx @insforge/cli datasource apify connect`
+
+Connect your Apify account to your InsForge project via OAuth, then automatically run the auth bridge (token login + agent skills) so the local agent is immediately usable.
+
+```bash
+npx @insforge/cli datasource apify connect
+npx @insforge/cli datasource apify connect --skip-browser   # only print the OAuth URL, do not auto-open the browser
+```
+
+#### `npx @insforge/cli datasource apify login`
+
+Authenticate the local Apify CLI/agent using your InsForge-managed token (no browser). Re-run this on any Apify `401`/"not logged in" error; InsForge re-fetches a fresh token. Never use the plain `apify login` browser flow.
+
+```bash
+npx @insforge/cli datasource apify login
+```
+
+---
+
 ### PostHog — `npx @insforge/cli posthog`
 
 Manage PostHog product analytics integration.

--- a/src/commands/datasource/apify/connect.ts
+++ b/src/commands/datasource/apify/connect.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../lib/api/apify.js';
 import { outputJson, outputSuccess } from '../../../lib/output.js';
 import { trackGroupCommand, shutdownAnalytics } from '../../../lib/analytics.js';
+import { runApifyAuthBridge } from '../../../lib/apify-bridge.js';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 15 * 60 * 1000;
@@ -97,6 +98,19 @@ async function runConnect(opts: RunConnectOpts): Promise<ConnectResult> {
     token,
     opts,
   );
+
+  // Auth bridge: log in the local Apify CLI + install skills so the agent is
+  // immediately usable — no manual `apify login` browser flow required.
+  // Gracefully degraded: a failure here never blocks the connect result.
+  try {
+    await runApifyAuthBridge(opts.json);
+  } catch {
+    if (!opts.json) {
+      clack.log.warn(
+        'Connected, but auto-login/skills install failed. Run `insforge datasource apify login` to finish.',
+      );
+    }
+  }
 
   if (!opts.json) {
     const details = [

--- a/src/commands/datasource/apify/connect.ts
+++ b/src/commands/datasource/apify/connect.ts
@@ -106,7 +106,12 @@ async function runConnect(opts: RunConnectOpts): Promise<ConnectResult> {
   // immediately usable — no manual `apify login` browser flow required.
   // Gracefully degraded: a failure here never blocks the connect result.
   try {
-    await runApifyAuthBridge(opts.json);
+    const { skillsInstalled } = await runApifyAuthBridge(opts.json);
+    if (!opts.json && !skillsInstalled) {
+      clack.log.warn(
+        'Agent skills did not install. Re-run `insforge datasource apify login`, or install manually with `npx skills add apify/agent-skills`.',
+      );
+    }
   } catch {
     if (!opts.json) {
       clack.log.warn(

--- a/src/commands/datasource/apify/connect.ts
+++ b/src/commands/datasource/apify/connect.ts
@@ -51,6 +51,9 @@ export function registerApifyConnectCommand(program: Command): void {
           outputJson({ success: true, ...result });
         }
       } catch (err) {
+        // handleError() calls process.exit(), which skips the finally block — so
+        // flush queued analytics here before the process dies.
+        await shutdownAnalytics();
         handleError(err, json);
       } finally {
         await shutdownAnalytics();
@@ -140,6 +143,12 @@ async function ensureConnection(
     // Sanity-check that cloud-backend has the connection row, surface a clear
     // error if cli-start says yes but /connection says no (data drift).
     const fetchResult = await fetchApifyConnection(projectId, token, opts.apiUrl);
+    if (fetchResult.kind === 'forbidden') {
+      throw new CLIError(`Forbidden: ${fetchResult.message}`, 5);
+    }
+    if (fetchResult.kind === 'error') {
+      throw new CLIError(`Could not verify the Apify connection: ${fetchResult.message}`);
+    }
     if (fetchResult.kind !== 'connected') {
       throw new CLIError(
         'cli-start reported connected, but /connection returned not-connected. Try again, or check the dashboard.',

--- a/src/commands/datasource/apify/connect.ts
+++ b/src/commands/datasource/apify/connect.ts
@@ -1,0 +1,229 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import pc from 'picocolors';
+import { getProjectConfig, getAccessToken } from '../../../lib/config.js';
+import {
+  handleError,
+  getRootOpts,
+  CLIError,
+  ProjectNotLinkedError,
+  AuthError,
+} from '../../../lib/errors.js';
+import { isInteractive } from '../../../lib/prompts.js';
+import {
+  fetchApifyConnection,
+  pollApifyConnection,
+  startApifyCliFlow,
+  type ApifyConnectionResponse,
+} from '../../../lib/api/apify.js';
+import { outputJson, outputSuccess } from '../../../lib/output.js';
+import { trackGroupCommand, shutdownAnalytics } from '../../../lib/analytics.js';
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 15 * 60 * 1000;
+const MAX_TRANSIENT_RETRIES = 5;
+
+interface ConnectResult {
+  /** Whether the connection already existed (skipped OAuth) or was just established. */
+  connectionState: 'already-connected' | 'newly-connected';
+  /** Metadata of the connected Apify account (no secrets — the token stays server-side). */
+  connection: {
+    apifyUsername?: string | null;
+    plan?: string | null;
+    status?: string;
+  };
+}
+
+export function registerApifyConnectCommand(program: Command): void {
+  program
+    .command('connect')
+    .description('Connect your Apify account to your InsForge project')
+    .option('--skip-browser', 'Do not auto-open the browser for OAuth; only print the URL')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        const result = await runConnect({
+          json,
+          apiUrl,
+          skipBrowser: Boolean(opts.skipBrowser),
+        });
+        if (json) {
+          outputJson({ success: true, ...result });
+        }
+      } catch (err) {
+        handleError(err, json);
+      } finally {
+        await shutdownAnalytics();
+      }
+    });
+}
+
+interface RunConnectOpts {
+  json: boolean;
+  apiUrl?: string;
+  skipBrowser: boolean;
+}
+
+// Ensures the InsForge project has an Apify connection (cli-start / OAuth).
+// This populates the connection in cloud-backend and makes the in-product
+// data-source integration usable. Unlike PostHog there is no SDK-install
+// wizard step — the command ends once connected.
+async function runConnect(opts: RunConnectOpts): Promise<ConnectResult> {
+  // 1. Linked project
+  const proj = getProjectConfig();
+  if (!proj || !proj.project_id) {
+    throw new ProjectNotLinkedError();
+  }
+
+  // 2. Login token
+  const token = getAccessToken();
+  if (!token) {
+    throw new AuthError('Not logged in. Run `insforge login` first.');
+  }
+
+  trackGroupCommand('apify', 'connect', proj);
+
+  if (!opts.json) {
+    clack.intro('Apify connect');
+    outputSuccess(`Linked to InsForge project: ${proj.project_name} (${proj.project_id})`);
+  }
+
+  // 3. Ensure connection exists
+  const { state: connectionState, connection } = await ensureConnection(
+    proj.project_id,
+    token,
+    opts,
+  );
+
+  if (!opts.json) {
+    const details = [
+      connection.apifyUsername ? `  Account:  ${connection.apifyUsername}` : null,
+      connection.plan ? `  Plan:     ${connection.plan}` : null,
+      connection.status ? `  Status:   ${connection.status}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n');
+    clack.outro(
+      details
+        ? `Apify is connected to your InsForge project.\n\n${details}`
+        : 'Apify is connected to your InsForge project.',
+    );
+  }
+
+  return {
+    connectionState,
+    connection: {
+      apifyUsername: connection.apifyUsername,
+      plan: connection.plan,
+      status: connection.status,
+    },
+  };
+}
+
+// Calls cli-start. If already connected, no-op. Otherwise opens the OAuth
+// browser flow and polls until the connection appears. Returns whether we
+// hit the fast path or had to wait, plus the connection metadata.
+async function ensureConnection(
+  projectId: string,
+  token: string,
+  opts: RunConnectOpts,
+): Promise<{
+  state: 'already-connected' | 'newly-connected';
+  connection: ApifyConnectionResponse;
+}> {
+  const startResult = await startApifyCliFlow(projectId, token, opts.apiUrl);
+
+  if (startResult.type === 'connected') {
+    if (!opts.json) {
+      outputSuccess('Apify is already connected to your InsForge project.');
+    }
+    // Sanity-check that cloud-backend has the connection row, surface a clear
+    // error if cli-start says yes but /connection says no (data drift).
+    const fetchResult = await fetchApifyConnection(projectId, token, opts.apiUrl);
+    if (fetchResult.kind !== 'connected') {
+      throw new CLIError(
+        'cli-start reported connected, but /connection returned not-connected. Try again, or check the dashboard.',
+      );
+    }
+    return { state: 'already-connected', connection: fetchResult.connection };
+  }
+
+  const connection = await runConnectFlow(projectId, token, startResult.authorizeUrl, opts);
+  return { state: 'newly-connected', connection };
+}
+
+async function runConnectFlow(
+  projectId: string,
+  token: string,
+  authorizeUrl: string,
+  opts: RunConnectOpts,
+): Promise<ApifyConnectionResponse> {
+  if (opts.json) {
+    // JSON mode: keep stdout clean for the final result object. Print the
+    // URL to stderr so a human can copy it if the browser fails to open.
+    process.stderr.write(`Authorize Apify: ${authorizeUrl}\n`);
+    process.stderr.write('Your browser should open automatically. If not, copy the URL above.\n');
+  } else {
+    clack.log.info('Apify is not yet connected to your InsForge project.');
+    if (opts.skipBrowser) {
+      clack.log.info(`Open this URL to authorize Apify:\n${pc.cyan(pc.underline(authorizeUrl))}`);
+    } else {
+      clack.log.info('Opening browser to authorize Apify...');
+      clack.log.info(`If browser doesn't open, visit:\n${pc.cyan(pc.underline(authorizeUrl))}`);
+    }
+  }
+
+  if (!opts.skipBrowser) {
+    try {
+      const open = (await import('open')).default;
+      await open(authorizeUrl);
+    } catch {
+      // Best-effort — URL was already printed above.
+    }
+  }
+
+  const spinner = !opts.json && isInteractive ? clack.spinner() : null;
+  if (spinner) {
+    spinner.start('Waiting for Apify connection... (timeout: 15 minutes)');
+  } else if (!opts.json) {
+    // Non-interactive (agent / CI / non-TTY): spinner can't animate, but the
+    // user still needs to know we're polling and how long we'll wait.
+    clack.log.info('Waiting for Apify connection (up to 15 minutes)...');
+  }
+
+  try {
+    const connection = await pollApifyConnection(
+      projectId,
+      token,
+      {
+        intervalMs: POLL_INTERVAL_MS,
+        timeoutMs: POLL_TIMEOUT_MS,
+        maxTransientRetries: MAX_TRANSIENT_RETRIES,
+        onTick: (elapsed): void => {
+          if (spinner) {
+            const secs = Math.floor(elapsed / 1000);
+            const mins = Math.floor(secs / 60);
+            const remaining = `${mins}m ${secs % 60}s elapsed`;
+            spinner.message(`Waiting for Apify connection... (${remaining})`);
+          }
+        },
+      },
+      opts.apiUrl,
+    );
+    // Always print success — spinner.stop only renders in TTY, but the agent /
+    // non-interactive user needs to see the outcome of the wait.
+    if (spinner) {
+      spinner.stop('Apify connection received.');
+    } else if (!opts.json) {
+      clack.log.success('Apify connection received.');
+    }
+    return connection;
+  } catch (err) {
+    if (spinner) {
+      spinner.stop('Apify connection wait failed.');
+    } else if (!opts.json) {
+      clack.log.error('Apify connection wait failed.');
+    }
+    throw err;
+  }
+}

--- a/src/commands/datasource/apify/connect.ts
+++ b/src/commands/datasource/apify/connect.ts
@@ -52,8 +52,11 @@ export function registerApifyConnectCommand(program: Command): void {
           outputJson({ success: true, ...result });
         }
       } catch (err) {
-        // handleError() calls process.exit(), which skips the finally block — so
-        // flush queued analytics here before the process dies.
+        // handleError() calls process.exit(), which skips the finally block, so
+        // this catch must flush analytics before handing off. The finally below
+        // covers the normal (success / json) return path. Both run at most once:
+        // on error the finally is skipped (process exits in handleError); on
+        // success the catch is skipped. Not a double flush.
         await shutdownAnalytics();
         handleError(err, json);
       } finally {
@@ -159,6 +162,9 @@ async function ensureConnection(
     const fetchResult = await fetchApifyConnection(projectId, token, opts.apiUrl);
     if (fetchResult.kind === 'forbidden') {
       throw new CLIError(`Forbidden: ${fetchResult.message}`, 5);
+    }
+    if (fetchResult.kind === 'unauthorized') {
+      throw new AuthError(`Not authenticated: ${fetchResult.message}. Re-run \`insforge login\`.`);
     }
     if (fetchResult.kind === 'error') {
       throw new CLIError(`Could not verify the Apify connection: ${fetchResult.message}`);

--- a/src/commands/datasource/apify/login.ts
+++ b/src/commands/datasource/apify/login.ts
@@ -25,10 +25,17 @@ export function registerApifyLoginCommand(program: Command): void {
       const { json } = getRootOpts(cmd);
       try {
         if (!json) clack.log.info('Setting up Apify for your agent (token login + skills)...');
-        await runApifyAuthBridge(json);
+        const { skillsInstalled } = await runApifyAuthBridge(json);
         if (!json) {
-          clack.log.success('Apify CLI authenticated and agent skills installed.');
-          clack.log.info('Tell your coding agent what to scrape.');
+          if (skillsInstalled) {
+            clack.log.success('Apify CLI authenticated and agent skills installed.');
+            clack.log.info('Tell your coding agent what to scrape.');
+          } else {
+            clack.log.success('Apify CLI authenticated.');
+            clack.log.warn(
+              'Agent skills did not install. Re-run `insforge datasource apify login`, or install manually with `npx skills add apify/agent-skills`.',
+            );
+          }
         }
       } catch (err) {
         handleError(err, json);

--- a/src/commands/datasource/apify/login.ts
+++ b/src/commands/datasource/apify/login.ts
@@ -1,0 +1,37 @@
+import type { Command } from 'commander';
+import * as clack from '@clack/prompts';
+import { handleError, getRootOpts } from '../../../lib/errors.js';
+import { runApifyAuthBridge } from '../../../lib/apify-bridge.js';
+
+/**
+ * `insforge datasource apify login`
+ *
+ * Auth bridge: fetches the InsForge-managed Apify token, ensures the Apify CLI
+ * is installed, runs `apify login --token <token>` (headless, no browser), and
+ * installs apify/agent-skills so the local coding agent is immediately
+ * Apify-ready.
+ *
+ * HARD REQUIREMENT: always `apify login --token`; never `apify login`
+ * (which would open browser OAuth). On Apify 401 the user should re-run this
+ * command — InsForge re-fetches a fresh token automatically.
+ */
+export function registerApifyLoginCommand(program: Command): void {
+  program
+    .command('login')
+    .description(
+      'Authenticate the local Apify CLI/agent using your InsForge-managed token (no browser)',
+    )
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        if (!json) clack.log.info('Setting up Apify for your agent (token login + skills)...');
+        await runApifyAuthBridge(json);
+        if (!json) {
+          clack.log.success('Apify CLI authenticated and agent skills installed.');
+          clack.log.info('Tell your coding agent what to scrape.');
+        }
+      } catch (err) {
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/datasource/index.ts
+++ b/src/commands/datasource/index.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { registerApifyConnectCommand } from './apify/connect.js';
+import { registerApifyLoginCommand } from './apify/login.js';
 
 // Mirrors payments/index.ts: a category group with one subcommand per provider.
 // Apify is the first data source; future providers (e.g. Firecrawl) slot in here.
@@ -8,4 +9,5 @@ export function registerDatasourceCommands(datasourceCmd: Command): void {
 
   const apifyCmd = datasourceCmd.command('apify').description('Manage the Apify data source');
   registerApifyConnectCommand(apifyCmd);
+  registerApifyLoginCommand(apifyCmd);
 }

--- a/src/commands/datasource/index.ts
+++ b/src/commands/datasource/index.ts
@@ -1,0 +1,11 @@
+import type { Command } from 'commander';
+import { registerApifyConnectCommand } from './apify/connect.js';
+
+// Mirrors payments/index.ts: a category group with one subcommand per provider.
+// Apify is the first data source; future providers (e.g. Firecrawl) slot in here.
+export function registerDatasourceCommands(datasourceCmd: Command): void {
+  datasourceCmd.description('Manage data-source integrations');
+
+  const apifyCmd = datasourceCmd.command('apify').description('Manage the Apify data source');
+  registerApifyConnectCommand(apifyCmd);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ import { registerMetadataCommand } from './commands/metadata.js';
 import { registerDiagnoseCommands } from './commands/diagnose/index.js';
 import { registerPaymentsCommands } from './commands/payments/index.js';
 import { registerPosthogSetupCommand } from './commands/posthog/setup.js';
+import { registerDatasourceCommands } from './commands/datasource/index.js';
 import { registerConfigCommand } from './commands/config/index.js';
 import { registerAiCommands } from './commands/ai/index.js';
 import { registerDomainsCommands } from './commands/domains/index.js';
@@ -243,6 +244,10 @@ registerComputeEventsCommand(computeCmd);
 // PostHog commands
 const posthogCmd = program.command('posthog').description('Manage PostHog product analytics integration');
 registerPosthogSetupCommand(posthogCmd);
+
+// Data source commands (Apify first; provider as subcommand, like payments)
+const datasourceCmd = program.command('datasource').description('Manage data-source integrations');
+registerDatasourceCommands(datasourceCmd);
 
 // AI commands
 const aiCmd = program.command('ai').description('Manage AI model gateway setup');

--- a/src/lib/api/apify-token.test.ts
+++ b/src/lib/api/apify-token.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as oss from './oss.js';
+import { CLIError } from '../errors.js';
+
+// We spy on ossFetch to avoid real network calls.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchApifyAccessToken', () => {
+  it('returns accessToken from the token endpoint', async () => {
+    vi.spyOn(oss, 'ossFetch').mockResolvedValue(
+      new Response(JSON.stringify({ accessToken: 'integration_api_token_x' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { fetchApifyAccessToken } = await import('./apify-token.js');
+    await expect(fetchApifyAccessToken()).resolves.toBe('integration_api_token_x');
+  });
+
+  it('throws a clear error when not connected (404)', async () => {
+    const err404 = new CLIError('Not found', 1, 'NOT_FOUND', 404);
+    vi.spyOn(oss, 'ossFetch').mockRejectedValue(err404);
+
+    const { fetchApifyAccessToken } = await import('./apify-token.js');
+    await expect(fetchApifyAccessToken()).rejects.toThrow(/not connected|connect/i);
+  });
+
+  it('propagates other errors unchanged', async () => {
+    const networkErr = new CLIError('Network error', 1, 'NETWORK', 500);
+    vi.spyOn(oss, 'ossFetch').mockRejectedValue(networkErr);
+
+    const { fetchApifyAccessToken } = await import('./apify-token.js');
+    await expect(fetchApifyAccessToken()).rejects.toThrow('Network error');
+  });
+
+  it('throws when accessToken is missing from response', async () => {
+    vi.spyOn(oss, 'ossFetch').mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { fetchApifyAccessToken } = await import('./apify-token.js');
+    await expect(fetchApifyAccessToken()).rejects.toThrow(/no token|reconnect/i);
+  });
+});

--- a/src/lib/api/apify-token.test.ts
+++ b/src/lib/api/apify-token.test.ts
@@ -20,12 +20,27 @@ describe('fetchApifyAccessToken', () => {
     await expect(fetchApifyAccessToken()).resolves.toBe('integration_api_token_x');
   });
 
-  it('throws a clear error when not connected (404)', async () => {
-    const err404 = new CLIError('Not found', 1, 'NOT_FOUND', 404);
-    vi.spyOn(oss, 'ossFetch').mockRejectedValue(err404);
+  it('remaps the resource-level not_connected 404 to a connect remediation', async () => {
+    const notConnected = new CLIError('Not connected', 1, 'not_connected', 404);
+    vi.spyOn(oss, 'ossFetch').mockRejectedValue(notConnected);
 
     const { fetchApifyAccessToken } = await import('./apify-token.js');
-    await expect(fetchApifyAccessToken()).rejects.toThrow(/not connected|connect/i);
+    await expect(fetchApifyAccessToken()).rejects.toThrow(/not connected.*connect/is);
+  });
+
+  it('propagates a route-level 404 unchanged (data source unsupported, not "run connect")', async () => {
+    // ossFetch rewrites a bare route-level 404 to a "not available on this
+    // backend" message; we must not clobber it with "run connect".
+    const routeMiss = new CLIError(
+      'Data source integrations are not available on this backend.',
+      1,
+      'NOT_FOUND',
+      404,
+    );
+    vi.spyOn(oss, 'ossFetch').mockRejectedValue(routeMiss);
+
+    const { fetchApifyAccessToken } = await import('./apify-token.js');
+    await expect(fetchApifyAccessToken()).rejects.toThrow(/not available on this backend/i);
   });
 
   it('propagates other errors unchanged', async () => {

--- a/src/lib/api/apify-token.ts
+++ b/src/lib/api/apify-token.ts
@@ -1,0 +1,40 @@
+import { ossFetch } from './oss.js';
+import { CLIError } from '../errors.js';
+
+/**
+ * Fetch the Apify access token that InsForge holds on behalf of the user.
+ *
+ * Calls GET /api/datasources/apify/token on the project's OSS host using the
+ * admin `ik_` key (via ossFetch). Returns the token string on success.
+ *
+ * Throws a CLIError:
+ * - If the project has no Apify connection (404 → human-readable message).
+ * - If the response contains no token (corrupt state).
+ * - Propagates any other ossFetch error (network, 401, etc.) as-is.
+ */
+export async function fetchApifyAccessToken(): Promise<string> {
+  let res: Response;
+  try {
+    res = await ossFetch('/api/datasources/apify/token');
+  } catch (err) {
+    if (err instanceof CLIError && err.statusCode === 404) {
+      throw new CLIError(
+        'Apify is not connected. Run `insforge datasource apify connect` first.',
+        1,
+        'APIFY_NOT_CONNECTED',
+        404,
+      );
+    }
+    throw err;
+  }
+
+  const data = (await res.json()) as { accessToken?: string };
+  if (!data.accessToken) {
+    throw new CLIError(
+      'Apify token endpoint returned no token; try reconnecting.',
+      1,
+      'APIFY_TOKEN_MISSING',
+    );
+  }
+  return data.accessToken;
+}

--- a/src/lib/api/apify-token.ts
+++ b/src/lib/api/apify-token.ts
@@ -18,8 +18,12 @@ export async function fetchApifyAccessToken(): Promise<string> {
     res = await ossFetch('/api/datasources/apify/token');
   } catch (err) {
     if (err instanceof CLIError && err.statusCode === 404) {
+      // A 404 here means either no Apify connection for this project, or the
+      // backend has no /datasources/apify route at all (older or self-hosted
+      // backends, where the data source is unsupported). Mention both so the
+      // user is not sent to `connect` on a backend that can never connect.
       throw new CLIError(
-        'Apify is not connected. Run `insforge datasource apify connect` first.',
+        'Apify is not connected, or this backend does not have the Apify data source enabled (it is cloud-only). Run `insforge datasource apify connect` to connect.',
         1,
         'APIFY_NOT_CONNECTED',
         404,

--- a/src/lib/api/apify-token.ts
+++ b/src/lib/api/apify-token.ts
@@ -17,13 +17,15 @@ export async function fetchApifyAccessToken(): Promise<string> {
   try {
     res = await ossFetch('/api/datasources/apify/token');
   } catch (err) {
-    if (err instanceof CLIError && err.statusCode === 404) {
-      // A 404 here means either no Apify connection for this project, or the
-      // backend has no /datasources/apify route at all (older or self-hosted
-      // backends, where the data source is unsupported). Mention both so the
-      // user is not sent to `connect` on a backend that can never connect.
+    // Only remap the backend's explicit "no connection" signal (resource-level
+    // 404 with `error: 'not_connected'`) to the connect remediation. A bare
+    // route-level 404 means the backend has no /datasources route at all
+    // (older/self-hosted, data source unsupported) — ossFetch already rewrites
+    // that to a "not available on this backend" message, so let it propagate
+    // rather than wrongly telling the user to run `connect`.
+    if (err instanceof CLIError && err.statusCode === 404 && err.code === 'not_connected') {
       throw new CLIError(
-        'Apify is not connected, or this backend does not have the Apify data source enabled (it is cloud-only). Run `insforge datasource apify connect` to connect.',
+        'Apify is not connected. Run `insforge datasource apify connect` first.',
         1,
         'APIFY_NOT_CONNECTED',
         404,

--- a/src/lib/api/apify.test.ts
+++ b/src/lib/api/apify.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CLIError } from '../errors.js';
+import { fetchApifyConnection, pollApifyConnection } from './apify.js';
+
+const API = 'https://platform.test';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// Queue a sequence of fetch outcomes. Each entry is either a Response or a
+// function that throws (network error). The last entry repeats once exhausted.
+function mockFetchSequence(outcomes: Array<Response | (() => never)>): void {
+  let i = 0;
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (): Promise<Response> => {
+    const outcome = outcomes[Math.min(i, outcomes.length - 1)];
+    i += 1;
+    if (typeof outcome === 'function') return outcome();
+    return outcome;
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchApifyConnection', () => {
+  it('maps 404 to not-connected', async () => {
+    mockFetchSequence([jsonResponse({}, 404)]);
+    await expect(fetchApifyConnection('p1', 'jwt', API)).resolves.toEqual({ kind: 'not-connected' });
+  });
+
+  it('maps 403 to forbidden with the backend message', async () => {
+    mockFetchSequence([jsonResponse({ error: 'no access' }, 403)]);
+    await expect(fetchApifyConnection('p1', 'jwt', API)).resolves.toEqual({
+      kind: 'forbidden',
+      message: 'no access',
+    });
+  });
+
+  it('maps 401 to unauthorized (non-transient)', async () => {
+    mockFetchSequence([jsonResponse({ error: 'token expired' }, 401)]);
+    await expect(fetchApifyConnection('p1', 'jwt', API)).resolves.toEqual({
+      kind: 'unauthorized',
+      message: 'token expired',
+    });
+  });
+
+  it('maps 5xx to error carrying the status', async () => {
+    mockFetchSequence([jsonResponse({ error: 'boom' }, 500)]);
+    await expect(fetchApifyConnection('p1', 'jwt', API)).resolves.toEqual({
+      kind: 'error',
+      message: 'boom',
+      status: 500,
+    });
+  });
+
+  it('returns connected when 200 carries a status', async () => {
+    mockFetchSequence([jsonResponse({ status: 'active', apifyUsername: 'carmen' })]);
+    await expect(fetchApifyConnection('p1', 'jwt', API)).resolves.toEqual({
+      kind: 'connected',
+      connection: { status: 'active', apifyUsername: 'carmen' },
+    });
+  });
+
+  it('remaps a revoked connection to not-connected', async () => {
+    mockFetchSequence([jsonResponse({ status: 'revoked' })]);
+    await expect(fetchApifyConnection('p1', 'jwt', API)).resolves.toEqual({ kind: 'not-connected' });
+  });
+
+  it('treats a 200 with no status as not-connected (keeps polling)', async () => {
+    mockFetchSequence([jsonResponse({})]);
+    await expect(fetchApifyConnection('p1', 'jwt', API)).resolves.toEqual({ kind: 'not-connected' });
+  });
+
+  it('maps a network failure to error', async () => {
+    mockFetchSequence([
+      () => {
+        throw new Error('ECONNREFUSED');
+      },
+    ]);
+    const res = await fetchApifyConnection('p1', 'jwt', API);
+    expect(res.kind).toBe('error');
+  });
+});
+
+describe('pollApifyConnection', () => {
+  const fastOpts = { timeoutMs: 5_000, intervalMs: 2, maxTransientRetries: 3 };
+
+  it('returns the connection once the endpoint reports connected', async () => {
+    mockFetchSequence([
+      jsonResponse({}, 404),
+      jsonResponse({ status: 'active', apifyUsername: 'carmen' }),
+    ]);
+    await expect(pollApifyConnection('p1', 'jwt', fastOpts, API)).resolves.toEqual({
+      status: 'active',
+      apifyUsername: 'carmen',
+    });
+  });
+
+  it('short-circuits on 403 (exit code 5)', async () => {
+    mockFetchSequence([jsonResponse({ error: 'no access' }, 403)]);
+    await expect(pollApifyConnection('p1', 'jwt', fastOpts, API)).rejects.toMatchObject({
+      exitCode: 5,
+    });
+  });
+
+  it('short-circuits on 401 instead of burning retries (exit code 2)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({}, 401));
+    await expect(pollApifyConnection('p1', 'jwt', fastOpts, API)).rejects.toMatchObject({
+      exitCode: 2,
+    });
+    // Exactly one call — not retried against the transient budget.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after maxTransientRetries consecutive errors', async () => {
+    mockFetchSequence([jsonResponse({ error: 'boom' }, 500)]);
+    await expect(
+      pollApifyConnection('p1', 'jwt', { ...fastOpts, maxTransientRetries: 3 }, API),
+    ).rejects.toThrow(/after 3 retries/);
+  });
+
+  it('resets the transient counter when a poll succeeds as not-connected', async () => {
+    // With maxTransientRetries=2 and no reset, two errors would throw. The
+    // not-connected in between resets the counter, so the final connected wins.
+    mockFetchSequence([
+      jsonResponse({ error: 'boom' }, 500),
+      jsonResponse({}, 404),
+      jsonResponse({ error: 'boom' }, 500),
+      jsonResponse({ status: 'active' }),
+    ]);
+    await expect(
+      pollApifyConnection('p1', 'jwt', { ...fastOpts, maxTransientRetries: 2 }, API),
+    ).resolves.toEqual({ status: 'active' });
+  });
+
+  it('throws on deadline', async () => {
+    mockFetchSequence([jsonResponse({}, 404)]);
+    await expect(
+      pollApifyConnection('p1', 'jwt', { timeoutMs: 5, intervalMs: 20, maxTransientRetries: 3 }, API),
+    ).rejects.toThrow(/Timed out/);
+  });
+
+  it('throws when the signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      pollApifyConnection('p1', 'jwt', { ...fastOpts, signal: ac.signal }, API),
+    ).rejects.toThrow(/cancelled/i);
+  });
+});

--- a/src/lib/api/apify.ts
+++ b/src/lib/api/apify.ts
@@ -10,6 +10,9 @@ async function fetchWithTimeout(
   init: RequestInit,
   callerSignal?: AbortSignal,
 ): Promise<Response> {
+  if (callerSignal?.aborted) {
+    throw new CLIError('Connection wait cancelled.');
+  }
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), REQUEST_TIMEOUT_MS);
   const onCallerAbort = (): void => ac.abort();
@@ -160,7 +163,7 @@ export async function pollApifyConnection(
     const elapsed = Date.now() - start;
     if (elapsed >= opts.timeoutMs) {
       throw new CLIError(
-        'Timed out waiting for Apify connection. Re-run `insforge apify connect` after authorizing.',
+        'Timed out waiting for Apify connection. Re-run `insforge datasource apify connect` after authorizing.',
       );
     }
     opts.onTick?.(elapsed);
@@ -174,7 +177,7 @@ export async function pollApifyConnection(
         throw new CLIError(`Forbidden: ${result.message}`, 5);
       case 'error':
         consecutiveErrors += 1;
-        if (consecutiveErrors > opts.maxTransientRetries) {
+        if (consecutiveErrors >= opts.maxTransientRetries) {
           throw new CLIError(
             `Connection check failed after ${opts.maxTransientRetries} retries: ${result.message}`,
           );

--- a/src/lib/api/apify.ts
+++ b/src/lib/api/apify.ts
@@ -1,0 +1,272 @@
+import { getPlatformApiUrl } from '../config.js';
+import { CLIError, formatFetchError } from '../errors.js';
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// Wraps fetch with a per-request 30s timeout. If `callerSignal` aborts, the
+// fetch aborts too. Always clears the timeout on completion.
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  callerSignal?: AbortSignal,
+): Promise<Response> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), REQUEST_TIMEOUT_MS);
+  const onCallerAbort = (): void => ac.abort();
+  callerSignal?.addEventListener('abort', onCallerAbort);
+  try {
+    return await fetch(url, { ...init, signal: ac.signal });
+  } finally {
+    clearTimeout(timer);
+    callerSignal?.removeEventListener('abort', onCallerAbort);
+  }
+}
+
+// Shape of GET /integrations/apify/v1/connection (cloud-backend
+// getConnectionByQuery). Apify has no separate project/api key like PostHog's
+// phc_ — only the OAuth token, held server-side — so this is metadata only.
+export interface ApifyConnectionResponse {
+  apifyUsername?: string | null;
+  plan?: string | null;
+  status?: string;
+  createdAt?: string;
+}
+
+export type ConnectionFetch =
+  | { kind: 'connected'; connection: ApifyConnectionResponse }
+  | { kind: 'not-connected' }
+  | { kind: 'forbidden'; message: string }
+  | { kind: 'error'; message: string; status?: number };
+
+/**
+ * GET /integrations/apify/v1/connection?project_id=<id>
+ *
+ * Endpoint is owned by cloud-backend. Uses user-level Bearer auth from
+ * `insforge login` rather than the project JWT — cloud-backend enforces a
+ * membership check on the project.
+ *
+ * Coded defensively: a 200 with a `status` field means connected.
+ *
+ * Returns a tagged union rather than throwing on the common 404 case so the
+ * caller can decide between "trigger browser flow" and "real error".
+ */
+export async function fetchApifyConnection(
+  projectId: string,
+  jwt: string,
+  apiUrl?: string,
+  signal?: AbortSignal,
+): Promise<ConnectionFetch> {
+  const baseUrl = getPlatformApiUrl(apiUrl);
+  const url = `${baseUrl}/integrations/apify/v1/connection?project_id=${encodeURIComponent(projectId)}`;
+
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(
+      url,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Accept: 'application/json',
+        },
+      },
+      signal,
+    );
+  } catch (err) {
+    return { kind: 'error', message: formatFetchError(err, url) };
+  }
+
+  if (res.status === 404) {
+    return { kind: 'not-connected' };
+  }
+
+  if (res.status === 403) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return {
+      kind: 'forbidden',
+      message: body.error ?? 'Forbidden — you may not have access to this project.',
+    };
+  }
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return {
+      kind: 'error',
+      message: body.error ?? `Request failed: HTTP ${res.status}`,
+      status: res.status,
+    };
+  }
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch (err) {
+    return {
+      kind: 'error',
+      message: `Could not parse connection response: ${(err as Error).message}`,
+    };
+  }
+
+  // 404 (handled above) is the not-connected signal. A 200 means cloud-backend
+  // has a connection row; it always carries `status`. Require that field so a
+  // stray empty body keeps us polling instead of declaring success early.
+  const conn = (data ?? {}) as ApifyConnectionResponse;
+  if (!conn.status) {
+    return { kind: 'not-connected' };
+  }
+
+  // A freshly-authorized connection is 'active'. 'revoked' means the refresh
+  // token died — treat as not-connected so the user re-authorizes.
+  if (conn.status === 'revoked') {
+    return { kind: 'not-connected' };
+  }
+
+  return { kind: 'connected', connection: conn };
+}
+
+export interface PollOptions {
+  /** Total deadline before giving up. */
+  timeoutMs: number;
+  /** Steady-state interval between polls. */
+  intervalMs: number;
+  /** Max retries on transient (network/5xx) errors before giving up early. */
+  maxTransientRetries: number;
+  /** Optional callback invoked once per attempt — used for spinner updates. */
+  onTick?: (elapsedMs: number) => void;
+  /** Optional cancellation signal. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Poll the connection endpoint until it returns a connected response, the
+ * deadline elapses, or the user aborts. 403 short-circuits (it's not going
+ * to flip to allowed by retrying); 4xx and transient 5xx are tolerated up to
+ * `maxTransientRetries` consecutive failures.
+ */
+export async function pollApifyConnection(
+  projectId: string,
+  jwt: string,
+  opts: PollOptions,
+  apiUrl?: string,
+): Promise<ApifyConnectionResponse> {
+  const start = Date.now();
+  let consecutiveErrors = 0;
+
+  for (;;) {
+    if (opts.signal?.aborted) {
+      throw new CLIError('Connection wait cancelled.');
+    }
+
+    const elapsed = Date.now() - start;
+    if (elapsed >= opts.timeoutMs) {
+      throw new CLIError(
+        'Timed out waiting for Apify connection. Re-run `insforge apify connect` after authorizing.',
+      );
+    }
+    opts.onTick?.(elapsed);
+
+    const result = await fetchApifyConnection(projectId, jwt, apiUrl, opts.signal);
+
+    switch (result.kind) {
+      case 'connected':
+        return result.connection;
+      case 'forbidden':
+        throw new CLIError(`Forbidden: ${result.message}`, 5);
+      case 'error':
+        consecutiveErrors += 1;
+        if (consecutiveErrors > opts.maxTransientRetries) {
+          throw new CLIError(
+            `Connection check failed after ${opts.maxTransientRetries} retries: ${result.message}`,
+          );
+        }
+        break;
+      case 'not-connected':
+        consecutiveErrors = 0;
+        break;
+    }
+
+    await sleep(opts.intervalMs, opts.signal);
+  }
+}
+
+export type ApifyCliStartResponse =
+  | { type: 'connected' }
+  | { type: 'authorize'; authorizeUrl: string };
+
+/**
+ * GET /integrations/apify/v1/cli-start?p=<projectId>
+ *
+ * Asks cloud-backend whether this project is already connected (or can be
+ * inline auto-provisioned for new users) — in which case we skip the browser
+ * hop entirely. Otherwise returns a direct Apify `authorizeUrl` that the user
+ * must consent at; the URL points straight at apify.com (no Insforge
+ * dashboard in the path).
+ */
+export async function startApifyCliFlow(
+  projectId: string,
+  jwt: string,
+  apiUrl?: string,
+): Promise<ApifyCliStartResponse> {
+  const baseUrl = getPlatformApiUrl(apiUrl);
+  const url = `${baseUrl}/integrations/apify/v1/cli-start?p=${encodeURIComponent(projectId)}`;
+
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/json',
+      },
+    });
+  } catch (err) {
+    throw new CLIError(`Failed to start Apify connect flow: ${formatFetchError(err, url)}`);
+  }
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    const msg = body.error ?? res.statusText ?? `HTTP ${res.status}`;
+    if (res.status === 401) {
+      throw new CLIError(`Not authenticated (HTTP 401): ${msg}. Re-run \`insforge login\`.`);
+    }
+    if (res.status === 403) {
+      throw new CLIError(`Forbidden (HTTP 403): ${msg}`, 5);
+    }
+    if (res.status === 404) {
+      throw new CLIError(
+        `Apify connect flow unavailable (HTTP 404): ${msg}. Check that the project is linked.`,
+      );
+    }
+    throw new CLIError(`Apify cli-start failed (HTTP ${res.status}): ${msg}`);
+  }
+
+  const data = (await res.json().catch(() => ({}))) as Partial<ApifyCliStartResponse> & {
+    authorizeUrl?: string;
+  };
+
+  if (data.type === 'connected') {
+    return { type: 'connected' };
+  }
+  if (data.type === 'authorize' && typeof data.authorizeUrl === 'string' && data.authorizeUrl) {
+    return { type: 'authorize', authorizeUrl: data.authorizeUrl };
+  }
+  throw new CLIError('Apify cli-start returned an unexpected response shape.');
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new CLIError('Connection wait cancelled.'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new CLIError('Connection wait cancelled.'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/src/lib/api/apify.ts
+++ b/src/lib/api/apify.ts
@@ -39,6 +39,7 @@ export type ConnectionFetch =
   | { kind: 'connected'; connection: ApifyConnectionResponse }
   | { kind: 'not-connected' }
   | { kind: 'forbidden'; message: string }
+  | { kind: 'unauthorized'; message: string }
   | { kind: 'error'; message: string; status?: number };
 
 /**
@@ -88,6 +89,14 @@ export async function fetchApifyConnection(
     return {
       kind: 'forbidden',
       message: body.error ?? 'Forbidden — you may not have access to this project.',
+    };
+  }
+
+  if (res.status === 401) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return {
+      kind: 'unauthorized',
+      message: body.error ?? 'Not authenticated.',
     };
   }
 
@@ -142,9 +151,9 @@ export interface PollOptions {
 
 /**
  * Poll the connection endpoint until it returns a connected response, the
- * deadline elapses, or the user aborts. 403 short-circuits (it's not going
- * to flip to allowed by retrying); 4xx and transient 5xx are tolerated up to
- * `maxTransientRetries` consecutive failures.
+ * deadline elapses, or the user aborts. 401 and 403 short-circuit (retrying
+ * won't flip an auth/permission failure); other transient errors (network,
+ * 5xx) are tolerated up to `maxTransientRetries` consecutive failures.
  */
 export async function pollApifyConnection(
   projectId: string,
@@ -175,6 +184,11 @@ export async function pollApifyConnection(
         return result.connection;
       case 'forbidden':
         throw new CLIError(`Forbidden: ${result.message}`, 5);
+      case 'unauthorized':
+        throw new CLIError(
+          `Not authenticated (HTTP 401): ${result.message}. Re-run \`insforge login\`.`,
+          2,
+        );
       case 'error':
         consecutiveErrors += 1;
         if (consecutiveErrors >= opts.maxTransientRetries) {

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -209,6 +209,10 @@ export async function ossFetch(
       message = 'Agent memory is not available on this backend.\nSelf-hosted: upgrade your InsForge instance to a version with the memory feature. Cloud: contact your InsForge admin to enable agent memory.';
     }
 
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/datasources')) {
+      message = 'Data source integrations are not available on this backend.\nThe Apify data source is cloud-only. Self-hosted: this feature is not supported. Cloud: contact your InsForge admin to enable it.';
+    }
+
     throw new CLIError(message, 1, err.error, res.status);
   }
 

--- a/src/lib/apify-bridge.test.ts
+++ b/src/lib/apify-bridge.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The bridge fetches the token first, then charset-validates it BEFORE any
+// shell exec. Mock the token source so we can drive the validation path without
+// touching the network, the Apify CLI, or the filesystem.
+vi.mock('./api/apify-token.js', () => ({
+  fetchApifyAccessToken: vi.fn(),
+}));
+
+import { fetchApifyAccessToken } from './api/apify-token.js';
+import { runApifyAuthBridge } from './apify-bridge.js';
+
+const mockedFetchToken = vi.mocked(fetchApifyAccessToken);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('runApifyAuthBridge token charset guard', () => {
+  // Each of these contains a shell metacharacter / space that must never reach
+  // `apify login --token <token>` under shell:true on Windows.
+  it.each([
+    'tok; rm -rf /',
+    'tok && calc',
+    'tok | cat',
+    'tok`whoami`',
+    'tok with space',
+    'tok$(id)',
+    '"quoted"',
+  ])('rejects a token containing shell metacharacters: %s', async (badToken) => {
+    mockedFetchToken.mockResolvedValue(badToken);
+    await expect(runApifyAuthBridge(true)).rejects.toThrow(/Unexpected Apify token format/);
+  });
+});

--- a/src/lib/apify-bridge.ts
+++ b/src/lib/apify-bridge.ts
@@ -9,19 +9,40 @@ import { installProviderSkillPack } from './skills.js';
 
 const execAsync = promisify(exec);
 
+/** Hard ceiling for a single bridge step (npm install / apify login). Generous
+ * so a slow global install on a poor connection still finishes, but bounded so
+ * a hung child never blocks forever — important in json/agent mode where stdio
+ * is silenced and there is no way to Ctrl-C. */
+const RUN_TIMEOUT_MS = 5 * 60 * 1000;
+
 /**
  * Run a command with inherited stdio (non-json) so the user sees live progress
  * and there is no output-buffer ceiling — unlike buffered `exec`, which can
  * silently fail a big `npm install` on maxBuffer or look frozen. Resolves on
- * exit code 0, rejects otherwise.
+ * exit code 0, rejects otherwise (including timeout).
+ *
+ * `shell: true` on Windows so `.cmd` shims (`npm`, `apify`) resolve — bare
+ * `spawn('npm', ...)` fails with ENOENT there. Args are alphanumeric tokens, so
+ * shell quoting is not a concern.
  */
 function run(cmd: string, args: string[], json: boolean): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: json ? 'ignore' : 'inherit' });
+    const child = spawn(cmd, args, {
+      stdio: json ? 'ignore' : 'inherit',
+      shell: process.platform === 'win32',
+      timeout: RUN_TIMEOUT_MS,
+      killSignal: 'SIGTERM',
+    });
     child.on('error', reject);
-    child.on('close', (code) =>
-      code === 0 ? resolve() : reject(new Error(`\`${cmd} ${args.join(' ')}\` exited with code ${code}`)),
-    );
+    child.on('close', (code, signal) => {
+      if (code === 0) return resolve();
+      if (signal) {
+        return reject(
+          new Error(`\`${cmd} ${args.join(' ')}\` was killed (${signal}) — likely timed out after ${RUN_TIMEOUT_MS / 1000}s.`),
+        );
+      }
+      reject(new Error(`\`${cmd} ${args.join(' ')}\` exited with code ${code}`));
+    });
   });
 }
 
@@ -60,12 +81,13 @@ async function isApifyLoggedIn(token: string): Promise<boolean> {
  *
  * `apify login --token` can exit non-zero in a non-TTY shell even when the
  * login actually succeeds, so its exit code is not trusted — success is
- * confirmed with `apify info` instead. Also sets APIFY_TOKEN in this process's
- * env so child processes (and apify-client code) can read it. Throws on real
- * failure — callers decide whether that is fatal (connect degrades gracefully;
- * login surfaces the error).
+ * confirmed by reading `~/.apify/auth.json` instead. Also sets APIFY_TOKEN in
+ * this process's env so child processes (and apify-client code) can read it.
+ * Throws if the login itself did not take effect (fatal); a failed skills
+ * install is non-fatal and reported via the returned `skillsInstalled` flag so
+ * the caller can warn instead of falsely claiming skills are ready.
  */
-export async function runApifyAuthBridge(json: boolean): Promise<void> {
+export async function runApifyAuthBridge(json: boolean): Promise<{ skillsInstalled: boolean }> {
   const token = await fetchApifyAccessToken();
 
   if (!(await hasApifyCli())) {
@@ -74,7 +96,7 @@ export async function runApifyAuthBridge(json: boolean): Promise<void> {
   }
 
   // HARD REQ: always --token; never plain `apify login` (browser OAuth).
-  // Do not trust the exit code (see above) — verify with `apify info`.
+  // Do not trust the exit code (see above) — verify via ~/.apify/auth.json.
   try {
     await run('apify', ['login', '--token', token], json);
   } catch {
@@ -86,5 +108,6 @@ export async function runApifyAuthBridge(json: boolean): Promise<void> {
 
   process.env.APIFY_TOKEN = token;
   // Only the Apify skill pack — do not reinstall the main InsForge skills.
-  await installProviderSkillPack(json, 'apify');
+  const skillsInstalled = await installProviderSkillPack(json, 'apify');
+  return { skillsInstalled };
 }

--- a/src/lib/apify-bridge.ts
+++ b/src/lib/apify-bridge.ts
@@ -1,0 +1,90 @@
+import { exec, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import * as clack from '@clack/prompts';
+import { fetchApifyAccessToken } from './api/apify-token.js';
+import { installProviderSkillPack } from './skills.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Run a command with inherited stdio (non-json) so the user sees live progress
+ * and there is no output-buffer ceiling — unlike buffered `exec`, which can
+ * silently fail a big `npm install` on maxBuffer or look frozen. Resolves on
+ * exit code 0, rejects otherwise.
+ */
+function run(cmd: string, args: string[], json: boolean): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: json ? 'ignore' : 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code) =>
+      code === 0 ? resolve() : reject(new Error(`\`${cmd} ${args.join(' ')}\` exited with code ${code}`)),
+    );
+  });
+}
+
+async function hasApifyCli(): Promise<boolean> {
+  try {
+    await execAsync('apify --version', { timeout: 20_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True if `apify login --token` actually persisted the credential. Reads
+ * `~/.apify/auth.json` directly instead of running `apify info`, whose exit
+ * code (like `apify login`'s) is unreliable in a non-TTY shell and produced a
+ * false "login did not take effect" failure.
+ */
+async function isApifyLoggedIn(token: string): Promise<boolean> {
+  try {
+    const raw = await readFile(join(homedir(), '.apify', 'auth.json'), 'utf8');
+    return raw.includes(token);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Auth bridge shared by `datasource apify connect` and `datasource apify
+ * login`:
+ *
+ * 1. fetch the InsForge-managed Apify access token,
+ * 2. ensure the Apify CLI is installed (visible progress; no buffer ceiling),
+ * 3. `apify login --token` (HARD REQ: never the browser OAuth flow),
+ * 4. install Apify's official agent skills.
+ *
+ * `apify login --token` can exit non-zero in a non-TTY shell even when the
+ * login actually succeeds, so its exit code is not trusted — success is
+ * confirmed with `apify info` instead. Also sets APIFY_TOKEN in this process's
+ * env so child processes (and apify-client code) can read it. Throws on real
+ * failure — callers decide whether that is fatal (connect degrades gracefully;
+ * login surfaces the error).
+ */
+export async function runApifyAuthBridge(json: boolean): Promise<void> {
+  const token = await fetchApifyAccessToken();
+
+  if (!(await hasApifyCli())) {
+    if (!json) clack.log.info('Apify CLI not found — installing apify-cli globally...');
+    await run('npm', ['install', '-g', 'apify-cli'], json);
+  }
+
+  // HARD REQ: always --token; never plain `apify login` (browser OAuth).
+  // Do not trust the exit code (see above) — verify with `apify info`.
+  try {
+    await run('apify', ['login', '--token', token], json);
+  } catch {
+    // fall through to verification
+  }
+  if (!(await isApifyLoggedIn(token))) {
+    throw new Error('Apify login did not take effect. Re-run `insforge datasource apify login`.');
+  }
+
+  process.env.APIFY_TOKEN = token;
+  // Only the Apify skill pack — do not reinstall the main InsForge skills.
+  await installProviderSkillPack(json, 'apify');
+}

--- a/src/lib/apify-bridge.ts
+++ b/src/lib/apify-bridge.ts
@@ -66,6 +66,18 @@ async function hasApifyCli(): Promise<boolean> {
 async function isApifyLoggedIn(token: string): Promise<boolean> {
   try {
     const raw = await readFile(join(homedir(), '.apify', 'auth.json'), 'utf8');
+    // Apify CLI writes `{ "token": "<token>", ... }`. Prefer an exact field
+    // compare over a substring scan of the raw text (more robust against false
+    // positives and format drift); fall back to substring only if the shape is
+    // unexpected and we cannot parse it.
+    try {
+      const parsed = JSON.parse(raw) as { token?: unknown };
+      if (typeof parsed.token === 'string') {
+        return parsed.token === token;
+      }
+    } catch {
+      // not JSON / unexpected shape — fall through to the substring check
+    }
     return raw.includes(token);
   } catch {
     return false;

--- a/src/lib/apify-bridge.ts
+++ b/src/lib/apify-bridge.ts
@@ -22,8 +22,10 @@ const RUN_TIMEOUT_MS = 5 * 60 * 1000;
  * exit code 0, rejects otherwise (including timeout).
  *
  * `shell: true` on Windows so `.cmd` shims (`npm`, `apify`) resolve — bare
- * `spawn('npm', ...)` fails with ENOENT there. Args are alphanumeric tokens, so
- * shell quoting is not a concern.
+ * `spawn('npm', ...)` fails with ENOENT there (modern Node also refuses to run
+ * `.cmd` without a shell). Callers MUST pass only shell-safe args on this path:
+ * the Apify token is charset-validated in `runApifyAuthBridge` before it reaches
+ * here, so no shell metacharacter can be injected.
  */
 function run(cmd: string, args: string[], json: boolean): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -89,6 +91,17 @@ async function isApifyLoggedIn(token: string): Promise<boolean> {
  */
 export async function runApifyAuthBridge(json: boolean): Promise<{ skillsInstalled: boolean }> {
   const token = await fetchApifyAccessToken();
+
+  // `apify login --token <token>` runs through a shell on Windows (required for
+  // the `.cmd` shims). Apify API tokens are `apify_api_<alphanumeric>`, so any
+  // character outside this safe set means a corrupt/unexpected token — reject it
+  // rather than let a shell metacharacter reach the command line (injection /
+  // broken arg parsing). The trusted source (InsForge) should never emit one.
+  if (!/^[A-Za-z0-9_-]+$/.test(token)) {
+    throw new Error(
+      'Unexpected Apify token format; refusing to pass it to the shell. Re-run `insforge datasource apify connect`.',
+    );
+  }
 
   if (!(await hasApifyCli())) {
     if (!json) clack.log.info('Apify CLI not found — installing apify-cli globally...');

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { describeExecError, reportCliUsage } from './skills.js';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { describeExecError, reportCliUsage, PROVIDER_SKILLS } from './skills.js';
+
+test('apify provider installs apify/agent-skills', () => {
+  expect(PROVIDER_SKILLS.apify).toEqual({ repo: 'apify/agent-skills', label: 'Apify skills' });
+});
 
 function execError(opts: {
   killed?: boolean;

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -120,21 +120,8 @@ export async function installSkills(json: boolean, authProvider?: string): Promi
   // Complements `insforge-integrations` rather than replacing it — that one
   // covers the InsForge bridge side; this one covers the provider's own
   // patterns (BA scaffolding, email/password, 2FA, organizations, etc.).
-  const providerEntry = authProvider ? PROVIDER_SKILLS[authProvider] : undefined;
-  if (providerEntry) {
-    try {
-      if (!json) clack.log.info(`Installing ${providerEntry.label} (global)...`);
-      await execAsync(`npx skills add ${providerEntry.repo} -g -y ${AGENT_FLAGS}`, {
-        cwd: process.cwd(),
-        timeout: SKILL_INSTALL_TIMEOUT_MS,
-      });
-      if (!json) clack.log.success(`${providerEntry.label} installed.`);
-    } catch (err) {
-      if (!json) {
-        clack.log.warn(`Could not install ${providerEntry.label}: ${describeExecError(err)}`);
-        clack.log.info(`Run \`npx skills add ${providerEntry.repo}\` once resolved to see the full output.`);
-      }
-    }
+  if (authProvider) {
+    await installProviderSkillPack(json, authProvider);
   }
 
   try {
@@ -158,11 +145,16 @@ export async function installSkills(json: boolean, authProvider?: string): Promi
  * Install ONLY a single provider's upstream skill pack (e.g. `apify`), without
  * reinstalling the main InsForge skills or find-skills. Use when wiring a
  * connector after the project already has the InsForge skills — avoids
- * clobbering them and is much faster.
+ * clobbering them and is much faster. Also the single source of truth for the
+ * provider-pack install used by `installSkills`.
+ *
+ * Returns `true` if the pack installed, `false` if the install failed (logged
+ * as a warning in non-json mode) or the provider key is unknown — so callers
+ * can adjust their success messaging instead of claiming skills are ready.
  */
-export async function installProviderSkillPack(json: boolean, providerKey: string): Promise<void> {
+export async function installProviderSkillPack(json: boolean, providerKey: string): Promise<boolean> {
   const entry = PROVIDER_SKILLS[providerKey];
-  if (!entry) return;
+  if (!entry) return false;
   try {
     if (!json) clack.log.info(`Installing ${entry.label} (global)...`);
     await execAsync(`npx skills add ${entry.repo} -g -y ${AGENT_FLAGS}`, {
@@ -170,11 +162,13 @@ export async function installProviderSkillPack(json: boolean, providerKey: strin
       timeout: SKILL_INSTALL_TIMEOUT_MS,
     });
     if (!json) clack.log.success(`${entry.label} installed.`);
+    return true;
   } catch (err) {
     if (!json) {
       clack.log.warn(`Could not install ${entry.label}: ${describeExecError(err)}`);
       clack.log.info(`Run \`npx skills add ${entry.repo}\` once resolved to see the full output.`);
     }
+    return false;
   }
 }
 

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -80,8 +80,9 @@ const AGENT_FLAGS =
 // --auth <provider>`. Each is its own marketplace/skill repo — they
 // complement (not duplicate) `insforge-integrations`, which covers the
 // InsForge bridge side of each provider.
-const PROVIDER_SKILLS: Record<string, { repo: string; label: string }> = {
+export const PROVIDER_SKILLS: Record<string, { repo: string; label: string }> = {
   'better-auth': { repo: 'better-auth/skills', label: 'Better Auth skills' },
+  apify: { repo: 'apify/agent-skills', label: 'Apify skills' },
 };
 
 export async function installSkills(json: boolean, authProvider?: string): Promise<void> {
@@ -150,6 +151,30 @@ export async function installSkills(json: boolean, authProvider?: string): Promi
     writeLocalAgentsMd(json);
   } catch {
     // non-critical, silently ignore
+  }
+}
+
+/**
+ * Install ONLY a single provider's upstream skill pack (e.g. `apify`), without
+ * reinstalling the main InsForge skills or find-skills. Use when wiring a
+ * connector after the project already has the InsForge skills — avoids
+ * clobbering them and is much faster.
+ */
+export async function installProviderSkillPack(json: boolean, providerKey: string): Promise<void> {
+  const entry = PROVIDER_SKILLS[providerKey];
+  if (!entry) return;
+  try {
+    if (!json) clack.log.info(`Installing ${entry.label} (global)...`);
+    await execAsync(`npx skills add ${entry.repo} -g -y ${AGENT_FLAGS}`, {
+      cwd: process.cwd(),
+      timeout: SKILL_INSTALL_TIMEOUT_MS,
+    });
+    if (!json) clack.log.success(`${entry.label} installed.`);
+  } catch (err) {
+    if (!json) {
+      clack.log.warn(`Could not install ${entry.label}: ${describeExecError(err)}`);
+      clack.log.info(`Run \`npx skills add ${entry.repo}\` once resolved to see the full output.`);
+    }
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new `datasource` CLI group with Apify integration. Connect your project via OAuth and auto-prepare the local agent with an InsForge‑managed token; warns if skills install fails.

- New Features
  - `insforge datasource apify connect`: guided OAuth with `--json` and `--skip-browser`. Skips if already connected (verifies via `/connection`). Polls every 2s up to 15m with transient retries and 30s per-request timeouts; short-circuits on 401/403. Runs an auth bridge to log in `apify` and install `apify/agent-skills` (non-blocking; suggests `login` on failure).
  - `insforge datasource apify login`: headless setup using the InsForge-managed token. Installs `apify-cli` if missing, runs `apify login --token`, and installs `apify/agent-skills`. Use this to fix Apify 401s.

- Bug Fixes
  - Hardened auth bridge: Windows-safe spawn (`shell: true`), 5m per-step timeout, token charset validation to block shell metacharacters, and login verification via `~/.apify/auth.json`. Sets `APIFY_TOKEN` for child processes.
  - Clear 404 handling for the token endpoint: distinguishes “not connected” (prompts `connect`) from route-level 404s (unsupported backend). Added polling abort guard, cancellation messaging, and avoid retrying 401s; maps forbidden/unauthorized cleanly. Analytics flushes on all error paths.
  - Connect now warns when `apify/agent-skills` fails to install instead of implying success.

<sup>Written for commit 086b7222ab789d3747eb610ef7d72ec8481d2d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `datasource apify connect` CLI command for OAuth-based Apify account linking
> - Adds a new `datasource` top-level CLI group with an `apify` subgroup, exposing `connect` and `login` subcommands in [src/commands/datasource/](https://github.com/InsForge/CLI/pull/179/files#diff-e236574a61d2ce58f2e0051f0bcd0f9606e60f4597463e39c86199e2e32969bc).
> - `datasource apify connect` starts an OAuth flow via Apify's CLI API, optionally opens a browser, and polls up to 15 minutes for connection confirmation; supports `--skip-browser` and `--json` flags.
> - `datasource apify login` performs headless Apify CLI authentication using an InsForge-managed token and installs Apify skills without opening a browser.
> - Adds [`runApifyAuthBridge`](https://github.com/InsForge/CLI/pull/179/files#diff-e4b332bed6e199a59e42fca4d3adad050031580b10f92948243d6635078aa557) which installs `apify-cli` if missing, logs in with the managed token, verifies persistence via `~/.apify/auth.json`, and sets `APIFY_TOKEN` in the process environment.
> - Extends [`ossFetch`](https://github.com/InsForge/CLI/pull/179/files#diff-f58ac4bae1c6cb74276f4a22539113c6ae034fbc1c2d789895c67e2d946725bc) to return a clear error for `/api/datasources` routes on self-hosted backends, where Apify is cloud-only.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #179 opened
>
> - Added HTTP 401 unauthorized response handling to Apify connection workflows [4f04500]
> - Modified token validation in `isApifyLoggedIn` to use exact JSON field matching [4f04500]
> - Added token character set validation to `runApifyAuthBridge` [4f04500]
> - Added test coverage for Apify API connection utilities [4f04500]
> - Added test coverage for Apify bridge token validation [4f04500]
> - Updated comments in `registerApifyConnectCommand` catch block [4f04500]
> - Added skill installation status feedback to `runConnect` command handler in the `datasource apify connect` command [086b722]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ae6dfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `datasource` command group with Apify `connect` and `login`.
  * Introduced an OAuth-based Apify connection flow with status output, optional browser skipping, and backend verification/polling.
  * Automatically attempts to set up the required Apify skills during login/connect.
* **Bug Fixes**
  * Improved error handling for forbidden/not-connected and unexpected response shapes.
  * Ensures clean shutdown of analytics and reliable termination on all outcomes (including aborts).
* **Documentation**
  * Updated README with a Data Sources section and Apify command instructions.
* **Tests**
  * Added coverage for token retrieval and “not connected” error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->