### PR TITLE
docs: add CHANGELOG for the new management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to `@insforge/cli` are documented here. This project
+follows [Keep a Changelog](https://keepachangelog.com/) and
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.94] - 2026-06-24
+
+### Added
+
+- **Billing management** — `billing upgrade <plan>` starts a Stripe checkout
+  (opens the hosted URL in a browser) and `billing manage` opens the Stripe
+  customer portal. Both print a JSON object with `--json` and skip the browser
+  open, for headless/CI use.
+- **Billing inspection** — `billing history` (past payments/invoices) and
+  `billing cycles` (current and previous billing-cycle windows).
+- **`projects transfer <targetOrgId>`** — move a project to another
+  organization. Requires an explicit `--project` and is guarded for human
+  approval, since billing and access move with it.
+
+## [0.1.93] - 2026-06-23
+
+### Added
+
+- **Project lifecycle** — `projects get`, `update`, `restore`,
+  `update-version` (updates to the latest InsForge version; `--wait` to block
+  until done), `upgrade-instance <type>`, and `delete` (requires an explicit
+  `--project`).
+- **Billing & usage (read)** — `billing status`, `billing credits`, and
+  `usage` (organization consumption for the current billing period).
+- **Organizations & members** — `orgs create`/`update` and
+  `orgs members list`/`invite`/`remove`/`role`.
+- **Backups** — `backups list`/`latest`/`create` (`--wait`)/`rename`/
+  `delete`/`restore`.
+- **Secrets** — `secrets rotate <api-key|anon-key>` with an optional grace
+  period.
+- **Storage** — `storage s3-keys list`/`create`/`delete` for S3-compatible
+  access keys.
+
+### Changed
+
+- The `orgs` and `projects` command groups are now shown in `--help`.
+
+[0.1.94]: https://github.com/InsForge/CLI/releases/tag/v0.1.94
+[0.1.93]: https://github.com/InsForge/CLI/releases/tag/v0.1.93


### PR DESCRIPTION
## Summary

Adds a `CHANGELOG.md` (Keep a Changelog format) covering the two feature releases that built out the CLI's management surface:

- **0.1.93** — project lifecycle, billing/usage inspection, orgs & members, backups, secrets rotate, storage S3 keys ([#175](https://github.com/InsForge/CLI/pull/175))
- **0.1.94** — billing checkout/portal management and `projects transfer` ([#176](https://github.com/InsForge/CLI/pull/176))

Documents user-facing features only; internal telemetry coverage (#177) is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `CHANGELOG.md` for `@insforge/cli`, documenting 0.1.93 and 0.1.94 in Keep a Changelog format.
Highlights new management commands: project lifecycle, billing (checkout/portal, status/credits/cycles/history), organizations and members, backups, secrets rotation, storage S3 keys, `projects transfer`, and `--help` updates.

<sup>Written for commit afd8ca0dfa7385c6a4fa1369c82b75d4470c9ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CHANGELOG entries for releases 0.1.93 and 0.1.94
> Adds a [CHANGELOG.md](https://github.com/InsForge/CLI/pull/180/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) documenting the new management commands introduced in releases 0.1.93 and 0.1.94, with links to the corresponding GitHub release tags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afd8ca0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes and changelog guidance.
  * Added entries for recent CLI releases covering billing, project transfers, project lifecycle actions, organization and member management, backups, secret rotation, and storage key operations.
  * Noted that the `orgs` and `projects` command groups now appear in help output.
  * Added release-tag reference links for the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->