### PR TITLE
feat(deployments): register metadata and slug commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,25 @@ npx @insforge/cli deployments env set API_URL https://api.example.com  # create 
 npx @insforge/cli deployments env delete <id>                # delete a variable by ID
 ```
 
+#### `npx @insforge/cli deployments metadata`
+
+Show current deployment metadata and domain URLs.
+
+```bash
+npx @insforge/cli deployments metadata
+npx @insforge/cli deployments metadata --json
+```
+
+#### `npx @insforge/cli deployments slug [slug]`
+
+Show, set, or remove the custom deployment slug.
+
+```bash
+npx @insforge/cli deployments slug
+npx @insforge/cli deployments slug my-app
+npx @insforge/cli deployments slug --remove
+```
+
 ---
 
 ### Domains — `npx @insforge/cli domains`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.92",
+  "version": "0.1.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.92",
+      "version": "0.1.94",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/src/commands/deployments/metadata-slug.test.ts
+++ b/src/commands/deployments/metadata-slug.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+import { registerDeploymentsMetadataCommand } from './metadata.js';
+import { registerDeploymentsSlugCommand } from './slug.js';
+import type * as ErrorsModule from '../../lib/errors.js';
+
+let nextMetadataResponse: unknown = {};
+let nextDeploymentMetadataResponse: unknown = {};
+
+const ossFetchMock = vi.fn(async (path: string, init?: RequestInit) => {
+  if (path === '/api/metadata' && (!init || init.method === undefined || init.method === 'GET')) {
+    return new Response(JSON.stringify(nextMetadataResponse), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  if (
+    path === '/api/deployments/metadata' &&
+    (!init || init.method === undefined || init.method === 'GET')
+  ) {
+    return new Response(JSON.stringify(nextDeploymentMetadataResponse), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  if (path === '/api/deployments/slug' && init?.method === 'PUT') {
+    const body = JSON.parse(String(init.body ?? '{}')) as { slug: string | null };
+    return new Response(
+      JSON.stringify({
+        success: true,
+        slug: body.slug,
+        domain: body.slug ? `${body.slug}.insforge.app` : null,
+      }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+});
+
+vi.mock('../../lib/api/oss.js', () => ({
+  ossFetch: (path: string, init?: RequestInit) => ossFetchMock(path, init),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok', userId: 'u' })),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  getProjectConfig: vi.fn(() => ({
+    project_id: 'p1',
+    project_name: 'project',
+    org_id: 'o1',
+    appkey: 'app',
+    region: 'us-east',
+    api_key: 'key',
+    oss_host: 'https://app.us-east.insforge.app',
+  })),
+}));
+
+vi.mock('./utils.js', () => ({
+  trackDeploymentUsage: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/errors.js', async (orig) => {
+  const actual = await orig<typeof ErrorsModule>();
+  return {
+    ...actual,
+    handleError: vi.fn((err: unknown) => {
+      throw err;
+    }),
+  };
+});
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  program.option('--json');
+  const deployments = program.command('deployments');
+  registerDeploymentsMetadataCommand(deployments);
+  registerDeploymentsSlugCommand(deployments);
+  return program;
+}
+
+async function runWithCapturedLog(program: Command, argv: string[]): Promise<string[]> {
+  const logs: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return logs;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  nextMetadataResponse = {};
+  nextDeploymentMetadataResponse = {};
+});
+
+describe('deployments metadata and slug registration', () => {
+  it('registers both subcommands on a deployments command', () => {
+    const deployments = new Command('deployments');
+    registerDeploymentsMetadataCommand(deployments);
+    registerDeploymentsSlugCommand(deployments);
+
+    expect(deployments.commands.map((cmd) => cmd.name())).toEqual(['metadata', 'slug']);
+  });
+});
+
+describe('deployments metadata', () => {
+  it('json mode calls /api/deployments/metadata and outputs the backend response', async () => {
+    nextDeploymentMetadataResponse = {
+      currentDeploymentId: 'dep_123',
+      defaultDomainUrl: 'https://default.example',
+      customDomainUrl: 'https://custom.example',
+    };
+
+    const logs = await runWithCapturedLog(makeProgram(), [
+      '--json',
+      'deployments',
+      'metadata',
+    ]);
+
+    expect(ossFetchMock.mock.calls.map(([path]) => path)).toEqual([
+      '/api/deployments/metadata',
+    ]);
+    expect(JSON.parse(logs.join('\n'))).toEqual(nextDeploymentMetadataResponse);
+  });
+});
+
+describe('deployments slug', () => {
+  it('json mode with no slug calls /api/metadata and reports current customSlug', async () => {
+    nextMetadataResponse = { deployments: { customSlug: 'my-app' } };
+
+    const logs = await runWithCapturedLog(makeProgram(), ['--json', 'deployments', 'slug']);
+
+    expect(ossFetchMock.mock.calls.map(([path]) => path)).toEqual(['/api/metadata']);
+    expect(JSON.parse(logs.join('\n'))).toEqual({ slug: 'my-app' });
+  });
+
+  it('setting a slug calls /api/metadata, then PUTs slug body', async () => {
+    nextMetadataResponse = { deployments: { customSlug: null } };
+
+    const logs = await runWithCapturedLog(makeProgram(), [
+      '--json',
+      'deployments',
+      'slug',
+      'my-app',
+    ]);
+
+    const putCall = ossFetchMock.mock.calls.find(
+      ([path, init]) => path === '/api/deployments/slug' && init?.method === 'PUT',
+    );
+    expect(ossFetchMock.mock.calls.map(([path]) => path)).toEqual([
+      '/api/metadata',
+      '/api/deployments/slug',
+    ]);
+    expect(JSON.parse(String(putCall?.[1]?.body))).toEqual({ slug: 'my-app' });
+    expect(JSON.parse(logs.join('\n'))).toMatchObject({ success: true, slug: 'my-app' });
+  });
+
+  it('removing a slug calls /api/metadata, then PUTs slug null', async () => {
+    nextMetadataResponse = { deployments: { customSlug: 'my-app' } };
+
+    const logs = await runWithCapturedLog(makeProgram(), [
+      '--json',
+      'deployments',
+      'slug',
+      '--remove',
+    ]);
+
+    const putCall = ossFetchMock.mock.calls.find(
+      ([path, init]) => path === '/api/deployments/slug' && init?.method === 'PUT',
+    );
+    expect(ossFetchMock.mock.calls.map(([path]) => path)).toEqual([
+      '/api/metadata',
+      '/api/deployments/slug',
+    ]);
+    expect(JSON.parse(String(putCall?.[1]?.body))).toEqual({ slug: null });
+    expect(JSON.parse(logs.join('\n'))).toMatchObject({ success: true, slug: null });
+  });
+
+  it('does not call /api/deployments/slug when backend lacks deployments metadata', async () => {
+    nextMetadataResponse = { auth: { allowedRedirectUrls: [] } };
+
+    await expect(
+      runWithCapturedLog(makeProgram(), ['--json', 'deployments', 'slug', 'my-app']),
+    ).rejects.toMatchObject({
+      code: 'DEPLOYMENT_SLUG_UNSUPPORTED',
+    });
+
+    expect(ossFetchMock.mock.calls.map(([path]) => path)).toEqual(['/api/metadata']);
+  });
+
+  it('does not remove a slug when backend lacks deployments metadata', async () => {
+    nextMetadataResponse = { auth: { allowedRedirectUrls: [] } };
+
+    await expect(
+      runWithCapturedLog(makeProgram(), ['--json', 'deployments', 'slug', '--remove']),
+    ).rejects.toMatchObject({
+      code: 'DEPLOYMENT_SLUG_UNSUPPORTED',
+    });
+
+    expect(ossFetchMock.mock.calls.map(([path]) => path)).toEqual(['/api/metadata']);
+  });
+});

--- a/src/commands/deployments/metadata-slug.test.ts
+++ b/src/commands/deployments/metadata-slug.test.ts
@@ -146,6 +146,18 @@ describe('deployments slug', () => {
     expect(JSON.parse(logs.join('\n'))).toEqual({ slug: 'my-app' });
   });
 
+  it('does not report an empty slug when backend lacks deployments metadata', async () => {
+    nextMetadataResponse = { auth: { allowedRedirectUrls: [] } };
+
+    await expect(
+      runWithCapturedLog(makeProgram(), ['--json', 'deployments', 'slug']),
+    ).rejects.toMatchObject({
+      code: 'DEPLOYMENT_SLUG_UNSUPPORTED',
+    });
+
+    expect(ossFetchMock.mock.calls.map(([path]) => path)).toEqual(['/api/metadata']);
+  });
+
   it('setting a slug calls /api/metadata, then PUTs slug body', async () => {
     nextMetadataResponse = { deployments: { customSlug: null } };
 

--- a/src/commands/deployments/metadata.ts
+++ b/src/commands/deployments/metadata.ts
@@ -5,6 +5,7 @@ import { getProjectConfig } from '../../lib/config.js';
 import { handleError, getRootOpts, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import type { DeploymentMetadataResponse } from '../../types.js';
+import { trackDeploymentUsage } from './utils.js';
 
 export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): void {
   deploymentsCmd
@@ -31,7 +32,9 @@ export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): voi
             ],
           );
         }
+        await trackDeploymentUsage('metadata', true);
       } catch (err) {
+        await trackDeploymentUsage('metadata', false);
         handleError(err, json);
       }
     });

--- a/src/commands/deployments/metadata.ts
+++ b/src/commands/deployments/metadata.ts
@@ -14,6 +14,7 @@ export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): voi
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
       let success = false;
+      let commandFailed = false;
       let commandError: unknown;
       try {
         await requireAuth();
@@ -36,6 +37,7 @@ export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): voi
         }
         success = true;
       } catch (err) {
+        commandFailed = true;
         commandError = err;
       } finally {
         try {
@@ -44,6 +46,6 @@ export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): voi
           // Telemetry should never affect command behavior.
         }
       }
-      if (commandError) handleError(commandError, json);
+      if (commandFailed) handleError(commandError, json);
     });
 }

--- a/src/commands/deployments/metadata.ts
+++ b/src/commands/deployments/metadata.ts
@@ -13,6 +13,8 @@ export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): voi
     .description('Get current deployment metadata and domain URLs')
     .action(async (_opts, cmd) => {
       const { json } = getRootOpts(cmd);
+      let success = false;
+      let commandError: unknown;
       try {
         await requireAuth();
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
@@ -32,10 +34,16 @@ export function registerDeploymentsMetadataCommand(deploymentsCmd: Command): voi
             ],
           );
         }
-        await trackDeploymentUsage('metadata', true);
+        success = true;
       } catch (err) {
-        await trackDeploymentUsage('metadata', false);
-        handleError(err, json);
+        commandError = err;
+      } finally {
+        try {
+          await trackDeploymentUsage('metadata', success);
+        } catch {
+          // Telemetry should never affect command behavior.
+        }
       }
+      if (commandError) handleError(commandError, json);
     });
 }

--- a/src/commands/deployments/slug.ts
+++ b/src/commands/deployments/slug.ts
@@ -2,8 +2,29 @@ import type { Command } from 'commander';
 import { ossFetch } from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { getProjectConfig } from '../../lib/config.js';
-import { handleError, getRootOpts, ProjectNotLinkedError } from '../../lib/errors.js';
+import { CLIError, handleError, getRootOpts, ProjectNotLinkedError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackDeploymentUsage } from './utils.js';
+
+interface DeploymentMetadataSlice {
+  customSlug?: string | null;
+}
+
+interface MetadataResponse {
+  deployments?: DeploymentMetadataSlice | null;
+}
+
+function getSupportedDeploymentsSlice(raw: MetadataResponse): DeploymentMetadataSlice {
+  const deployments = raw.deployments;
+  if (!deployments || typeof deployments !== 'object') {
+    throw new CLIError(
+      'Deployment slug management is not supported by this backend. Upgrade the project or use a cloud deployment that exposes /api/metadata.deployments.',
+      1,
+      'DEPLOYMENT_SLUG_UNSUPPORTED',
+    );
+  }
+  return deployments;
+}
 
 export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
   deploymentsCmd
@@ -17,20 +38,21 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
 
         const slugValue = opts.remove ? null : (slug ?? null);
+        const metadataRes = await ossFetch('/api/metadata');
+        const metadata = (await metadataRes.json()) as MetadataResponse;
 
         if (!opts.remove && !slug) {
-          // No slug provided and not removing — show current metadata instead
-          const res = await ossFetch('/api/deployments/metadata');
-          const d = await res.json() as Record<string, unknown>;
+          const currentSlug = metadata.deployments?.customSlug ?? null;
           if (json) {
-            outputJson(d);
+            outputJson({ slug: currentSlug });
           } else {
-            console.log(`Current slug: ${d.slug ?? '(none)'}`);
-            if (d.domain) console.log(`Domain: ${d.domain}`);
+            console.log(`Current slug: ${currentSlug ?? '(none)'}`);
           }
+          await trackDeploymentUsage('slug', true, { action: 'show' });
           return;
         }
 
+        getSupportedDeploymentsSlice(metadata);
         const res = await ossFetch('/api/deployments/slug', {
           method: 'PUT',
           body: JSON.stringify({ slug: slugValue }),
@@ -47,7 +69,11 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
             outputSuccess('Custom slug removed.');
           }
         }
+        await trackDeploymentUsage('slug', true, { action: opts.remove ? 'remove' : 'set' });
       } catch (err) {
+        await trackDeploymentUsage('slug', false, {
+          action: opts.remove ? 'remove' : slug ? 'set' : 'show',
+        });
         handleError(err, json);
       }
     });

--- a/src/commands/deployments/slug.ts
+++ b/src/commands/deployments/slug.ts
@@ -35,6 +35,7 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
       const { json } = getRootOpts(cmd);
       const action = opts.remove ? 'remove' : slug ? 'set' : 'show';
       let success = false;
+      let commandFailed = false;
       let commandError: unknown;
       try {
         await requireAuth();
@@ -74,6 +75,7 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
         }
         success = true;
       } catch (err) {
+        commandFailed = true;
         commandError = err;
       } finally {
         try {
@@ -82,6 +84,6 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
           // Telemetry should never affect command behavior.
         }
       }
-      if (commandError) handleError(commandError, json);
+      if (commandFailed) handleError(commandError, json);
     });
 }

--- a/src/commands/deployments/slug.ts
+++ b/src/commands/deployments/slug.ts
@@ -33,6 +33,9 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
     .option('--remove', 'Remove the custom slug')
     .action(async (slug: string | undefined, opts, cmd) => {
       const { json } = getRootOpts(cmd);
+      const action = opts.remove ? 'remove' : slug ? 'set' : 'show';
+      let success = false;
+      let commandError: unknown;
       try {
         await requireAuth();
         if (!getProjectConfig()) throw new ProjectNotLinkedError();
@@ -40,19 +43,19 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
         const slugValue = opts.remove ? null : (slug ?? null);
         const metadataRes = await ossFetch('/api/metadata');
         const metadata = (await metadataRes.json()) as MetadataResponse;
+        const deployments = getSupportedDeploymentsSlice(metadata);
 
         if (!opts.remove && !slug) {
-          const currentSlug = metadata.deployments?.customSlug ?? null;
+          const currentSlug = deployments.customSlug ?? null;
           if (json) {
             outputJson({ slug: currentSlug });
           } else {
             console.log(`Current slug: ${currentSlug ?? '(none)'}`);
           }
-          await trackDeploymentUsage('slug', true, { action: 'show' });
+          success = true;
           return;
         }
 
-        getSupportedDeploymentsSlice(metadata);
         const res = await ossFetch('/api/deployments/slug', {
           method: 'PUT',
           body: JSON.stringify({ slug: slugValue }),
@@ -69,12 +72,16 @@ export function registerDeploymentsSlugCommand(deploymentsCmd: Command): void {
             outputSuccess('Custom slug removed.');
           }
         }
-        await trackDeploymentUsage('slug', true, { action: opts.remove ? 'remove' : 'set' });
+        success = true;
       } catch (err) {
-        await trackDeploymentUsage('slug', false, {
-          action: opts.remove ? 'remove' : slug ? 'set' : 'show',
-        });
-        handleError(err, json);
+        commandError = err;
+      } finally {
+        try {
+          await trackDeploymentUsage('slug', success, { action });
+        } catch {
+          // Telemetry should never affect command behavior.
+        }
       }
+      if (commandError) handleError(commandError, json);
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ import { registerDeploymentsListCommand } from './commands/deployments/list.js';
 import { registerDeploymentsStatusCommand } from './commands/deployments/status.js';
 import { registerDeploymentsCancelCommand } from './commands/deployments/cancel.js';
 import { registerDeploymentsEnvVarsCommand } from './commands/deployments/env-vars.js';
+import { registerDeploymentsMetadataCommand } from './commands/deployments/metadata.js';
+import { registerDeploymentsSlugCommand } from './commands/deployments/slug.js';
 
 import { registerDocsCommand } from './commands/docs.js';
 import { registerSecretsListCommand } from './commands/secrets/list.js';
@@ -191,9 +193,8 @@ registerDeploymentsListCommand(deploymentsCmd);
 registerDeploymentsStatusCommand(deploymentsCmd);
 registerDeploymentsCancelCommand(deploymentsCmd);
 registerDeploymentsEnvVarsCommand(deploymentsCmd);
-// registerDeploymentsMetadataCommand(deploymentsCmd);
-// slug command doesn't work yet.
-// registerDeploymentsSlugCommand(deploymentsCmd);
+registerDeploymentsMetadataCommand(deploymentsCmd);
+registerDeploymentsSlugCommand(deploymentsCmd);
 
 // Secrets commands
 const secretsCmd = program.command('secrets').description('Manage secrets');


### PR DESCRIPTION
Closes #153 

- Registered deployments metadata and deployments slug.
- Fixed deployments slug to use /api/metadata.deployments.customSlug for reads and capability-gate writes before calling /api/deployments/slug.
- Added README docs and focused Vitest coverage.
- Verification: npm test, npm run lint, and npm run build pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds and registers `deployments metadata` and `deployments slug` in `@insforge/cli`. Slug now reads from `/api/metadata.deployments.customSlug`, gates support for both reads and writes, and “show” outputs only the slug.

- **New Features**
  - Register `deployments metadata` and `deployments slug`.
  - `deployments metadata`: show current deployment metadata and domain URLs; supports `--json`.
  - `deployments slug`: show, set, or remove a custom slug; supports `--json`.

- **Bug Fixes**
  - Read current slug from `/api/metadata.deployments.customSlug`.
  - Gate slug reads and updates via `/api/metadata.deployments`; return `DEPLOYMENT_SLUG_UNSUPPORTED` when missing.
  - Telemetry for both commands is isolated and never affects output or errors.
  - Handle falsy errors in both commands.

<sup>Written for commit 84e92312b2075fd0950fc1af8701009dc2863ea5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register `deployments metadata` and `deployments slug` CLI commands
> - Activates `deployments metadata` and `deployments slug` subcommands in [src/index.ts](https://github.com/InsForge/CLI/pull/181/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) by uncommenting their registration calls.
> - `deployments slug` now validates backend support via `GET /api/metadata` before any operation, throwing `DEPLOYMENT_SLUG_UNSUPPORTED` if the `deployments` slice is absent.
> - The `show` mode for `deployments slug` now returns only `{ slug }` in JSON mode, removing the prior domain and other metadata fields from the output.
> - Both commands emit telemetry via `trackDeploymentUsage` with deferred error handling so telemetry failures do not surface to the user.
> - Behavioral Change: `deployments slug` (show) JSON output shape changes from the previous metadata response to `{ slug: string|null }`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84e9231.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `deployments metadata` and `deployments slug` subcommands.
  * `deployments metadata` outputs deployment metadata in text or `--json`.
  * `deployments slug` supports show, set, and remove, with `--json` support.

* **Bug Fixes**
  * Improved behavior and messaging when custom deployment slugs aren’t supported by the backend.
  * Enhanced reliability of usage reporting and error handling for deployment commands.

* **Documentation**
  * Updated README with new deployment subcommand examples and options.

* **Tests**
  * Added a CLI test suite covering metadata and slug flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->