### PR TITLE
refactor: rename `datasource` command group to `webscraper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,25 +986,25 @@ npx @insforge/cli diagnose metrics --range 6h
 
 ---
 
-### Data Sources — `npx @insforge/cli datasource`
+### Web Scraper — `npx @insforge/cli webscraper`
 
-Connect external data-source integrations to the linked InsForge project. Provider-specific commands live under `datasource <provider>` (Apify is the first provider). These commands are intended for developers and agents who want to scrape or pull external data into a project: connect the account once, then let the local agent run the provider's tools using an InsForge-managed token. Runtime data calls should fetch a fresh token from InsForge rather than embedding a personal key.
+Connect a web scraper provider to the linked InsForge project. Provider-specific commands live under `webscraper <provider>` (Apify is the first provider). These commands are intended for developers and agents who want to scrape or pull external data into a project: connect the account once, then let the local agent run the provider's tools using an InsForge-managed token. Runtime data calls should fetch a fresh token from InsForge rather than embedding a personal key.
 
-#### `npx @insforge/cli datasource apify connect`
+#### `npx @insforge/cli webscraper apify connect`
 
 Connect your Apify account to your InsForge project via OAuth, then automatically run the auth bridge (token login + agent skills) so the local agent is immediately usable.
 
 ```bash
-npx @insforge/cli datasource apify connect
-npx @insforge/cli datasource apify connect --skip-browser   # only print the OAuth URL, do not auto-open the browser
+npx @insforge/cli webscraper apify connect
+npx @insforge/cli webscraper apify connect --skip-browser   # only print the OAuth URL, do not auto-open the browser
 ```
 
-#### `npx @insforge/cli datasource apify login`
+#### `npx @insforge/cli webscraper apify login`
 
 Authenticate the local Apify CLI/agent using your InsForge-managed token (no browser). Re-run this on any Apify `401`/"not logged in" error; InsForge re-fetches a fresh token. Never use the plain `apify login` browser flow.
 
 ```bash
-npx @insforge/cli datasource apify login
+npx @insforge/cli webscraper apify login
 ```
 
 ---

--- a/src/commands/webscraper/apify/connect.ts
+++ b/src/commands/webscraper/apify/connect.ts
@@ -109,13 +109,13 @@ async function runConnect(opts: RunConnectOpts): Promise<ConnectResult> {
     const { skillsInstalled } = await runApifyAuthBridge(opts.json);
     if (!opts.json && !skillsInstalled) {
       clack.log.warn(
-        'Agent skills did not install. Re-run `insforge datasource apify login`, or install manually with `npx skills add apify/agent-skills`.',
+        'Agent skills did not install. Re-run `insforge webscraper apify login`, or install manually with `npx skills add apify/agent-skills`.',
       );
     }
   } catch {
     if (!opts.json) {
       clack.log.warn(
-        'Connected, but auto-login/skills install failed. Run `insforge datasource apify login` to finish.',
+        'Connected, but auto-login/skills install failed. Run `insforge webscraper apify login` to finish.',
       );
     }
   }

--- a/src/commands/webscraper/apify/connect.ts
+++ b/src/commands/webscraper/apify/connect.ts
@@ -112,10 +112,14 @@ async function runConnect(opts: RunConnectOpts): Promise<ConnectResult> {
         'Agent skills did not install. Re-run `insforge webscraper apify login`, or install manually with `npx skills add apify/agent-skills`.',
       );
     }
-  } catch {
+  } catch (err) {
     if (!opts.json) {
+      // The bridge's malformed-token error carries its own remediation
+      // (re-run `connect`); preserve it instead of the generic login hint.
       clack.log.warn(
-        'Connected, but auto-login/skills install failed. Run `insforge webscraper apify login` to finish.',
+        err instanceof Error && err.message.includes('`insforge webscraper apify connect`')
+          ? err.message
+          : 'Connected, but auto-login/skills install failed. Run `insforge webscraper apify login` to finish.',
       );
     }
   }

--- a/src/commands/webscraper/apify/login.ts
+++ b/src/commands/webscraper/apify/login.ts
@@ -4,7 +4,7 @@ import { handleError, getRootOpts } from '../../../lib/errors.js';
 import { runApifyAuthBridge } from '../../../lib/apify-bridge.js';
 
 /**
- * `insforge datasource apify login`
+ * `insforge webscraper apify login`
  *
  * Auth bridge: fetches the InsForge-managed Apify token, ensures the Apify CLI
  * is installed, runs `apify login --token <token>` (headless, no browser), and
@@ -33,7 +33,7 @@ export function registerApifyLoginCommand(program: Command): void {
           } else {
             clack.log.success('Apify CLI authenticated.');
             clack.log.warn(
-              'Agent skills did not install. Re-run `insforge datasource apify login`, or install manually with `npx skills add apify/agent-skills`.',
+              'Agent skills did not install. Re-run `insforge webscraper apify login`, or install manually with `npx skills add apify/agent-skills`.',
             );
           }
         }

--- a/src/commands/webscraper/index.ts
+++ b/src/commands/webscraper/index.ts
@@ -3,11 +3,11 @@ import { registerApifyConnectCommand } from './apify/connect.js';
 import { registerApifyLoginCommand } from './apify/login.js';
 
 // Mirrors payments/index.ts: a category group with one subcommand per provider.
-// Apify is the first data source; future providers (e.g. Firecrawl) slot in here.
-export function registerDatasourceCommands(datasourceCmd: Command): void {
-  datasourceCmd.description('Manage data-source integrations');
+// Apify is the first web scraper provider; future providers (e.g. Firecrawl) slot in here.
+export function registerWebscraperCommands(webscraperCmd: Command): void {
+  webscraperCmd.description('Manage web scraper integrations');
 
-  const apifyCmd = datasourceCmd.command('apify').description('Manage the Apify data source');
+  const apifyCmd = webscraperCmd.command('apify').description('Manage the Apify web scraper');
   registerApifyConnectCommand(apifyCmd);
   registerApifyLoginCommand(apifyCmd);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ import { registerMetadataCommand } from './commands/metadata.js';
 import { registerDiagnoseCommands } from './commands/diagnose/index.js';
 import { registerPaymentsCommands } from './commands/payments/index.js';
 import { registerPosthogSetupCommand } from './commands/posthog/setup.js';
-import { registerDatasourceCommands } from './commands/datasource/index.js';
+import { registerWebscraperCommands } from './commands/webscraper/index.js';
 import { registerConfigCommand } from './commands/config/index.js';
 import { registerAiCommands } from './commands/ai/index.js';
 import { registerDomainsCommands } from './commands/domains/index.js';
@@ -245,9 +245,9 @@ registerComputeEventsCommand(computeCmd);
 const posthogCmd = program.command('posthog').description('Manage PostHog product analytics integration');
 registerPosthogSetupCommand(posthogCmd);
 
-// Data source commands (Apify first; provider as subcommand, like payments)
-const datasourceCmd = program.command('datasource').description('Manage data-source integrations');
-registerDatasourceCommands(datasourceCmd);
+// Web scraper commands (Apify first; provider as subcommand, like payments)
+const webscraperCmd = program.command('webscraper').description('Manage web scraper integrations');
+registerWebscraperCommands(webscraperCmd);
 
 // AI commands
 const aiCmd = program.command('ai').description('Manage AI model gateway setup');

--- a/src/lib/api/apify-token.test.ts
+++ b/src/lib/api/apify-token.test.ts
@@ -32,7 +32,7 @@ describe('fetchApifyAccessToken', () => {
     // ossFetch rewrites a bare route-level 404 to a "not available on this
     // backend" message; we must not clobber it with "run connect".
     const routeMiss = new CLIError(
-      'Data source integrations are not available on this backend.',
+      'The web scraper is not available on this backend.',
       1,
       'NOT_FOUND',
       404,

--- a/src/lib/api/apify-token.ts
+++ b/src/lib/api/apify-token.ts
@@ -4,7 +4,7 @@ import { CLIError } from '../errors.js';
 /**
  * Fetch the Apify access token that InsForge holds on behalf of the user.
  *
- * Calls GET /api/datasources/apify/token on the project's OSS host using the
+ * Calls GET /api/webscraper/apify/token on the project's OSS host using the
  * admin `ik_` key (via ossFetch). Returns the token string on success.
  *
  * Throws a CLIError:
@@ -15,17 +15,17 @@ import { CLIError } from '../errors.js';
 export async function fetchApifyAccessToken(): Promise<string> {
   let res: Response;
   try {
-    res = await ossFetch('/api/datasources/apify/token');
+    res = await ossFetch('/api/webscraper/apify/token');
   } catch (err) {
     // Only remap the backend's explicit "no connection" signal (resource-level
     // 404 with `error: 'not_connected'`) to the connect remediation. A bare
-    // route-level 404 means the backend has no /datasources route at all
+    // route-level 404 means the backend has no /webscraper route at all
     // (older/self-hosted, data source unsupported) — ossFetch already rewrites
     // that to a "not available on this backend" message, so let it propagate
     // rather than wrongly telling the user to run `connect`.
     if (err instanceof CLIError && err.statusCode === 404 && err.code === 'not_connected') {
       throw new CLIError(
-        'Apify is not connected. Run `insforge datasource apify connect` first.',
+        'Apify is not connected. Run `insforge webscraper apify connect` first.',
         1,
         'APIFY_NOT_CONNECTED',
         404,

--- a/src/lib/api/apify-token.ts
+++ b/src/lib/api/apify-token.ts
@@ -20,7 +20,7 @@ export async function fetchApifyAccessToken(): Promise<string> {
     // Only remap the backend's explicit "no connection" signal (resource-level
     // 404 with `error: 'not_connected'`) to the connect remediation. A bare
     // route-level 404 means the backend has no /webscraper route at all
-    // (older/self-hosted, data source unsupported) — ossFetch already rewrites
+    // (older/self-hosted, web scraper unsupported) — ossFetch already rewrites
     // that to a "not available on this backend" message, so let it propagate
     // rather than wrongly telling the user to run `connect`.
     if (err instanceof CLIError && err.statusCode === 404 && err.code === 'not_connected') {

--- a/src/lib/api/apify.ts
+++ b/src/lib/api/apify.ts
@@ -172,7 +172,7 @@ export async function pollApifyConnection(
     const elapsed = Date.now() - start;
     if (elapsed >= opts.timeoutMs) {
       throw new CLIError(
-        'Timed out waiting for Apify connection. Re-run `insforge datasource apify connect` after authorizing.',
+        'Timed out waiting for Apify connection. Re-run `insforge webscraper apify connect` after authorizing.',
       );
     }
     opts.onTick?.(elapsed);

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -209,8 +209,8 @@ export async function ossFetch(
       message = 'Agent memory is not available on this backend.\nSelf-hosted: upgrade your InsForge instance to a version with the memory feature. Cloud: contact your InsForge admin to enable agent memory.';
     }
 
-    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/datasources')) {
-      message = 'Data source integrations are not available on this backend.\nThe Apify data source is cloud-only. Self-hosted: this feature is not supported. Cloud: contact your InsForge admin to enable it.';
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/webscraper')) {
+      message = 'The web scraper is not available on this backend.\nThe Apify web scraper is cloud-only. Self-hosted: this feature is not supported. Cloud: contact your InsForge admin to enable it.';
     }
 
     throw new CLIError(message, 1, err.error, res.status);

--- a/src/lib/apify-bridge.ts
+++ b/src/lib/apify-bridge.ts
@@ -85,7 +85,7 @@ async function isApifyLoggedIn(token: string): Promise<boolean> {
 }
 
 /**
- * Auth bridge shared by `datasource apify connect` and `datasource apify
+ * Auth bridge shared by `webscraper apify connect` and `webscraper apify
  * login`:
  *
  * 1. fetch the InsForge-managed Apify access token,
@@ -111,7 +111,7 @@ export async function runApifyAuthBridge(json: boolean): Promise<{ skillsInstall
   // broken arg parsing). The trusted source (InsForge) should never emit one.
   if (!/^[A-Za-z0-9_-]+$/.test(token)) {
     throw new Error(
-      'Unexpected Apify token format; refusing to pass it to the shell. Re-run `insforge datasource apify connect`.',
+      'Unexpected Apify token format; refusing to pass it to the shell. Re-run `insforge webscraper apify connect`.',
     );
   }
 
@@ -128,7 +128,7 @@ export async function runApifyAuthBridge(json: boolean): Promise<{ skillsInstall
     // fall through to verification
   }
   if (!(await isApifyLoggedIn(token))) {
-    throw new Error('Apify login did not take effect. Re-run `insforge datasource apify login`.');
+    throw new Error('Apify login did not take effect. Re-run `insforge webscraper apify login`.');
   }
 
   process.env.APIFY_TOKEN = token;


### PR DESCRIPTION
Renames the CLI command group `datasource` → `webscraper` (follow-up to the merged #179). The integration is web-scraping-only, so `webscraper` reads truer than the generic `datasource`.

## Changes
- Command: `insforge datasource apify connect/login` → `insforge webscraper apify connect/login` (provider sub-level `apify` kept for future providers e.g. Firecrawl)
- Directory `src/commands/datasource/` → `src/commands/webscraper/`, `registerWebscraperCommands`
- Backend API path consumed by the token fetch + route-level-404 handling: `/api/datasources/apify/*` → `/api/webscraper/apify/*`
- README "Data Sources" section → "Web Scraper"
- All user-facing command strings updated

## Verification
- `npm run build` ✓, `npx tsc --noEmit` clean for changed files
- 46/46 vitest pass (`apify`, `apify-bridge`, `apify-token`, `skills`)
- `insforge webscraper apify --help` works; old `datasource` command removed

## Cross-repo dependency
Depends on the InsForge OSS backend renaming the route mount `/datasources` → `/webscraper` (PR forthcoming) and the insforge-skills web-scraper rename. Merge together — the CLI now calls `/api/webscraper/apify/token`, which the renamed backend serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the CLI `datasource` group to `webscraper` and updated API paths, docs, and messages. The connect flow now preserves detailed remediation from the auth bridge on failure.

- **Refactors**
  - Commands: `insforge webscraper apify connect` and `... login`; removed the `datasource` group.
  - Code: moved `src/commands/datasource/*` to `src/commands/webscraper/*`; `registerWebscraperCommands` replaces `registerDatasourceCommands`.
  - API: switched token fetch and 404 handling to `/api/webscraper/apify/*`.
  - Docs/UX: README retitled to “Web Scraper”; user-facing strings updated. Connect now surfaces the bridge’s specific remediation instead of a generic login hint.

- **Migration**
  - Use `insforge webscraper apify connect` and `insforge webscraper apify login` going forward.
  - Requires backend exposing `/api/webscraper/apify/*`; older/self-hosted backends will show “web scraper not available.”

<sup>Written for commit 2341f8282ed57616ce5cdd0e6c8b28f102430213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `datasource` CLI command group to `webscraper`
> - Renames the top-level CLI group from `datasource` to `webscraper` in [src/index.ts](https://github.com/InsForge/CLI/pull/184/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), so all Apify commands now live under `insforge webscraper apify`.
> - Updates the API endpoint in [src/lib/api/apify-token.ts](https://github.com/InsForge/CLI/pull/184/files#diff-111bb1a3f7d9e7acf42343ea2a93861a2590055cf873e42befe0b4d2a7d3868c) from `/api/datasources/apify/token` to `/api/webscraper/apify/token`.
> - Updates route-level 404 detection in [src/lib/api/oss.ts](https://github.com/InsForge/CLI/pull/184/files#diff-f58ac4bae1c6cb74276f4a22539113c6ae034fbc1c2d789895c67e2d946725bc) to match `/api/webscraper` paths, with a new error message referencing "web scraper".
> - Updates all user-facing remediation messages, docs, and test fixtures to reference `webscraper` instead of `datasource`.
> - Risk: the old `/api/datasources/apify/token` endpoint and `datasource` CLI commands are no longer referenced; clients using the old path or command will not get the updated error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2341f82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed the integration flow from **Data Sources** to **Web Scraper** in the CLI and docs, including the new `webscraper` command namespace (Apify first).
* **Bug Fixes**
  * Updated token, connection, and login guidance so errors direct to the correct `webscraper apify connect/login` commands.
  * Improved backend “not available” messaging for Web Scraper–related 404 responses.
* **Documentation**
  * Refreshed README integration instructions and examples to match the Web Scraper flow.
* **Tests**
  * Adjusted Apify token test expectations for Web Scraper–specific error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->