### PR TITLE
feat(cli): support custom schemas in records commands via --schema

### DIFF
--- a/src/commands/records/create.ts
+++ b/src/commands/records/create.ts
@@ -4,12 +4,14 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import { schemaProfileHeaders } from './profile.js';
 
 export function registerRecordsCreateCommand(recordsCmd: Command): void {
   recordsCmd
     .command('create <table>')
     .description('Create record(s) in a table')
     .option('--data <json>', 'JSON data to insert (object or array of objects)')
+    .option('--schema <name>', 'Schema to target (default: public)')
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
@@ -32,6 +34,7 @@ export function registerRecordsCreateCommand(recordsCmd: Command): void {
           {
             method: 'POST',
             body: JSON.stringify(records),
+            headers: schemaProfileHeaders('write', opts.schema),
           },
         );
 

--- a/src/commands/records/delete.ts
+++ b/src/commands/records/delete.ts
@@ -4,12 +4,14 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import { schemaProfileHeaders } from './profile.js';
 
 export function registerRecordsDeleteCommand(recordsCmd: Command): void {
   recordsCmd
     .command('delete <table>')
     .description('Delete records from a table matching a filter')
     .option('--filter <filter>', 'Filter expression (e.g. "id=eq.123")')
+    .option('--schema <name>', 'Schema to target (default: public)')
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
@@ -25,7 +27,7 @@ export function registerRecordsDeleteCommand(recordsCmd: Command): void {
 
         const res = await ossFetch(
           `/api/database/records/${encodeURIComponent(table)}?${params}`,
-          { method: 'DELETE' },
+          { method: 'DELETE', headers: schemaProfileHeaders('write', opts.schema) },
         );
 
         const data = await res.json() as { data?: unknown[] };

--- a/src/commands/records/list.ts
+++ b/src/commands/records/list.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import { schemaProfileHeaders } from './profile.js';
 
 export function registerRecordsCommands(recordsCmd: Command): void {
   recordsCmd
@@ -14,6 +15,7 @@ export function registerRecordsCommands(recordsCmd: Command): void {
     .option('--order <order>', 'Order by (e.g. "created_at.desc")')
     .option('--limit <n>', 'Limit number of records', parseInt)
     .option('--offset <n>', 'Offset for pagination', parseInt)
+    .option('--schema <name>', 'Schema to target (default: public)')
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
@@ -28,7 +30,7 @@ export function registerRecordsCommands(recordsCmd: Command): void {
 
         const query = params.toString();
         const path = `/api/database/records/${encodeURIComponent(table)}${query ? `?${query}` : ''}`;
-        const res = await ossFetch(path);
+        const res = await ossFetch(path, { headers: schemaProfileHeaders('read', opts.schema) });
         const data = await res.json() as { data?: Record<string, unknown>[] };
         const records = data.data ?? [];
 

--- a/src/commands/records/profile.test.ts
+++ b/src/commands/records/profile.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { schemaProfileHeaders } from './profile.js';
+
+describe('schemaProfileHeaders', () => {
+  it('returns no headers when no schema is given (defaults to public)', () => {
+    expect(schemaProfileHeaders('read')).toEqual({});
+    expect(schemaProfileHeaders('write', undefined)).toEqual({});
+    expect(schemaProfileHeaders('read', '')).toEqual({});
+  });
+
+  it('uses Accept-Profile for reads', () => {
+    expect(schemaProfileHeaders('read', 'analytics')).toEqual({
+      'Accept-Profile': 'analytics',
+    });
+  });
+
+  it('uses Content-Profile for writes', () => {
+    expect(schemaProfileHeaders('write', 'analytics')).toEqual({
+      'Content-Profile': 'analytics',
+    });
+  });
+});

--- a/src/commands/records/profile.ts
+++ b/src/commands/records/profile.ts
@@ -1,0 +1,15 @@
+/**
+ * PostgREST selects the target schema via a profile header: `Accept-Profile`
+ * for reads and `Content-Profile` for writes/RPC. The table path stays bare.
+ *
+ * Returns the header(s) to send for a `--schema` option, or `{}` when it is
+ * unset (the backend then uses its default schema, `public`).
+ */
+export function schemaProfileHeaders(
+  kind: 'read' | 'write',
+  schema?: string,
+): Record<string, string> {
+  if (!schema) return {};
+  const header = kind === 'read' ? 'Accept-Profile' : 'Content-Profile';
+  return { [header]: schema };
+}

--- a/src/commands/records/update.ts
+++ b/src/commands/records/update.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import { schemaProfileHeaders } from './profile.js';
 
 export function registerRecordsUpdateCommand(recordsCmd: Command): void {
   recordsCmd
@@ -11,6 +12,7 @@ export function registerRecordsUpdateCommand(recordsCmd: Command): void {
     .description('Update records in a table matching a filter')
     .option('--filter <filter>', 'Filter expression (e.g. "id=eq.123")')
     .option('--data <json>', 'JSON data to update')
+    .option('--schema <name>', 'Schema to target (default: public)')
     .action(async (table: string, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
@@ -39,6 +41,7 @@ export function registerRecordsUpdateCommand(recordsCmd: Command): void {
           {
             method: 'PATCH',
             body: JSON.stringify(body),
+            headers: schemaProfileHeaders('write', opts.schema),
           },
         );
 


### PR DESCRIPTION
## What

Adds a `--schema <name>` option to `records list/create/update/delete`. It maps to PostgREST's profile header — `Accept-Profile` for reads, `Content-Profile` for writes — with the table path left bare. Omitted → backend default (`public`).

New `src/commands/records/profile.ts` (`schemaProfileHeaders`) centralizes the verb→header mapping; covered by `profile.test.ts` (3 cases, green on Node 20).

## Why

Pairs with v2.2.3 custom-schema exposure (InsForge migration 056) and the SDK `.schema()` support ([InsForge-sdk-js#98](https://github.com/InsForge/InsForge-sdk-js/pull/98)), giving the records commands parity for custom schemas.

## Note

`db query` (raw SQL) and migrations remain the primary, fully schema-aware data path in the CLI — this just brings the `records` data-API commands in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--schema <name>` option to `records list/create/update/delete` to target custom schemas via PostgREST profile headers. Defaults to `public` when omitted.

- **New Features**
  - Sends `Accept-Profile` for reads and `Content-Profile` for writes; table path stays bare.
  - Adds `schemaProfileHeaders` helper with unit tests.
  - Aligns CLI records commands with backend custom-schema support and SDK `.schema()`.

<sup>Written for commit 18be0ee582d04c145dd988a5a483da4c704f22c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--schema` flag to records CLI commands for custom PostgREST schema support
> - Adds a `--schema <name>` option to the `records create`, `update`, `delete`, and `list` commands.
> - Introduces a new [`schemaProfileHeaders`](https://github.com/InsForge/CLI/pull/187/files#diff-3d04c484b298c458398849b3ff88986c820e4df15c5d2ab6b3ec1bd079c4c389) utility that returns `Accept-Profile` for read operations and `Content-Profile` for write operations, or an empty object when no schema is provided.
> - Each command passes the generated headers to its respective HTTP request, following the PostgREST content profile spec.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18be0ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--schema` option to records create, list, update, and delete commands, with `public` as the default.
  * Record operations now honor the selected schema when reading or writing data.
* **Tests**
  * Added coverage for schema-aware request header behavior, including read and write cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->