### PR TITLE
feat: authenticate CLI directly with user API key (no exchange)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -14,12 +14,15 @@ export function registerLoginCommand(program: Command): void {
     .description('Authenticate with InsForge platform')
     .option('--email', 'Login with email and password instead of browser')
     .option('--client-id <id>', 'OAuth client ID (defaults to insforge-cli)')
-    .option('--user-api-key <key>', 'Authenticate with a uak_ personal access token')
+    .option('--api-key <key>', 'Authenticate directly with a uak_ user API key (no exchange)')
+    .option('--user-api-key <key>', 'Authenticate with a uak_ personal access token (exchanged for a session)')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
 
       try {
-        if (opts.userApiKey) {
+        if (opts.apiKey) {
+          await loginWithApiKeyDirect(opts.apiKey, json, apiUrl);
+        } else if (opts.userApiKey) {
           await loginWithUserApiKey(opts.userApiKey, json, apiUrl);
         } else if (opts.email) {
           await loginWithEmail(json, apiUrl);
@@ -153,6 +156,82 @@ async function loginWithUserApiKey(
   } else {
     console.log(JSON.stringify({ success: true, user }));
   }
+}
+
+/**
+ * Direct API-key login: store the uak_ key itself as the credential and use it
+ * as the Bearer token on every request — no exchange, no JWT, no refresh. We
+ * still fetch the profile once (authenticating with the key directly) to
+ * validate it and persist identity.
+ */
+async function loginWithApiKeyDirect(
+  key: string,
+  json: boolean,
+  apiUrl?: string,
+): Promise<void> {
+  if (!json) {
+    clack.intro('InsForge CLI');
+  }
+
+  if (!key.startsWith('uak_')) {
+    throw new CLIError('Invalid API key — must start with "uak_".');
+  }
+
+  const s = !json ? clack.spinner() : null;
+  s?.start('Verifying API key...');
+
+  let user: User;
+  try {
+    user = await fetchProfileWithApiKey(key, apiUrl);
+  } catch (err) {
+    s?.stop('API key verification failed');
+    throw err instanceof CLIError
+      ? err
+      : new CLIError(err instanceof Error ? err.message : String(err));
+  }
+
+  // Store the uak_ as the direct bearer credential. access_token/refresh_token
+  // stay empty so getAccessToken() serves user_api_key and refresh logic treats
+  // this as a non-refreshable direct login.
+  saveCredentials({
+    access_token: '',
+    refresh_token: '',
+    user_api_key: key,
+    user,
+  });
+
+  if (!json) {
+    s?.stop(`Authenticated as ${user.email}`);
+    clack.outro('Done');
+  } else {
+    console.log(JSON.stringify({ success: true, user }));
+  }
+}
+
+/** Fetch the user profile authenticating with a uak_ key directly as Bearer. */
+async function fetchProfileWithApiKey(apiKey: string, apiUrl?: string): Promise<User> {
+  const baseUrl = getPlatformApiUrl(apiUrl);
+  const url = `${baseUrl}/auth/v1/profile`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Authorization: `Bearer ${apiKey}` } });
+  } catch (err) {
+    throw new CLIError(formatFetchError(err, url));
+  }
+  if (!res.ok) {
+    throw new CLIError(`API key is invalid or revoked: HTTP ${res.status}`);
+  }
+
+  const profile = (await res.json().catch(() => null)) as { user?: User } | User | null;
+  const user =
+    profile && typeof profile === 'object' && 'user' in profile
+      ? (profile as { user?: User }).user
+      : ((profile as User | null) ?? undefined);
+  if (!user) {
+    throw new CLIError('Profile response was empty');
+  }
+  return user;
 }
 
 /**

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -171,7 +171,14 @@ async function fetchProfileWithApiKey(apiKey: string, apiUrl?: string): Promise<
     throw new CLIError(formatFetchError(err, url));
   }
   if (!res.ok) {
-    throw new CLIError(`API key is invalid or revoked: HTTP ${res.status}`);
+    const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
+    const detail = body.message ?? body.error;
+    // Only claim the key itself is bad on an actual auth failure. A 5xx/429
+    // (outage, rate limit) must NOT tell the user to rotate a valid key.
+    if (res.status === 401 || res.status === 403) {
+      throw new CLIError(`API key is invalid or revoked${detail ? `: ${detail}` : ''}`);
+    }
+    throw new CLIError(`Could not verify API key (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
   }
 
   const profile = (await res.json().catch(() => null)) as { user?: User } | User | null;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -186,8 +186,11 @@ async function fetchProfileWithApiKey(apiKey: string, apiUrl?: string): Promise<
     profile && typeof profile === 'object' && 'user' in profile
       ? (profile as { user?: User }).user
       : ((profile as User | null) ?? undefined);
-  if (!user) {
-    throw new CLIError('Profile response was empty');
+  // Require a real identity, not just a truthy value: the flat-shape fallback
+  // can yield `{}` from an empty body, which would persist a malformed user
+  // and print "Authenticated as undefined".
+  if (!user?.id) {
+    throw new CLIError('Profile response was empty or malformed');
   }
   return user;
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -14,15 +14,12 @@ export function registerLoginCommand(program: Command): void {
     .description('Authenticate with InsForge platform')
     .option('--email', 'Login with email and password instead of browser')
     .option('--client-id <id>', 'OAuth client ID (defaults to insforge-cli)')
-    .option('--api-key <key>', 'Authenticate directly with a uak_ user API key (no exchange)')
-    .option('--user-api-key <key>', 'Authenticate with a uak_ personal access token (exchanged for a session)')
+    .option('--user-api-key <key>', 'Authenticate with a uak_ user API key')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
 
       try {
-        if (opts.apiKey) {
-          await loginWithApiKeyDirect(opts.apiKey, json, apiUrl);
-        } else if (opts.userApiKey) {
+        if (opts.userApiKey) {
           await loginWithUserApiKey(opts.userApiKey, json, apiUrl);
         } else if (opts.email) {
           await loginWithEmail(json, apiUrl);
@@ -113,58 +110,12 @@ async function loginWithOAuth(json: boolean, apiUrl?: string): Promise<void> {
   }
 }
 
-async function loginWithUserApiKey(
-  key: string,
-  json: boolean,
-  apiUrl?: string,
-): Promise<void> {
-  if (!json) {
-    clack.intro('InsForge CLI');
-  }
-
-  if (!key.startsWith('uak_')) {
-    throw new CLIError('Invalid API key — must start with "uak_".');
-  }
-
-  const s = !json ? clack.spinner() : null;
-  s?.start('Verifying API key...');
-
-  let jwt: string;
-  let user: User;
-  try {
-    const exchanged = await exchangePatForJwt(key, apiUrl);
-    jwt = exchanged.token;
-    user = exchanged.user;
-  } catch (err) {
-    s?.stop('API key verification failed');
-    throw err instanceof CLIError
-      ? err
-      : new CLIError(err instanceof Error ? err.message : String(err));
-  }
-
-  // Storage: access_token holds the JWT, refresh_token holds the PAT.
-  // Detect PAT login later by checking refresh_token.startsWith('uak_').
-  saveCredentials({
-    access_token: jwt,
-    refresh_token: key,
-    user,
-  });
-
-  if (!json) {
-    s?.stop(`Authenticated as ${user.email}`);
-    clack.outro('Done');
-  } else {
-    console.log(JSON.stringify({ success: true, user }));
-  }
-}
-
 /**
- * Direct API-key login: store the uak_ key itself as the credential and use it
- * as the Bearer token on every request — no exchange, no JWT, no refresh. We
- * still fetch the profile once (authenticating with the key directly) to
- * validate it and persist identity.
+ * Log in with a uak_ user API key used DIRECTLY as the bearer credential — no
+ * exchange endpoint, no JWT, no refresh cycle. We fetch the profile once
+ * (authenticating with the key itself) to validate it and persist identity.
  */
-async function loginWithApiKeyDirect(
+async function loginWithUserApiKey(
   key: string,
   json: boolean,
   apiUrl?: string,
@@ -191,8 +142,8 @@ async function loginWithApiKeyDirect(
   }
 
   // Store the uak_ as the direct bearer credential. access_token/refresh_token
-  // stay empty so getAccessToken() serves user_api_key and refresh logic treats
-  // this as a non-refreshable direct login.
+  // stay empty so getAccessToken() serves user_api_key, and refresh logic
+  // treats this as a non-refreshable direct login (isDirectApiKeyLogin).
   saveCredentials({
     access_token: '',
     refresh_token: '',
@@ -232,70 +183,4 @@ async function fetchProfileWithApiKey(apiKey: string, apiUrl?: string): Promise<
     throw new CLIError('Profile response was empty');
   }
   return user;
-}
-
-/**
- * Exchange a uak_ PAT for a short-lived JWT via the backend exchange endpoint.
- * The PAT itself is never stored as an access token — we store the JWT and
- * keep the PAT only for silent re-exchange when the JWT expires.
- */
-async function exchangePatForJwt(
-  apiKey: string,
-  apiUrl?: string,
-): Promise<{ token: string; user: User }> {
-  const baseUrl = getPlatformApiUrl(apiUrl);
-  const fullUrl = `${baseUrl}/auth/v1/exchange-api-key`;
-
-  let res: Response;
-  try {
-    res = await fetch(fullUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ apiKey }),
-    });
-  } catch (err) {
-    throw new CLIError(formatFetchError(err, fullUrl));
-  }
-
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as {
-      error?: string;
-      message?: string;
-    };
-    const msg = body.message ?? body.error ?? `HTTP ${res.status}`;
-    throw new CLIError(`API key is invalid or revoked: ${msg}`);
-  }
-
-  const data = (await res.json().catch(() => ({}))) as { token?: unknown };
-  if (typeof data.token !== 'string' || data.token.length === 0) {
-    throw new CLIError('Exchange endpoint returned an invalid response (missing token).');
-  }
-  const jwt = data.token;
-
-  // The exchange endpoint returns only the JWT. Fetch the user via /auth/v1/profile
-  // using the fresh JWT so we can persist identity in credentials.json.
-  let profileRes: Response;
-  try {
-    profileRes = await fetch(`${baseUrl}/auth/v1/profile`, {
-      headers: { Authorization: `Bearer ${jwt}` },
-    });
-  } catch (err) {
-    throw new CLIError(formatFetchError(err, `${baseUrl}/auth/v1/profile`));
-  }
-  if (!profileRes.ok) {
-    throw new CLIError(`Exchange succeeded but could not fetch profile: HTTP ${profileRes.status}`);
-  }
-  const profile = (await profileRes.json().catch(() => null)) as
-    | { user?: User }
-    | User
-    | null;
-  const user =
-    profile && typeof profile === 'object' && 'user' in profile
-      ? (profile as { user?: User }).user
-      : ((profile as User | null) ?? undefined);
-  if (!user) {
-    throw new CLIError('Exchange succeeded but profile response was empty');
-  }
-
-  return { token: jwt, user };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,8 @@ async function showInteractiveMenu(): Promise<void> {
   let isLinked = false;
 
   try {
-    isLoggedIn = !!getCredentials()?.access_token;
+    const creds = getCredentials();
+    isLoggedIn = !!(creds?.user_api_key || creds?.access_token);
   } catch { /* corrupted credentials file */ }
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,10 @@ async function showInteractiveMenu(): Promise<void> {
 
   try {
     const creds = getCredentials();
-    isLoggedIn = !!(creds?.user_api_key || creds?.access_token);
+    // Any credential requireAuth() can act on counts as logged in: a direct
+    // key, a live access token, or a refresh token it can mint/migrate from
+    // (OAuth refresh or a legacy exchange-PAT uak_).
+    isLoggedIn = !!(creds?.user_api_key || creds?.access_token || creds?.refresh_token);
   } catch { /* corrupted credentials file */ }
 
   try {

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -1,4 +1,4 @@
-import { getAccessToken, getPlatformApiUrl } from '../config.js';
+import { getAccessToken, getCredentials, getPlatformApiUrl } from '../config.js';
 import { AuthError, CLIError, formatFetchError } from '../errors.js';
 import { refreshAccessToken } from '../credentials.js';
 import type {
@@ -46,7 +46,15 @@ export async function platformFetch(
 ): Promise<Response> {
   const { passThroughStatuses, ...fetchOptions } = options;
   const baseUrl = getPlatformApiUrl(apiUrl);
-  const token = getAccessToken();
+  let token = getAccessToken();
+  if (!token) {
+    // No usable bearer (e.g. an OAuth/exchange session whose access_token was
+    // cleared) but a refresh token can mint one. Direct-API-key logins never
+    // reach here — getAccessToken returns the uak_ itself.
+    if (getCredentials()?.refresh_token) {
+      token = await refreshAccessToken(apiUrl);
+    }
+  }
   if (!token) {
     throw new AuthError();
   }

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -39,6 +39,18 @@ export interface PlatformFetchOptions extends RequestInit {
   passThroughStatuses?: number[];
 }
 
+/**
+ * Mask a bearer credential for debug output: keep only a short prefix and the
+ * last 4 chars so a leaked debug line can't be used, while staying enough to
+ * eyeball which key is in play.
+ */
+function redactBearer(authHeader: string | undefined): string {
+  if (!authHeader) return '<none>';
+  const token = authHeader.replace(/^Bearer\s+/i, '');
+  if (token.length <= 12) return 'Bearer ***';
+  return `Bearer ${token.slice(0, 8)}…${token.slice(-4)}`;
+}
+
 export async function platformFetch(
   path: string,
   options: PlatformFetchOptions = {},
@@ -67,7 +79,11 @@ export async function platformFetch(
   const fullUrl = `${baseUrl}${path}`;
   if (process.env.INSFORGE_DEBUG) {
     console.error(`[DEBUG] ${fetchOptions.method ?? 'GET'} ${fullUrl}`);
-    console.error(`[DEBUG] Headers: ${JSON.stringify(headers, null, 2)}`);
+    // Redact the bearer credential. For direct-key sessions it is now the
+    // long-lived, non-rotating uak_ (not a short-lived JWT), so never write it
+    // in full — even behind the debug flag.
+    const safeHeaders = { ...headers, Authorization: redactBearer(headers.Authorization) };
+    console.error(`[DEBUG] Headers: ${JSON.stringify(safeHeaders, null, 2)}`);
     if (fetchOptions.body) {
       console.error(`[DEBUG] Body: ${typeof fetchOptions.body === 'string' ? fetchOptions.body : JSON.stringify(fetchOptions.body)}`);
     }

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -81,8 +81,12 @@ export async function platformFetch(
     console.error(`[DEBUG] ${fetchOptions.method ?? 'GET'} ${fullUrl}`);
     // Redact the bearer credential. For direct-key sessions it is now the
     // long-lived, non-rotating uak_ (not a short-lived JWT), so never write it
-    // in full — even behind the debug flag.
-    const safeHeaders = { ...headers, Authorization: redactBearer(headers.Authorization) };
+    // in full — even behind the debug flag. Match the auth header in ANY case,
+    // since a caller-provided lowercase `authorization` survives the spread.
+    const safeHeaders: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) {
+      safeHeaders[k] = /^authorization$/i.test(k) ? redactBearer(v) : v;
+    }
     console.error(`[DEBUG] Headers: ${JSON.stringify(safeHeaders, null, 2)}`);
     if (fetchOptions.body) {
       console.error(`[DEBUG] Body: ${typeof fetchOptions.body === 'string' ? fetchOptions.body : JSON.stringify(fetchOptions.body)}`);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -130,7 +130,13 @@ export function getFrontendUrl(): string {
 }
 
 export function getAccessToken(): string | null {
-  return process.env.INSFORGE_ACCESS_TOKEN ?? getCredentials()?.access_token ?? null;
+  const creds = getCredentials();
+  // Priority: env override > direct user API key (uak_) > OAuth/exchange JWT.
+  // refresh_token is intentionally NOT a fallback here — it is refresh fuel,
+  // not a bearer credential (an OAuth refresh token would just 401).
+  return (
+    process.env.INSFORGE_ACCESS_TOKEN ?? creds?.user_api_key ?? creds?.access_token ?? null
+  );
 }
 
 export function getProjectId(override?: string): string | null {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -130,13 +130,15 @@ export function getFrontendUrl(): string {
 }
 
 export function getAccessToken(): string | null {
+  // Env override wins and must work even if credentials.json is missing or
+  // corrupt — so check it BEFORE reading/parsing the file (getCredentials can
+  // throw on malformed JSON).
+  if (process.env.INSFORGE_ACCESS_TOKEN) return process.env.INSFORGE_ACCESS_TOKEN;
+  // Then: direct user API key (uak_) > OAuth/exchange JWT. refresh_token is
+  // intentionally NOT a fallback here — it is refresh fuel, not a bearer
+  // credential (an OAuth refresh token would just 401).
   const creds = getCredentials();
-  // Priority: env override > direct user API key (uak_) > OAuth/exchange JWT.
-  // refresh_token is intentionally NOT a fallback here — it is refresh fuel,
-  // not a bearer credential (an OAuth refresh token would just 401).
-  return (
-    process.env.INSFORGE_ACCESS_TOKEN ?? creds?.user_api_key ?? creds?.access_token ?? null
-  );
+  return creds?.user_api_key ?? creds?.access_token ?? null;
 }
 
 export function getProjectId(override?: string): string | null {

--- a/src/lib/credentials.migration.test.ts
+++ b/src/lib/credentials.migration.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StoredCredentials } from '../types.js';
+
+// refreshAccessToken reads/writes credentials via ./config.js. Mock it so we
+// can assert the state transition without touching disk or the network.
+const configMock = vi.hoisted(() => ({
+  getCredentials: vi.fn(),
+  saveCredentials: vi.fn(),
+  getPlatformApiUrl: vi.fn(() => 'https://api.test'),
+  getGlobalConfig: vi.fn(() => ({ platform_api_url: 'https://api.test' })),
+  getProjectConfig: vi.fn(() => null),
+  FAKE_PROJECT_ID: 'fa4e0000-1234-5678-90ab-cd1234567890',
+}));
+vi.mock('./config.js', () => configMock);
+
+import { refreshAccessToken } from './credentials.js';
+
+const user = {} as unknown as StoredCredentials['user'];
+
+describe('refreshAccessToken — legacy exchange-PAT → direct migration', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('promotes {access_token: jwt, refresh_token: uak_} to {user_api_key: uak_} with the other fields cleared', async () => {
+    configMock.getCredentials.mockReturnValue({
+      access_token: 'old-jwt',
+      refresh_token: 'uak_legacy123',
+      user,
+    } satisfies StoredCredentials);
+
+    const token = await refreshAccessToken();
+
+    // Returns the key itself (no exchange, no network) and rewrites the file
+    // into the clean direct-auth shape.
+    expect(token).toBe('uak_legacy123');
+    expect(configMock.saveCredentials).toHaveBeenCalledTimes(1);
+    expect(configMock.saveCredentials).toHaveBeenCalledWith({
+      access_token: '',
+      refresh_token: '',
+      user_api_key: 'uak_legacy123',
+      user,
+    });
+  });
+
+  it('throws a re-login error for a direct-key session (a uak_ cannot be refreshed) and does not rewrite creds', async () => {
+    configMock.getCredentials.mockReturnValue({
+      access_token: '',
+      refresh_token: '',
+      user_api_key: 'uak_direct',
+      user,
+    } satisfies StoredCredentials);
+
+    await expect(refreshAccessToken()).rejects.toThrow(/invalid, revoked, or expired/i);
+    expect(configMock.saveCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/credentials.pat.test.ts
+++ b/src/lib/credentials.pat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPatLogin } from './credentials.js';
+import { isPatLogin, isDirectApiKeyLogin } from './credentials.js';
 import type { StoredCredentials } from '../types.js';
 
 describe('isPatLogin', () => {
@@ -24,5 +24,57 @@ describe('isPatLogin', () => {
 
   it('returns false when refresh_token is empty', () => {
     expect(isPatLogin(base(''))).toBe(false);
+  });
+
+  // A direct-API-key login stores the uak_ in user_api_key, NOT refresh_token,
+  // so it must not be mistaken for an exchange-based PAT login (which would try
+  // to re-exchange it against the deprecated endpoint).
+  it('returns false for a direct-API-key login (uak_ in user_api_key, empty refresh_token)', () => {
+    const creds: StoredCredentials = {
+      access_token: '',
+      refresh_token: '',
+      user_api_key: 'uak_abc',
+      user: {} as unknown as StoredCredentials['user'],
+    };
+    expect(isPatLogin(creds)).toBe(false);
+  });
+});
+
+describe('isDirectApiKeyLogin', () => {
+  const withApiKey = (user_api_key?: string): StoredCredentials => ({
+    access_token: '',
+    refresh_token: '',
+    user_api_key,
+    user: {} as unknown as StoredCredentials['user'],
+  });
+
+  it('returns true when user_api_key is set', () => {
+    expect(isDirectApiKeyLogin(withApiKey('uak_abc'))).toBe(true);
+  });
+
+  it('returns false when user_api_key is absent', () => {
+    expect(isDirectApiKeyLogin(withApiKey(undefined))).toBe(false);
+  });
+
+  it('returns false for exchange-PAT and OAuth logins', () => {
+    expect(
+      isDirectApiKeyLogin({
+        access_token: 'jwt',
+        refresh_token: 'uak_abc',
+        user: {} as unknown as StoredCredentials['user'],
+      })
+    ).toBe(false);
+    expect(
+      isDirectApiKeyLogin({
+        access_token: 'jwt',
+        refresh_token: 'oauth-refresh',
+        user: {} as unknown as StoredCredentials['user'],
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for null / undefined', () => {
+    expect(isDirectApiKeyLogin(null)).toBe(false);
+    expect(isDirectApiKeyLogin(undefined)).toBe(false);
   });
 });

--- a/src/lib/credentials.pat.test.ts
+++ b/src/lib/credentials.pat.test.ts
@@ -27,8 +27,8 @@ describe('isPatLogin', () => {
   });
 
   // A direct-API-key login stores the uak_ in user_api_key, NOT refresh_token,
-  // so it must not be mistaken for an exchange-based PAT login (which would try
-  // to re-exchange it against the deprecated endpoint).
+  // so it must not be mistaken for a legacy exchange-PAT session (which the
+  // refresh path migrates by promoting refresh_token -> user_api_key).
   it('returns false for a direct-API-key login (uak_ in user_api_key, empty refresh_token)', () => {
     const creds: StoredCredentials = {
       access_token: '',

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -5,9 +5,14 @@ import * as clack from '@clack/prompts';
 import * as prompts from './prompts.js';
 import type { StoredCredentials } from '../types.js';
 
-/** True if stored credentials represent a PAT-based login (refresh_token is a uak_ token). */
+/** True if stored credentials represent an exchange-based PAT login (refresh_token is a uak_ token). */
 export function isPatLogin(creds: StoredCredentials | null | undefined): boolean {
   return creds?.refresh_token?.startsWith('uak_') ?? false;
+}
+
+/** True if stored credentials use a direct user API key (uak_) as the bearer token. */
+export function isDirectApiKeyLogin(creds: StoredCredentials | null | undefined): boolean {
+  return !!creds?.user_api_key;
 }
 
 export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promise<StoredCredentials> {
@@ -27,7 +32,8 @@ export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promi
   }
 
   const creds = getCredentials();
-  if (creds && creds.access_token) return creds;
+  // A direct API key or a present access token is enough to proceed.
+  if (creds && (creds.user_api_key || creds.access_token)) return creds;
 
   // PAT session with an expired/empty access_token: silently re-exchange
   // instead of prompting for browser OAuth.
@@ -62,6 +68,15 @@ export async function refreshAccessToken(apiUrl?: string): Promise<string> {
   }
 
   const platformUrl = getPlatformApiUrl(apiUrl);
+
+  // Direct API key branch: the uak_ IS the credential and cannot be refreshed.
+  // Reaching here means a request 401'd with the key attached, i.e. the key was
+  // revoked or expired — surface a clear re-login message rather than looping.
+  if (isDirectApiKeyLogin(creds)) {
+    throw new AuthError(
+      'API key is invalid, revoked, or expired. Run `npx @insforge/cli login --api-key <new-key>` again.'
+    );
+  }
 
   // PAT branch: re-exchange the stored uak_ for a fresh JWT.
   if (isPatLogin(creds)) {

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -69,49 +69,23 @@ export async function refreshAccessToken(apiUrl?: string): Promise<string> {
 
   const platformUrl = getPlatformApiUrl(apiUrl);
 
-  // Direct API key branch: the uak_ IS the credential and cannot be refreshed.
+  // Direct API key: the uak_ IS the credential and cannot be refreshed.
   // Reaching here means a request 401'd with the key attached, i.e. the key was
   // revoked or expired — surface a clear re-login message rather than looping.
   if (isDirectApiKeyLogin(creds)) {
     throw new AuthError(
-      'API key is invalid, revoked, or expired. Run `npx @insforge/cli login --api-key <new-key>` again.'
+      'API key is invalid, revoked, or expired. Run `npx @insforge/cli login --user-api-key <new-key>` again.'
     );
   }
 
-  // PAT branch: re-exchange the stored uak_ for a fresh JWT.
+  // Legacy exchange-PAT session (created by an older CLI: uak_ in refresh_token,
+  // JWT in access_token). The uak_ now authenticates directly, so migrate this
+  // session to direct auth instead of calling the deprecated exchange endpoint.
+  // One-time, no network: promote the key and reuse it going forward.
   if (isPatLogin(creds)) {
-    let res: Response;
-    try {
-      res = await fetch(`${platformUrl}/auth/v1/exchange-api-key`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ apiKey: creds.refresh_token }),
-      });
-    } catch {
-      // Background refresh path — surface a network error clearly.
-      throw new AuthError(
-        `Unable to reach auth server at ${platformUrl}. Check your network connection.`
-      );
-    }
-    if (!res.ok) {
-      // Auth failures (401/403/404) mean the PAT is actually bad — ask the user
-      // to rotate. Everything else (5xx, 429, gateway errors) is transient and
-      // shouldn't instruct the user to rotate a healthy key.
-      if (res.status === 401 || res.status === 403 || res.status === 404) {
-        throw new AuthError(
-          'API key is invalid or revoked. Run `npx @insforge/cli login --user-api-key <new-key>` again.'
-        );
-      }
-      throw new AuthError(
-        `Auth server returned HTTP ${res.status} while refreshing session. Please retry shortly.`
-      );
-    }
-    const data = (await res.json().catch(() => ({}))) as { token?: unknown };
-    if (typeof data.token !== 'string' || data.token.length === 0) {
-      throw new AuthError('Exchange endpoint returned an invalid response (missing token).');
-    }
-    saveCredentials({ ...creds, access_token: data.token });
-    return data.token;
+    const key = creds.refresh_token;
+    saveCredentials({ ...creds, user_api_key: key, access_token: '', refresh_token: '' });
+    return key;
   }
 
   if (!creds.refresh_token) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,10 +77,17 @@ export interface StoredCredentials {
   access_token: string;
   /**
    * Either an OAuth refresh token (opaque string) or a user API key
-   * prefixed `uak_` (for PAT-based CLI logins). The `uak_` prefix is the
+   * prefixed `uak_` (for exchange-based PAT logins). The `uak_` prefix is the
    * discriminator — see `isPatLogin()` in `lib/credentials.ts`.
    */
   refresh_token: string;
+  /**
+   * A user API key (`uak_`) used DIRECTLY as the Bearer token — no exchange,
+   * no refresh (set by `login --api-key`). When present it takes priority over
+   * `access_token`; a 401 means the key was revoked/expired (re-login needed).
+   * Its presence is the discriminator — see `isDirectApiKeyLogin()`.
+   */
+  user_api_key?: string;
   user: User;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export interface StoredCredentials {
   refresh_token: string;
   /**
    * A user API key (`uak_`) used DIRECTLY as the Bearer token — no exchange,
-   * no refresh (set by `login --api-key`). When present it takes priority over
+   * no refresh (set by `login --user-api-key`). When present it takes priority over
    * `access_token`; a 401 means the key was revoked/expired (re-login needed).
    * Its presence is the discriminator — see `isDirectApiKeyLogin()`.
    */


### PR DESCRIPTION
## Summary

`insforge login --user-api-key uak_…` now authenticates **directly** with the key as the bearer token — no `/auth/v1/exchange-api-key` call, no JWT, no refresh cycle. (The backend accepts `Authorization: Bearer uak_…` directly as of the org-scoped-keys work.)

Kept the existing `--user-api-key` flag name — backward-compatible with published docs/scripts; only the internal behavior changes from exchange to direct. This is the prerequisite step before the exchange endpoint can eventually be retired.

## credentials.json

Gains one optional field, `user_api_key`. Its **presence** is the discriminator — no `auth_method` tag:

| Mode | `user_api_key` | `access_token` | `refresh_token` |
|---|---|---|---|
| API-key (direct) | `uak_…` | `""` | `""` |
| OAuth | — | JWT | opaque |
| legacy exchange-PAT (old CLI) | — | JWT | `uak_…` |

Existing files have no `user_api_key`, so they keep working — no forced re-login.

## Changes

- **`getAccessToken()` priority:** `user_api_key ?? access_token`. `refresh_token` is deliberately not a bearer fallback (it's refresh fuel).
- **`login --user-api-key`** validates the key via `/auth/v1/profile` (Bearer `uak_`) and stores it directly. `exchangePatForJwt` removed.
- **`refreshAccessToken()`**:
  - direct login → clear re-login error (a `uak_` can't be refreshed; a 401 means revoked/expired).
  - **legacy exchange-PAT session** (from an older CLI) → migrated to direct on first refresh: promote `refresh_token → user_api_key`, no network call. The new CLI never calls the exchange endpoint.
  - OAuth → unchanged.
- **`platformFetch`** now refreshes when there's no bearer but a `refresh_token` exists (previously it threw outright).
- `isDirectApiKeyLogin()` discriminator; `isLoggedIn` / `requireAuth` count direct-key sessions.

## Backward compatibility

- Upgrade path is clean: OAuth and exchange-PAT sessions created by older CLIs keep working; exchange-PAT ones transparently migrate to direct on next refresh.
- The exchange **endpoint** stays live server-side for already-installed old CLIs (its `Deprecation` header + warn-log track remaining callers); removal is a later, separate backend PR.
- Downgrade (new→old CLI) of a direct-login session isn't supported (old CLI won't recognize `user_api_key`, prompts re-login — no crash).

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` — changed files clean (one pre-existing unrelated warning in `apify.test.ts` on main)
- [x] `npm test` — 567 passed / 13 skipped (incl. `isDirectApiKeyLogin` + the isPatLogin/direct separation)
- [ ] Manual: `login --user-api-key uak_…` → run an authed command → confirm `Bearer uak_` on the wire; revoke → next call surfaces "log in again"; upgrade an old exchange-PAT session → confirm transparent migration; OAuth login still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate CLI directly with user API key without JWT exchange
> - Replaces the PAT-to-JWT exchange flow with direct Bearer authentication using the `uak_` key against `/auth/v1/profile`.
> - Stores the key in `user_api_key` on the `StoredCredentials` interface, leaving `access_token` and `refresh_token` empty for direct API key sessions.
> - Updates `getAccessToken` to return `user_api_key` as the Bearer token when present, and updates `requireAuth` and `showInteractiveMenu` to treat `user_api_key` as a valid logged-in state.
> - Migrates legacy exchange-PAT sessions (where `uak_` was stored in `refresh_token`) to the new `user_api_key` field on first token refresh, without any network calls.
> - Behavioral Change: direct API key sessions no longer attempt token refresh — on auth failure, users are prompted to re-login with a new key.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #190 opened
>
> - Modified `fetchProfileWithApiKey` function to distinguish between authentication failures and verification failures [cd3a2e5]
> - Added test coverage for credential migration and direct-key session handling [cd3a2e5]
> - Added bearer token redaction to debug logging output [cd3a2e5]
> - Updated login state determination to include `refresh_token` in the check [cd3a2e5]
> - Updated documentation comment for `StoredCredentials` interface [cd3a2e5]
> - Bumped package version to 0.1.97 [029bb62]
> - Updated dependency lockfile [029bb62]
> - Modified `lib.config.getAccessToken` to return `INSFORGE_ACCESS_TOKEN` environment variable immediately before attempting to read or parse credentials, then fall back to `user_api_key` and finally `access_token` from the credentials object [1f56467]
> - Updated `lib.api.platform.platformFetch` debug header redaction logic to iterate through all headers and redact any header with a key matching 'authorization' case-insensitively [1f56467]
> - Changed `commands.fetchProfileWithApiKey` validation guard from checking truthiness of `user` to requiring a defined `user.id` property [1f56467]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e1943f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for logging in with a direct user API key, including proper session recognition across the CLI.
  * Updated authentication to verify the key via an authenticated profile check.

* **Bug Fixes**
  * Improved credential storage for API key sessions and streamlined legacy refresh-token migration.
  * Redacted bearer tokens from debug output headers.

* **Tests**
  * Added/expanded tests for direct API key login detection and legacy migration behavior.

* **Chores**
  * Bumped package version to 0.1.97.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->