### PR TITLE
feat(compute): add --always-on flag to opt out of scale-to-zero

### DIFF
--- a/src/commands/compute/deploy.test.ts
+++ b/src/commands/compute/deploy.test.ts
@@ -70,3 +70,68 @@ describe('compute deploy --protocol', () => {
     ).rejects.toThrow(/Invalid --protocol/);
   });
 });
+
+describe('compute deploy --always-on / --scale-to-zero', () => {
+  beforeEach(() => {
+    ossFetchMock.mockReset();
+    ossFetchMock.mockResolvedValueOnce({ json: async () => [] }); // initial list
+    ossFetchMock.mockResolvedValueOnce({
+      json: async () => ({ name: 'api', status: 'running', endpointUrl: 'https://api.fly.dev', port: 8080, scaleToZero: false }),
+    });
+  });
+
+  it('includes scaleToZero=false in request body when --always-on', async () => {
+    const cmd = new Command();
+    cmd.exitOverride();
+    const compute = cmd.command('compute');
+    registerComputeDeployCommand(compute);
+    await cmd.parseAsync([
+      'node', 'lim', 'compute', 'deploy',
+      '--image', 'nginx', '--name', 'api', '--always-on',
+    ]);
+    const createCall = ossFetchMock.mock.calls[1];
+    const body = JSON.parse(createCall[1].body);
+    expect(body.scaleToZero).toBe(false);
+  });
+
+  it('includes scaleToZero=true in request body when --scale-to-zero (explicit revert)', async () => {
+    const cmd = new Command();
+    cmd.exitOverride();
+    const compute = cmd.command('compute');
+    registerComputeDeployCommand(compute);
+    await cmd.parseAsync([
+      'node', 'lim', 'compute', 'deploy',
+      '--image', 'nginx', '--name', 'api', '--scale-to-zero',
+    ]);
+    const createCall = ossFetchMock.mock.calls[1];
+    const body = JSON.parse(createCall[1].body);
+    expect(body.scaleToZero).toBe(true);
+  });
+
+  it('omits scaleToZero from body when neither flag is passed — create defaults server-side, update keeps the existing setting', async () => {
+    const cmd = new Command();
+    cmd.exitOverride();
+    const compute = cmd.command('compute');
+    registerComputeDeployCommand(compute);
+    await cmd.parseAsync([
+      'node', 'lim', 'compute', 'deploy',
+      '--image', 'nginx', '--name', 'api',
+    ]);
+    const createCall = ossFetchMock.mock.calls[1];
+    const body = JSON.parse(createCall[1].body);
+    expect('scaleToZero' in body).toBe(false);
+  });
+
+  it('rejects --always-on combined with --scale-to-zero', async () => {
+    const cmd = new Command();
+    cmd.exitOverride();
+    const compute = cmd.command('compute');
+    registerComputeDeployCommand(compute);
+    await expect(
+      cmd.parseAsync([
+        'node', 'lim', 'compute', 'deploy',
+        '--image', 'nginx', '--name', 'api', '--always-on', '--scale-to-zero',
+      ])
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+});

--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -55,6 +55,14 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
       'Edge protocol: "http" (default) or "tcp" (raw pass-through for Redis, etc.)',
       'http'
     )
+    .option(
+      '--always-on',
+      'Keep the machine running 24/7 instead of scaling to zero when idle (no cold starts; billed for the full uptime)'
+    )
+    .option(
+      '--scale-to-zero',
+      'Explicitly switch an always-on service back to scale-to-zero (the default for new services)'
+    )
     .action(async (dir: string | undefined, opts, cmd) => {
       const { json } = getRootOpts(cmd);
       try {
@@ -86,6 +94,16 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
             '--env and --env-file are mutually exclusive — pick one source for the env vars.'
           );
         }
+        if (opts.alwaysOn && opts.scaleToZero) {
+          throw new CLIError('--always-on and --scale-to-zero are mutually exclusive — pick one.');
+        }
+        // Omitted flags send nothing: create defaults to scale-to-zero
+        // server-side, update keeps the service's existing setting.
+        const scaleToZero: boolean | undefined = opts.alwaysOn
+          ? false
+          : opts.scaleToZero
+            ? true
+            : undefined;
         let envVars: Record<string, string> | undefined;
         if (opts.env) {
           let parsed: unknown;
@@ -118,6 +136,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
         };
         if (envVars) baseBody.envVars = envVars;
         if (opts.protocol === 'tcp') baseBody.protocol = 'tcp';
+        if (scaleToZero !== undefined) baseBody.scaleToZero = scaleToZero;
 
         // ─── Image mode ─────────────────────────────────────────────────
         if (!dir) {
@@ -163,6 +182,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
               console.log(`  Endpoint: ${service.endpointUrl}`);
             }
             if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
+            if (service.scaleToZero === false) console.log(`  Always-on: scale-to-zero disabled (machine runs 24/7; pass --scale-to-zero to revert)`);
           }
           await reportCliUsage('cli.compute.deploy', true);
           return;
@@ -279,6 +299,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
         };
         if (envVars) updateBody.envVars = envVars;
         if (opts.protocol === 'tcp') updateBody.protocol = 'tcp';
+        if (scaleToZero !== undefined) updateBody.scaleToZero = scaleToZero;
 
         const finalRes = await ossFetch(
           `/api/compute/services/${encodeURIComponent(serviceId)}`,
@@ -302,6 +323,7 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
             console.log(`  Endpoint: ${service.endpointUrl}`);
           }
           if (service.port !== undefined) console.log(`  Port: ${service.port} (container must listen on this port)`);
+          if (service.scaleToZero === false) console.log(`  Always-on: scale-to-zero disabled (machine runs 24/7; pass --scale-to-zero to revert)`);
           console.log(`  Image: ${imageRef} (built remotely; no local image to clean up)`);
         }
 


### PR DESCRIPTION
## What

Adds `--always-on` / `--scale-to-zero` flags to `compute deploy`. **Default unchanged** — omitting both flags sends no field: new services scale to zero, existing services keep their current setting.

- `--always-on` → `scaleToZero: false` in the create/update body (machine runs 24/7, no cold starts)
- `--scale-to-zero` → explicit `scaleToZero: true` to revert an always-on service on a later deploy
- Passing both is rejected as mutually exclusive
- Success output shows an `Always-on:` line when the service has scale-to-zero disabled

Wired into both deploy modes (image mode POST/PATCH and source mode prepare + final PATCH), same pattern as `--protocol`.

## Dependencies

- Backend counterpart: InsForge/InsForge#1638 (adds `scaleToZero` to the compute services API + Fly autostop mapping). Against an older backend the flag is silently ignored (zod strips unknown keys), and deploys without the flag are wire-identical to today.
- Cloud-managed mode passthrough: insforge-cloud-backend companion PR.
- `insforge-cli` agent-skill update (compute-deploy.md) ships as a separate insforge-skills PR.

## Validation

- `npm test` — 573 passed (4 new: body contains scaleToZero=false / =true, omitted when no flag, mutual-exclusion error)
- `npm run build` — clean
- `npx eslint` on changed files — clean
- `node dist/index.js compute deploy --help` shows the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtvPScrRiH2k5RT7tNPXah


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--always-on` and `--scale-to-zero` flags to `compute deploy`
> - `--always-on` sets `scaleToZero=false` in the service create/update request; `--scale-to-zero` sets it to `true`; omitting both leaves the field unset
> - Passing both flags together is rejected with a mutually exclusive error
> - Prints a confirmation line when a service is deployed with scale-to-zero disabled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab4ce06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `compute deploy` scaling options to choose between always-on and scale-to-zero behavior.
  * The command now shows an “Always-on” message in non-JSON output when applicable.

* **Bug Fixes**
  * Prevents using `--always-on` and `--scale-to-zero` together by returning a clear validation error.
  * Preserves existing/default scaling behavior when neither flag is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->