### PR TITLE
Guard compute deploy against stale registry.fly.io image references

### DIFF
--- a/src/commands/compute/deploy.test.ts
+++ b/src/commands/compute/deploy.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type * as ErrorsModule from '../../lib/errors.js';
+import type * as ConfigModule from '../../lib/config.js';
+
+const PROJECT_ID = '6cdb996f-c696-429b-b9a9-d5abd114dce5';
 
 const ossFetchMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/api/oss.js', () => ({ ossFetch: ossFetchMock }));
 vi.mock('../../lib/credentials.js', () => ({ requireAuth: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../../lib/skills.js', () => ({ reportCliUsage: vi.fn() }));
+vi.mock('../../lib/config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConfigModule>();
+  return {
+    ...actual,
+    getProjectConfig: () => ({ project_id: '6cdb996f-c696-429b-b9a9-d5abd114dce5' }),
+  };
+});
 vi.mock('../../lib/errors.js', async (importOriginal) => {
   const actual = await importOriginal<typeof ErrorsModule>();
   return {
@@ -133,5 +143,85 @@ describe('compute deploy --always-on / --scale-to-zero', () => {
         '--image', 'nginx', '--name', 'api', '--always-on', '--scale-to-zero',
       ])
     ).rejects.toThrow(/mutually exclusive/);
+  });
+});
+
+describe('compute deploy stale fly-registry image guard', () => {
+  const OWN_IMAGE = `registry.fly.io/hospet-api-${PROJECT_ID}:cli-1783654786759`;
+
+  function makeCmd() {
+    const cmd = new Command();
+    cmd.exitOverride();
+    const compute = cmd.command('compute');
+    registerComputeDeployCommand(compute);
+    return cmd;
+  }
+
+  beforeEach(() => {
+    ossFetchMock.mockReset();
+  });
+
+  it('fails fast (before any create call) when a fresh create references its own service registry', async () => {
+    ossFetchMock.mockResolvedValueOnce({ json: async () => [] }); // list: no existing service
+    await expect(
+      makeCmd().parseAsync([
+        'node', 'lim', 'compute', 'deploy',
+        '--image', OWN_IMAGE, '--name', 'hospet-api',
+      ])
+    ).rejects.toThrow(/deleting a service deletes its registry images/);
+    // Only the list call went out — no POST that would hang for 60s server-side.
+    expect(ossFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not block fresh creates on foreign registry.fly.io images or other registries', async () => {
+    for (const image of [`registry.fly.io/other-svc-${PROJECT_ID}:v1`, 'redis:7-alpine']) {
+      ossFetchMock.mockReset();
+      ossFetchMock.mockResolvedValueOnce({ json: async () => [] });
+      ossFetchMock.mockResolvedValueOnce({
+        json: async () => ({ name: 'hospet-api', status: 'creating' }),
+      });
+      await makeCmd().parseAsync([
+        'node', 'lim', 'compute', 'deploy',
+        '--image', image, '--name', 'hospet-api',
+      ]);
+      expect(ossFetchMock).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  it('appends the stale-image hint when an update of an existing service times out', async () => {
+    const { CLIError } = await vi.importActual<typeof ErrorsModule>('../../lib/errors.js');
+    ossFetchMock.mockResolvedValueOnce({
+      json: async () => [{ id: 'svc-1', name: 'hospet-api' }],
+    });
+    ossFetchMock.mockRejectedValueOnce(
+      new CLIError(
+        'COMPUTE_CLOUD_UNAVAILABLE: The operation was aborted due to timeout',
+        1,
+        'COMPUTE_CLOUD_UNAVAILABLE',
+        503
+      )
+    );
+    await expect(
+      makeCmd().parseAsync([
+        'node', 'lim', 'compute', 'deploy',
+        '--image', OWN_IMAGE, '--name', 'hospet-api',
+      ])
+    ).rejects.toThrow(/Rebuild and push a fresh image by deploying from source/);
+  });
+
+  it('leaves timeout errors on non-fly images untouched', async () => {
+    const { CLIError } = await vi.importActual<typeof ErrorsModule>('../../lib/errors.js');
+    ossFetchMock.mockResolvedValueOnce({ json: async () => [] });
+    ossFetchMock.mockRejectedValueOnce(new CLIError('OSS request failed: 504', 1, undefined, 504));
+    let caught: unknown;
+    try {
+      await makeCmd().parseAsync([
+        'node', 'lim', 'compute', 'deploy',
+        '--image', 'redis:7-alpine', '--name', 'cache',
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(String((caught as Error).message)).not.toContain('Hint:');
   });
 });

--- a/src/commands/compute/deploy.ts
+++ b/src/commands/compute/deploy.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { Command } from 'commander';
 import { ossFetch } from '../../lib/api/oss.js';
+import { getProjectConfig } from '../../lib/config.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess, outputInfo } from '../../lib/output.js';
@@ -12,6 +13,10 @@ import {
   ensureFlyctlAvailable,
   flyctlBuildAndPush,
 } from '../../lib/flyctl.js';
+import {
+  imageBelongsToOwnService,
+  withStaleImageHint,
+} from '../../lib/fly-registry.js';
 
 // `compute deploy` has two modes:
 //
@@ -148,21 +153,49 @@ export function registerComputeDeployCommand(computeCmd: Command): void {
             (s) => s.name === opts.name
           );
 
+          // A registry.fly.io image whose repo is this service's own Fly app
+          // (`<name>-<projectId>`) cannot exist when the service doesn't:
+          // deleting a service destroys the app and its registry images with
+          // it. Fail fast instead of letting the platform spin in
+          // MANIFEST_UNKNOWN retries until a timeout that reads as a cloud
+          // outage.
+          if (!existing) {
+            const config = getProjectConfig();
+            const projectIds = [
+              config?.project_id,
+              config?.branched_from?.project_id,
+            ].filter((id): id is string => Boolean(id));
+            if (imageBelongsToOwnService(String(opts.image), opts.name, projectIds)) {
+              throw new CLIError(
+                `Image ${opts.image} lives in the registry of the Fly app that backs service ` +
+                  `"${opts.name}" — but that service doesn't exist, so the image is gone ` +
+                  `(deleting a service deletes its registry images). Deploying this reference ` +
+                  `will always fail.\n` +
+                  `Rebuild and push a fresh image by deploying from source:\n` +
+                  `  npx @insforge/cli compute deploy <dir> --name ${opts.name}`
+              );
+            }
+          }
+
           let res;
-          if (existing) {
-            if (!json) outputInfo(`Found existing service "${opts.name}", updating...`);
-            const updateBody: Record<string, unknown> = { ...body };
-            delete updateBody.name;
-            if (opts.protocol === 'tcp') updateBody.protocol = 'tcp';
-            res = await ossFetch(`/api/compute/services/${encodeURIComponent(existing.id)}`, {
-              method: 'PATCH',
-              body: JSON.stringify(updateBody),
-            });
-          } else {
-            res = await ossFetch('/api/compute/services', {
-              method: 'POST',
-              body: JSON.stringify(body),
-            });
+          try {
+            if (existing) {
+              if (!json) outputInfo(`Found existing service "${opts.name}", updating...`);
+              const updateBody: Record<string, unknown> = { ...body };
+              delete updateBody.name;
+              if (opts.protocol === 'tcp') updateBody.protocol = 'tcp';
+              res = await ossFetch(`/api/compute/services/${encodeURIComponent(existing.id)}`, {
+                method: 'PATCH',
+                body: JSON.stringify(updateBody),
+              });
+            } else {
+              res = await ossFetch('/api/compute/services', {
+                method: 'POST',
+                body: JSON.stringify(body),
+              });
+            }
+          } catch (deployErr) {
+            throw withStaleImageHint(deployErr, String(opts.image), opts.name);
           }
           const service = (await res.json()) as Record<string, unknown>;
 

--- a/src/commands/compute/update.test.ts
+++ b/src/commands/compute/update.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type * as ErrorsModule from '../../lib/errors.js';
+
+const ossFetchMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/api/oss.js', () => ({ ossFetch: ossFetchMock }));
+vi.mock('../../lib/credentials.js', () => ({ requireAuth: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../lib/skills.js', () => ({ reportCliUsage: vi.fn() }));
+vi.mock('../../lib/errors.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ErrorsModule>();
+  return {
+    ...actual,
+    handleError: (err: unknown) => { throw err; },
+  };
+});
+
+import { Command } from 'commander';
+import { registerComputeUpdateCommand } from './update.js';
+
+describe('compute update stale fly-registry image hint', () => {
+  const FLY_IMAGE = 'registry.fly.io/hospet-api-6cdb996f-c696-429b-b9a9-d5abd114dce5:cli-1783654786759';
+
+  function makeCmd() {
+    const cmd = new Command();
+    cmd.exitOverride();
+    const compute = cmd.command('compute');
+    registerComputeUpdateCommand(compute);
+    return cmd;
+  }
+
+  async function timeoutError() {
+    const { CLIError } = await vi.importActual<typeof ErrorsModule>('../../lib/errors.js');
+    return new CLIError(
+      'COMPUTE_CLOUD_UNAVAILABLE: The operation was aborted due to timeout',
+      1,
+      'COMPUTE_CLOUD_UNAVAILABLE',
+      503
+    );
+  }
+
+  beforeEach(() => {
+    ossFetchMock.mockReset();
+  });
+
+  it('appends the hint when a PATCH with --image on a fly registry ref times out', async () => {
+    ossFetchMock.mockRejectedValueOnce(await timeoutError());
+    await expect(
+      makeCmd().parseAsync([
+        'node', 'lim', 'compute', 'update', 'svc-1', '--image', FLY_IMAGE,
+      ])
+    ).rejects.toThrow(/Rebuild and push a fresh image by deploying from source/);
+  });
+
+  it('leaves timeouts unhinted when no --image was supplied (stored-image gap)', async () => {
+    ossFetchMock.mockRejectedValueOnce(await timeoutError());
+    let caught: unknown;
+    try {
+      await makeCmd().parseAsync([
+        'node', 'lim', 'compute', 'update', 'svc-1', '--memory', '1024',
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(String((caught as Error).message)).not.toContain('Hint:');
+  });
+
+  it('leaves timeouts unhinted for non-fly images', async () => {
+    ossFetchMock.mockRejectedValueOnce(await timeoutError());
+    let caught: unknown;
+    try {
+      await makeCmd().parseAsync([
+        'node', 'lim', 'compute', 'update', 'svc-1', '--image', 'redis:7-alpine',
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(String((caught as Error).message)).not.toContain('Hint:');
+  });
+});

--- a/src/commands/compute/update.ts
+++ b/src/commands/compute/update.ts
@@ -5,6 +5,7 @@ import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
 import { reportCliUsage } from '../../lib/skills.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import { withStaleImageHint } from '../../lib/fly-registry.js';
 
 const ENV_KEY_REGEX = /^[A-Z_][A-Z0-9_]*$/;
 
@@ -122,10 +123,20 @@ export function registerComputeUpdateCommand(computeCmd: Command): void {
           );
         }
 
-        const res = await ossFetch(`/api/compute/services/${encodeURIComponent(id)}`, {
-          method: 'PATCH',
-          body: JSON.stringify(body),
-        });
+        let res;
+        try {
+          res = await ossFetch(`/api/compute/services/${encodeURIComponent(id)}`, {
+            method: 'PATCH',
+            body: JSON.stringify(body),
+          });
+        } catch (updateErr) {
+          // A timeout on a registry.fly.io image usually means the tag was
+          // deleted along with a previous service — say so instead of
+          // "cloud unavailable".
+          throw opts.image
+            ? withStaleImageHint(updateErr, String(opts.image))
+            : updateErr;
+        }
         const service = await res.json() as Record<string, unknown>;
 
         await trackCommandUsage('compute', 'update', true);

--- a/src/commands/compute/update.ts
+++ b/src/commands/compute/update.ts
@@ -132,7 +132,10 @@ export function registerComputeUpdateCommand(computeCmd: Command): void {
         } catch (updateErr) {
           // A timeout on a registry.fly.io image usually means the tag was
           // deleted along with a previous service — say so instead of
-          // "cloud unavailable".
+          // "cloud unavailable". Known gap: an update without --image
+          // relaunches against the service's *stored* image, which can be a
+          // dead registry.fly.io tag too, but the CLI doesn't know that URL
+          // without an extra fetch — those timeouts pass through unhinted.
           throw opts.image
             ? withStaleImageHint(updateErr, String(opts.image))
             : updateErr;

--- a/src/lib/fly-registry.test.ts
+++ b/src/lib/fly-registry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { CLIError } from './errors.js';
+import {
+  flyRegistryRepo,
+  imageBelongsToOwnService,
+  staleFlyImageHint,
+  withStaleImageHint,
+} from './fly-registry.js';
+
+const PROJECT_ID = '6cdb996f-c696-429b-b9a9-d5abd114dce5';
+const OWN_IMAGE = `registry.fly.io/hospet-api-${PROJECT_ID}:cli-1783654786759`;
+
+describe('flyRegistryRepo', () => {
+  it('extracts the repo from a plain registry.fly.io ref', () => {
+    expect(flyRegistryRepo(OWN_IMAGE)).toBe(`hospet-api-${PROJECT_ID}`);
+  });
+
+  it('tolerates docker:// and https:// prefixes and digests', () => {
+    expect(flyRegistryRepo(`docker://registry.fly.io/foo:latest`)).toBe('foo');
+    expect(flyRegistryRepo(`https://registry.fly.io/foo@sha256:abc`)).toBe('foo');
+  });
+
+  it('returns null for other registries', () => {
+    expect(flyRegistryRepo('redis:7-alpine')).toBeNull();
+    expect(flyRegistryRepo('ghcr.io/acme/api:v1')).toBeNull();
+    expect(flyRegistryRepo('docker.io/library/nginx')).toBeNull();
+    // registry.fly.io as a path segment, not the host
+    expect(flyRegistryRepo('example.com/registry.fly.io/foo')).toBeNull();
+  });
+});
+
+describe('imageBelongsToOwnService', () => {
+  it('matches only the exact <name>-<projectId> repo', () => {
+    expect(imageBelongsToOwnService(OWN_IMAGE, 'hospet-api', [PROJECT_ID])).toBe(true);
+    // another service's repo that shares a name prefix must NOT match
+    expect(
+      imageBelongsToOwnService(
+        `registry.fly.io/hospet-api-gateway-${PROJECT_ID}:v1`,
+        'hospet-api',
+        [PROJECT_ID]
+      )
+    ).toBe(false);
+    // same name, different project — could be a live app elsewhere
+    expect(
+      imageBelongsToOwnService(OWN_IMAGE, 'hospet-api', ['00000000-0000-0000-0000-000000000000'])
+    ).toBe(false);
+    expect(imageBelongsToOwnService('redis:7-alpine', 'hospet-api', [PROJECT_ID])).toBe(false);
+  });
+});
+
+describe('withStaleImageHint', () => {
+  const timeoutErr = () =>
+    new CLIError('OSS request failed: 504', 1, undefined, 504);
+
+  it('appends the hint for timeout-ish failures on fly registry images', () => {
+    const wrapped = withStaleImageHint(timeoutErr(), OWN_IMAGE, 'hospet-api') as CLIError;
+    expect(wrapped.message).toContain('deleted together with');
+    expect(wrapped.message).toContain('--name hospet-api');
+    expect(wrapped.statusCode).toBe(504);
+  });
+
+  it('matches COMPUTE_CLOUD_UNAVAILABLE by code and 502/503 by status', () => {
+    for (const err of [
+      new CLIError('unavailable', 1, 'COMPUTE_CLOUD_UNAVAILABLE', 503),
+      new CLIError('bad gateway', 1, undefined, 502),
+      new CLIError('unavailable', 1, undefined, 503),
+    ]) {
+      const wrapped = withStaleImageHint(err, OWN_IMAGE, 'x') as CLIError;
+      expect(wrapped.message).toContain('Hint:');
+    }
+  });
+
+  it('passes through non-timeout errors, non-fly images, and non-CLIErrors', () => {
+    const quota = new CLIError('quota exceeded', 1, 'COMPUTE_QUOTA_EXCEEDED', 403);
+    expect(withStaleImageHint(quota, OWN_IMAGE, 'x')).toBe(quota);
+
+    const dockerhubTimeout = timeoutErr();
+    expect(withStaleImageHint(dockerhubTimeout, 'redis:7', 'x')).toBe(dockerhubTimeout);
+
+    const plain = new Error('boom');
+    expect(withStaleImageHint(plain, OWN_IMAGE, 'x')).toBe(plain);
+  });
+
+  it('falls back to a <name> placeholder when the service name is unknown', () => {
+    expect(staleFlyImageHint()).toContain('--name <name>');
+  });
+});

--- a/src/lib/fly-registry.ts
+++ b/src/lib/fly-registry.ts
@@ -1,0 +1,69 @@
+// registry.fly.io repositories live and die with the Fly app they belong to:
+// deleting a compute service destroys its Fly app AND every image ever pushed
+// to that app's registry. A cached `--image registry.fly.io/<app>:<tag>`
+// reference therefore goes permanently stale the moment the service is
+// deleted — and redeploying it makes the platform spin in MANIFEST_UNKNOWN
+// retries until the request times out as a misleading COMPUTE_CLOUD_UNAVAILABLE.
+// These helpers let the deploy/update commands catch that before (or explain
+// it after) the round-trip.
+
+import { CLIError } from './errors.js';
+
+/** Extract the repository name from a registry.fly.io image URL, or null if
+ *  the image lives in any other registry. Tolerates docker://, https://, a
+ *  :tag suffix, and an @sha256 digest. */
+export function flyRegistryRepo(imageUrl: string): string | null {
+  const m = /^(?:docker:\/\/|https?:\/\/)?registry\.fly\.io\/([^:@/\s]+)/i.exec(imageUrl.trim());
+  return m ? m[1] : null;
+}
+
+/** True when the image reference points at the registry of the Fly app that
+ *  backs this very service (`<service-name>-<project-id>`). If that service
+ *  does not exist, neither does the app — so the registry is empty and the
+ *  deploy is guaranteed to fail. */
+export function imageBelongsToOwnService(
+  imageUrl: string,
+  serviceName: string,
+  projectIds: string[]
+): boolean {
+  const repo = flyRegistryRepo(imageUrl);
+  if (!repo) return false;
+  return projectIds.some((id) => repo === `${serviceName}-${id}`);
+}
+
+/** Appended to deploy/update failures that smell like a vanished registry
+ *  image, so users get "re-push the image" instead of "cloud unavailable". */
+export function staleFlyImageHint(serviceName?: string): string {
+  return (
+    `\nHint: this image lives in registry.fly.io, where images are deleted together with ` +
+    `their service. If the service was deleted (or this tag came from an older build), ` +
+    `the image no longer exists and every retry will fail the same way.\n` +
+    `Rebuild and push a fresh image by deploying from source:\n` +
+    `  npx @insforge/cli compute deploy <dir> --name ${serviceName ?? '<name>'}`
+  );
+}
+
+/** Rewrap a deploy/update failure with the stale-image hint when it looks
+ *  like the platform timed out resolving a registry.fly.io image — the
+ *  signature of a manifest that no longer exists. Non-matching errors pass
+ *  through untouched. */
+export function withStaleImageHint(
+  err: unknown,
+  imageUrl: string,
+  serviceName?: string
+): unknown {
+  if (!(err instanceof CLIError)) return err;
+  if (!flyRegistryRepo(imageUrl)) return err;
+  const timeoutish =
+    err.code === 'COMPUTE_CLOUD_UNAVAILABLE' ||
+    err.statusCode === 502 ||
+    err.statusCode === 503 ||
+    err.statusCode === 504;
+  if (!timeoutish) return err;
+  return new CLIError(
+    err.message + staleFlyImageHint(serviceName),
+    err.exitCode,
+    err.code,
+    err.statusCode
+  );
+}

--- a/src/lib/fly-registry.ts
+++ b/src/lib/fly-registry.ts
@@ -20,7 +20,13 @@ export function flyRegistryRepo(imageUrl: string): string | null {
 /** True when the image reference points at the registry of the Fly app that
  *  backs this very service (`<service-name>-<project-id>`). If that service
  *  does not exist, neither does the app — so the registry is empty and the
- *  deploy is guaranteed to fail. */
+ *  deploy is guaranteed to fail.
+ *
+ *  The `<name>-<projectId>` scheme mirrors the OSS backend's makeFlyAppName
+ *  (insforge/backend/src/providers/compute/services.service.ts) — the CLI
+ *  never builds app names itself. If the server ever changes the scheme this
+ *  guard silently no-ops (falls back to the timeout + hint path); it can
+ *  never wrongly block a valid deploy. */
 export function imageBelongsToOwnService(
   imageUrl: string,
   serviceName: string,


### PR DESCRIPTION
## Incident context

Project `6cdb996f` (customer "Ovixis", hospet-api) — every compute create/update failed for ~4 hours on Jul 10 with `OSS request failed: 504` / `COMPUTE_CLOUD_UNAVAILABLE`. Cloud logs show the real story: each attempt created the Fly app fine (201), then `launchMachine` exhausted all 5 `MANIFEST_UNKNOWN` retries (~72s) because the referenced image `registry.fly.io/hospet-api-…:cli-1783654786759` no longer exists — the customer's delete-and-retry loop kept destroying the Fly app **and its registry images**, while image-mode deploys kept referencing the dead tag (zero deploy-token requests all day = nothing was ever re-pushed). The OSS backend's 60s `AbortSignal` fires before the real 404 arrives, so the user sees a fake platform outage. The same project deployed three fresh test apps fine minutes later.

## Fix (CLI, two layers)

1. **Fail fast** — image-mode create of a service that doesn't exist, referencing that service's own registry repo (`<name>-<projectId>`), cannot succeed: the app was just confirmed absent, so its registry is empty. The CLI now errors immediately with the recovery command instead of triggering a guaranteed 60s server-side hang.
2. **Actionable hint** — any deploy/update with a `registry.fly.io` image that fails with `COMPUTE_CLOUD_UNAVAILABLE` / 502 / 503 / 504 gets the vanished-image explanation and the source-mode recovery command appended. Non-Fly images and non-timeout errors are untouched.

## Verification

- 585 unit tests pass (10 new: `fly-registry.test.ts` + 4 deploy scenario tests)
- `tsc` clean on touched files (pre-existing unrelated errors in payments/config-apply remain), `npm run build` succeeds
- End-to-end against a stub OSS backend with the built binary:
  - fresh create + own stale image → immediate clear error, only the list call goes out
  - existing service + timeout → original error + hint appended
  - `redis:7-alpine` + same timeout → behavior unchanged

## Follow-ups (server-side, separate repos)

- cloud-backend: map exhausted `MANIFEST_UNKNOWN` to a 422 `IMAGE_NOT_FOUND` instead of letting Fly's 404 bubble as `COMPUTE_CLOUD_UNAVAILABLE`; retry backoff (2+4+8+16+30s) alone exceeds the OSS 60s abort budget
- cloud-backend: confirm the `scale_to_zero` migration drift from 06:32–06:44 UTC Jul 10 is fully resolved (it failed other projects' launches after successful Fly machine creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xie2GAar6gT2KR3MybTsaQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents misleading timeouts when deploying with stale `registry.fly.io` image references by failing fast and adding a clear recovery hint. Also documents and tests the `compute update` without `--image` gap where timeouts pass through unchanged.

- **Bug Fixes**
  - Fail fast on fresh creates when `--image` points to the service’s own repo (`<name>-<projectId>`). Shows why it cannot work and suggests: `npx @insforge/cli compute deploy <dir> --name <name>`.
  - On deploy/update failures for `registry.fly.io` images with `COMPUTE_CLOUD_UNAVAILABLE` or 502/503/504, append an actionable stale-image hint. Other registries and non-timeout errors unchanged.
  - Known gap: `compute update` without `--image` relaunches the stored image; if that tag is stale, the timeout surfaces without a hint. Added command-level tests to cover hinted and pass-through cases.

<sup>Written for commit 378200e5227c9fd5ab4db8deaa72cba5afbfe9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard compute deploy against stale registry.fly.io image references
> - Adds a fast-fail check in `compute deploy` that throws a `CLIError` when deploying a new service using an image from its own `registry.fly.io` repository (i.e. `<name>-<projectId>`), since that image no longer exists after the service was deleted.
> - Wraps deploy/update errors in `compute deploy` and `compute update` with a stale-image hint via `withStaleImageHint` when a timeout-like failure (502/503/504 or `COMPUTE_CLOUD_UNAVAILABLE`) occurs on a `registry.fly.io` image.
> - Adds a new [`src/lib/fly-registry.ts`](https://github.com/InsForge/CLI/pull/194/files#diff-a7b2029bab3442f8a2f7d4ddb6bc74133af353c9e45c5980fc90a5ae096902d3) module with helpers: `flyRegistryRepo`, `imageBelongsToOwnService`, `staleFlyImageHint`, and `withStaleImageHint`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #194 opened
>
> - Added tests validating timeout error hints when updating compute services with `registry.fly.io` images [378200e]
> - Expanded inline comment in `registerComputeUpdateCommand` action handler clarifying limitation of hint logic [378200e]
> - Added documentation to `fly-registry.imageBelongsToOwnService` explaining naming scheme validation [378200e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82a9063.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for `compute deploy`/`compute update` when using `--image` backed by Fly image registries and the image is stale or unavailable.
  * Added preflight validation to fail fast when the provided Fly image is tied to a service registry that would be deleted alongside the service.
  * Ensured timeouts for non-Fly images (and unrelated failures) do not get stale-image “Hint:” guidance.
  * Reduced deploy blocking by only guarding against the relevant stale/mismatched registry images.

* **Tests**
  * Added coverage for Fly registry URL parsing, service/image matching rules, and timeout/hint behavior for deploy and update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->