### PR TITLE
feat: track login method in telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.98",
+      "version": "0.1.99",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -17,6 +17,9 @@ export function registerLoginCommand(program: Command): void {
     .option('--user-api-key <key>', 'Authenticate with a uak_ user API key')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
+      // Which auth path was taken — user_api_key logins are the signal the
+      // dashboard's connect-agent onboarding funnel is measured by.
+      const method = opts.userApiKey ? 'user_api_key' : opts.email ? 'email' : 'oauth';
 
       try {
         if (opts.userApiKey) {
@@ -27,12 +30,12 @@ export function registerLoginCommand(program: Command): void {
           await loginWithOAuth(json, apiUrl);
         }
 
-        await trackTopLevelUsage('login', true);
+        await trackTopLevelUsage('login', true, { method });
       } catch (err) {
         if (err instanceof Error && err.message.includes('cancelled')) {
           process.exit(0);
         }
-        await trackTopLevelUsage('login', false, {}, err);
+        await trackTopLevelUsage('login', false, { method }, err);
         handleError(err, json);
       }
     });


### PR DESCRIPTION
## What

The `login` command's PostHog event (`cli_command_invoked`) now includes a `method` property: `user_api_key` | `email` | `oauth`, on both success and failure events.

## Why

The insforge-cloud dashboard is running a `connect-agent-dock` A/B experiment whose test-group onboarding hands users a prompt containing `npx @insforge/cli login --user-api-key <key>`. The funnel's mid-step — "the user's coding agent actually authenticated with the copied key" — is currently invisible: all three auth paths emit an identical `login` event. With `method`, PostHog can chart API-key logins over time against dock copy-clicks.

## Notes

- `method` is a fixed enum derived from CLI flags — no user input, keys, or free text — consistent with `command-telemetry.ts`'s "counts, booleans, enums" contract.
- Derived before the `try` so the failure event carries it too (a failed API-key login is still funnel signal).

## Verification

- `npm run lint` passes (one pre-existing warning in `apify.test.ts`, untouched)
- `npm test`: 569 passed, 13 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `method` property to the `cli_command_invoked` event for `login` to capture the auth path: `user_api_key`, `email`, or `oauth`. Sent on both success and failure so PostHog can distinguish API-key logins used by the connect-agent onboarding funnel.

- **Dependencies**
  - Bump `@insforge/cli` to `0.1.99`.

<sup>Written for commit a62b062a6fc17859d1b3a6117f98d81befd6a89d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track login method in telemetry for the `login` command
> Adds a `method` property (`'user_api_key'`, `'email'`, or `'oauth'`) to the `trackTopLevelUsage` call in [`login.ts`](https://github.com/InsForge/CLI/pull/195/files#diff-f770fcb31e1ca2693fd54adb15e6e9a44e23be978206f3b79f2abbe6ab828148) on both success and failure paths. The method is determined by inspecting the options passed to `registerLoginCommand`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a62b062.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->