### PR TITLE
docs: publish workflow triggers on GitHub Release, not tag push

### DIFF
--- a/.claude/skills/cli-development/SKILL.md
+++ b/.claude/skills/cli-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-development
-description: Use when working on the @insforge/cli codebase itself — adding or modifying commands under src/commands/, touching src/lib/api or src/lib/analytics, changing package.json version, wiring telemetry, or preparing an npm release. Covers code conventions, PostHog analytics, agent-skills sync, and the tag-triggered publish workflow.
+description: Use when working on the @insforge/cli codebase itself — adding or modifying commands under src/commands/, touching src/lib/api or src/lib/analytics, changing package.json version, wiring telemetry, or preparing an npm release. Covers code conventions, PostHog analytics, agent-skills sync, and the release-triggered publish workflow.
 license: Apache-2.0
 metadata:
   organization: InsForge
@@ -17,8 +17,8 @@ in the repo root. It covers:
    property allow-list, flushing in `finally`, build-time key injection.
 3. **Agent-skills sync** — when to update the `InsForge/agent-skills` repo
    alongside CLI command changes.
-4. **Release workflow** — version bump → merge → tag `vX.Y.Z` → push → GitHub
-   Actions publishes to npm.
+4. **Release workflow** — version bump → merge → publish a GitHub Release for
+   `vX.Y.Z` → GitHub Actions publishes to npm.
 
 Always read `DEVELOPMENT.md` before editing files under `src/`, touching
 `package.json` version, or shipping a release.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,8 +106,8 @@ npm pack --dry-run
 
 Releases are fully automated via GitHub Actions
 ([`.github/workflows/publish.yml`](.github/workflows/publish.yml)).
-The CLI is published to npm as `@insforge/cli` whenever a version tag is
-pushed.
+The CLI is published to npm as `@insforge/cli` whenever a GitHub Release is
+published.
 
 **Steps to ship a release:**
 
@@ -116,14 +116,17 @@ pushed.
    additive features, major for breaking changes.
 2. **Commit the bump** with a message like `chore: bump version to X.Y.Z`.
 3. **Merge to `main`** via PR as usual.
-4. **Create and push a tag** matching the version on `main`:
+4. **Create and publish a GitHub Release** for the version tag on `main`:
    ```bash
    git checkout main && git pull
-   git tag vX.Y.Z
-   git push origin vX.Y.Z
+   gh release create vX.Y.Z --title vX.Y.Z --generate-notes
    ```
-5. The `publish` workflow triggers on the tag push and:
-   - Runs `npm run build` with `POSTHOG_API_KEY` injected from repo secrets.
+   `gh release create` creates the tag and the release in one step. Note that
+   pushing a bare tag (`git push origin vX.Y.Z`) does **not** trigger the
+   workflow — it only fires when a GitHub Release is published for the tag.
+5. The `publish` workflow triggers on the release being published and:
+   - Runs `npm run lint`, then `npm run build` with `POSTHOG_API_KEY`
+     injected from repo secrets.
    - Runs `npm publish --access public` with `NPM_TOKEN` from repo secrets.
 6. **Verify** the new version appears on
    [npmjs.com/package/@insforge/cli](https://www.npmjs.com/package/@insforge/cli)


### PR DESCRIPTION
## Summary

`DEVELOPMENT.md` section 5 (Release workflow) said pushing a version tag (`git push origin vX.Y.Z`) triggers the npm publish workflow. That's out of date: [`.github/workflows/publish.yml`](.github/workflows/publish.yml) triggers on `release: types: [published]`, so a bare tag push does nothing until a GitHub Release is published for that tag.

This was verified during the v0.1.99 release: the tag alone sat for 10+ minutes with no workflow run; creating the GitHub Release fired it immediately.

## Changes

- **DEVELOPMENT.md**: steps 4–5 now say to create and publish a GitHub Release (`gh release create vX.Y.Z --title vX.Y.Z --generate-notes`), with a note that a bare tag push does not trigger the workflow. Also mentions the lint step the workflow runs before building.
- **.claude/skills/cli-development/SKILL.md**: updated the release-workflow summary to match.

README's release instructions were already correct (they mention drafting a Release), so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release docs to match the current workflow: publishing a GitHub Release triggers npm publish, not pushing a tag. Updated `DEVELOPMENT.md` and `.claude/skills/cli-development/SKILL.md` with `gh release create vX.Y.Z`, noted that bare tag pushes do nothing, and clarified the lint step runs before build for `@insforge/cli`.

<sup>Written for commit 67a64787812eb7917144172deeedeb64f2471d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update publish workflow docs to trigger on GitHub Release instead of tag push
> - Updates [DEVELOPMENT.md](https://github.com/InsForge/CLI/pull/196/files#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33ece) and [SKILL.md](https://github.com/InsForge/CLI/pull/196/files#diff-fb9bb5659ce26eb2580c59768dbdb5c68e4b19641fe623813e2f9db73c4cecbe) to document that the npm publish workflow triggers on GitHub Release publication, not a bare tag push.
> - Replaces the manual `git tag` + `git push` release step with `gh release create vX.Y.Z --title vX.Y.Z --generate-notes`.
> - Adds a note that pushing a bare tag does not trigger the publish workflow.
> - Adds `npm run lint` before `npm run build` in the documented release steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67a6478.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release and publishing guidance to reflect the GitHub Release-based workflow.
  * Clarified that publishing to npm occurs after a GitHub Release is created.
  * Added updated release creation steps and documented the validation and build checks performed during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->