### PR TITLE
Restrict self-serve billing plans to free and pro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -9,14 +9,15 @@ import {
   createPortalSession,
 } from '../../lib/api/platform.js';
 import { requireAuth } from '../../lib/credentials.js';
-import { handleError, getRootOpts } from '../../lib/errors.js';
+import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
 import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
-// Shown in help only. Not used to validate — the backend owns the plan enum,
-// so a hard-coded allowlist here could reject a newly added plan.
-const BILLING_PLANS = ['free', 'starter', 'pro', 'team', 'enterprise'];
+// Plans currently offered for self-serve upgrade. The backend owns the full
+// plan enum, but only these are open right now, so we gate locally to fail fast
+// with a clear message instead of sending a not-yet-available plan to Stripe.
+const BILLING_PLANS = ['free', 'pro'];
 
 /** Render a backend date-only string (YYYY-MM-DD) without UTC→local day shift. */
 function formatCalendarDate(d: string): string {
@@ -161,7 +162,12 @@ export function registerBillingCommands(billingCmd: Command): void {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
         await requireAuth(apiUrl);
-        // Plan is validated server-side against the canonical billing enum.
+        // Only a subset of the backend plan enum is open for self-serve upgrade
+        // right now; reject anything else up front so we don't hand an
+        // unavailable plan off to Stripe checkout.
+        if (!BILLING_PLANS.includes(plan)) {
+          throw new CLIError(`Invalid plan "${plan}". Available plans: ${BILLING_PLANS.join(', ')}.`);
+        }
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const session = await createCheckoutSession(orgId, plan, apiUrl);
 

--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -161,13 +161,13 @@ export function registerBillingCommands(billingCmd: Command): void {
     .action(async (plan: string, opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        await requireAuth(apiUrl);
-        // Only a subset of the backend plan enum is open for self-serve upgrade
-        // right now; reject anything else up front so we don't hand an
-        // unavailable plan off to Stripe checkout.
+        // Validate the plan before any network work (auth, checkout) so a typo
+        // like `billing upgrade enterprise` fails instantly. Only a subset of
+        // the backend plan enum is open for self-serve upgrade right now.
         if (!BILLING_PLANS.includes(plan)) {
           throw new CLIError(`Invalid plan "${plan}". Available plans: ${BILLING_PLANS.join(', ')}.`);
         }
+        await requireAuth(apiUrl);
         const orgId = await resolveOrgId(opts.orgId, json, apiUrl);
         const session = await createCheckoutSession(orgId, plan, apiUrl);
 


### PR DESCRIPTION
## What

Restricts the `insforge billing upgrade <plan>` command to only accept `free` and `pro`.

- Narrows `BILLING_PLANS` from `['free', 'starter', 'pro', 'team', 'enterprise']` to `['free', 'pro']`. This also updates the `upgrade` command's help text automatically (`Start a checkout to change the plan (free | pro)`).
- Adds local validation in the `upgrade` action: any plan outside the allowlist now throws a `CLIError` before the backend is called.

## Why

Only `free` and `pro` are open for self-serve upgrade at the moment. Previously the CLI passed the plan string straight through to Stripe checkout and relied entirely on server-side validation. Gating locally lets us fail fast with a clear message (`Invalid plan "<x>". Available plans: free, pro.`) instead of creating a checkout session for a plan that isn't available yet.

## Notes for reviewers

- The rejection flows through the existing `catch`, so `trackCommandUsage('billing', 'upgrade', false, …)` still records the failed attempt.
- Widening the list later is a one-line change: add plans back to `BILLING_PLANS`.
- The prior code comment explicitly warned against a local allowlist (backend owns the enum). That comment has been updated to reflect this is now an intentional "only these are open right now" gate.
- Typecheck passes for the changed file. `tsc` reports pre-existing errors in unrelated files (`config/apply.ts`, `metadata.ts`, `payments/transactions.test.ts`, etc.) that this change does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the `insforge billing upgrade <plan>` command to only accept `free` and `pro`. Adds a client-side `CLIError` guard that runs before auth or checkout, so invalid plans fail instantly with no network calls.

<sup>Written for commit 5c4de5672d453c8a9d668d477faa2e7653cbc916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict `billing upgrade` command to free and pro plans
> Limits the `BILLING_PLANS` allowlist in [index.ts](https://github.com/InsForge/CLI/pull/197/files#diff-8e9dda9e9379e2d71083d926fc500dda1b71a45123d8ca910abf18322f9dd44d) to `['free', 'pro']` and adds a client-side guard that throws a `CLIError` for any other plan before making API calls. Help text for the `upgrade` command now reflects only `free | pro` as valid options.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d84ef3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added upfront validation for `billing upgrade <plan>` before any processing.
  * Invalid plans are rejected immediately with an error listing the available options.
  * Self-serve billing upgrades are now limited to the Free and Pro plans.
* **Chores**
  * Updated package version to 0.1.100.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->