### PR TITLE
feat(login): headless OAuth via --no-browser / --callback-url

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,7 +3,7 @@ import * as clack from '@clack/prompts';
 import * as prompts from '../lib/prompts.js';
 import { saveCredentials, getPlatformApiUrl } from '../lib/config.js';
 import { login as platformLogin } from '../lib/api/platform.js';
-import { performOAuthLogin } from '../lib/auth.js';
+import { performOAuthLogin, startHeadlessOAuthLogin, completeHeadlessOAuthLogin } from '../lib/auth.js';
 import { handleError, getRootOpts, CLIError, formatFetchError } from '../lib/errors.js';
 import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 import type { StoredCredentials, User } from '../types.js';
@@ -15,17 +15,31 @@ export function registerLoginCommand(program: Command): void {
     .option('--email', 'Login with email and password instead of browser')
     .option('--client-id <id>', 'OAuth client ID (defaults to insforge-cli)')
     .option('--user-api-key <key>', 'Authenticate with a uak_ user API key')
+    .option('--no-browser', 'Print the sign-in URL and exit; finish later with --callback-url (for sandboxes/SSH where the browser cannot reach this process)')
+    .option('--callback-url <url>', 'Complete a --no-browser login with the URL the browser was redirected to')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       // Which auth path was taken — user_api_key logins are the signal the
       // dashboard's connect-agent onboarding funnel is measured by.
-      const method = opts.userApiKey ? 'user_api_key' : opts.email ? 'email' : 'oauth';
+      const method = opts.userApiKey
+        ? 'user_api_key'
+        : opts.email
+          ? 'email'
+          : opts.callbackUrl
+            ? 'oauth_callback_url'
+            : opts.browser === false
+              ? 'oauth_no_browser'
+              : 'oauth';
 
       try {
         if (opts.userApiKey) {
           await loginWithUserApiKey(opts.userApiKey, json, apiUrl);
         } else if (opts.email) {
           await loginWithEmail(json, apiUrl);
+        } else if (opts.callbackUrl) {
+          await completeHeadlessLogin(opts.callbackUrl, json, apiUrl);
+        } else if (opts.browser === false) {
+          startHeadlessLogin(json, apiUrl);
         } else {
           await loginWithOAuth(json, apiUrl);
         }
@@ -96,6 +110,51 @@ async function loginWithEmail(json: boolean, apiUrl?: string): Promise<void> {
     };
     saveCredentials(creds);
     console.log(JSON.stringify({ success: true, user: result.user }));
+  }
+}
+
+/**
+ * `login --no-browser`, step 1: print the authorize URL and exit. The PKCE
+ * state is persisted so a separate `login --callback-url` invocation can
+ * finish — required in agent sandboxes (e.g. the ChatGPT app) where the
+ * browser can never reach a loopback listener inside this process.
+ */
+function startHeadlessLogin(json: boolean, apiUrl?: string): void {
+  const { authUrl } = startHeadlessOAuthLogin(apiUrl);
+
+  if (json) {
+    console.log(JSON.stringify({
+      success: true,
+      pending: true,
+      auth_url: authUrl,
+      next_step: 'Open auth_url in a browser, sign in, then run: insforge login --callback-url "<url from the browser address bar>"',
+    }));
+    return;
+  }
+
+  clack.intro('InsForge CLI');
+  clack.log.info(`Open this URL in your browser to sign in:\n\n${authUrl}`);
+  clack.log.info(
+    'After signing in, the browser will land on a http://127.0.0.1/... page that cannot connect — that is expected.\n' +
+    'Copy the FULL URL from the address bar and run:\n\n' +
+    '  insforge login --callback-url "<pasted url>"',
+  );
+  clack.outro('Waiting for you to finish in the browser (link valid ~10 minutes)');
+}
+
+/** `login --callback-url`, step 2: redeem the pasted callback URL. */
+async function completeHeadlessLogin(callbackUrl: string, json: boolean, apiUrl?: string): Promise<void> {
+  if (!json) {
+    clack.intro('InsForge CLI');
+  }
+
+  const creds = await completeHeadlessOAuthLogin(callbackUrl, apiUrl);
+
+  if (!json) {
+    clack.log.success(`Authenticated as ${creds.user.email || creds.user.id}`);
+    clack.outro('Done');
+  } else {
+    console.log(JSON.stringify({ success: true, user: creds.user }));
   }
 }
 

--- a/src/lib/auth.headless.test.ts
+++ b/src/lib/auth.headless.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+
+// GLOBAL_DIR in config.ts is derived from homedir() at import time, so the
+// mock must be in place before auth.js/config.js are (dynamically) imported.
+// Type-only imports are erased at compile time, so they don't evaluate the
+// modules before the homedir mock is in place — the real imports are dynamic.
+import type * as AuthModule from './auth.js';
+import type * as ConfigModule from './config.js';
+import type * as OsModule from 'node:os';
+
+const mocks = vi.hoisted(() => ({ home: '' }));
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof OsModule>();
+  return { ...actual, homedir: () => mocks.home || actual.homedir() };
+});
+
+let auth: typeof AuthModule;
+let config: typeof ConfigModule;
+
+beforeAll(async () => {
+  mocks.home = mkdtempSync(join(tmpdir(), 'insforge-auth-test-'));
+  auth = await import('./auth.js');
+  config = await import('./config.js');
+});
+
+afterAll(() => {
+  rmSync(mocks.home, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  config.clearPendingLogin();
+  vi.unstubAllGlobals();
+});
+
+describe('parseCallbackInput', () => {
+  it('parses a full callback URL', () => {
+    const result = auth.parseCallbackInput(
+      'http://127.0.0.1:38961/callback?code=ac_abc123&state=st_xyz',
+    );
+    expect(result).toEqual({ code: 'ac_abc123', state: 'st_xyz' });
+  });
+
+  it('tolerates surrounding whitespace and quotes from copy-paste', () => {
+    const result = auth.parseCallbackInput(
+      '  "http://127.0.0.1:1234/callback?code=ac_a&state=s1"  ',
+    );
+    expect(result).toEqual({ code: 'ac_a', state: 's1' });
+  });
+
+  it('accepts a bare query string', () => {
+    expect(auth.parseCallbackInput('?code=ac_a&state=s1')).toEqual({ code: 'ac_a', state: 's1' });
+    expect(auth.parseCallbackInput('code=ac_a&state=s1')).toEqual({ code: 'ac_a', state: 's1' });
+  });
+
+  it('surfaces the provider error over a missing code', () => {
+    expect(() =>
+      auth.parseCallbackInput('http://127.0.0.1:1/callback?error=access_denied&error_description=User+denied'),
+    ).toThrow(/denied/i);
+  });
+
+  it('rejects a bare code with guidance to paste the full URL', () => {
+    expect(() => auth.parseCallbackInput('ac_abc123')).toThrow(/full callback URL/i);
+  });
+
+  it('rejects a URL missing state', () => {
+    expect(() => auth.parseCallbackInput('http://127.0.0.1:1/callback?code=ac_a')).toThrow(/missing code or state/i);
+  });
+});
+
+describe('startHeadlessOAuthLogin', () => {
+  it('persists pending state and returns a matching authorize URL', () => {
+    const { authUrl, redirectUri } = auth.startHeadlessOAuthLogin();
+    const url = new URL(authUrl);
+
+    expect(url.pathname).toBe('/api/oauth/v1/authorize');
+    expect(url.searchParams.get('redirect_uri')).toBe(redirectUri);
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+
+    const pending = config.getPendingLogin();
+    expect(pending).not.toBeNull();
+    expect(pending!.state).toBe(url.searchParams.get('state'));
+    expect(pending!.redirect_uri).toBe(redirectUri);
+    expect(pending!.code_verifier).toBeTruthy();
+    // Loopback redirect, random port — the platform allows any 127.0.0.1 port.
+    expect(redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+  });
+});
+
+describe('completeHeadlessOAuthLogin', () => {
+  function stubTokenAndProfileFetch() {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/api/oauth/v1/token')) {
+        return new Response(
+          JSON.stringify({ access_token: 'at_test', refresh_token: 'rt_test', expires_in: 3600 }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.includes('/auth/v1/profile')) {
+        return new Response(
+          JSON.stringify({ user: { id: 'u1', name: 'T', email: 't@x.dev', avatar_url: null, email_verified: true } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  it('fails with guidance when no login is pending', async () => {
+    await expect(
+      auth.completeHeadlessOAuthLogin('http://127.0.0.1:1/callback?code=ac_a&state=s1'),
+    ).rejects.toThrow(/--no-browser/);
+  });
+
+  it('rejects a state mismatch', async () => {
+    auth.startHeadlessOAuthLogin();
+    await expect(
+      auth.completeHeadlessOAuthLogin('http://127.0.0.1:1/callback?code=ac_a&state=WRONG'),
+    ).rejects.toThrow(/state mismatch/i);
+  });
+
+  it('rejects an expired pending login and clears it', async () => {
+    auth.startHeadlessOAuthLogin();
+    const pending = config.getPendingLogin()!;
+    config.savePendingLogin({
+      ...pending,
+      created_at: new Date(Date.now() - 11 * 60 * 1000).toISOString(),
+    });
+    await expect(
+      auth.completeHeadlessOAuthLogin(`http://127.0.0.1:1/callback?code=ac_a&state=${pending.state}`),
+    ).rejects.toThrow(/expired/i);
+    expect(config.getPendingLogin()).toBeNull();
+  });
+
+  it('exchanges the code with the pending PKCE verifier and stores credentials', async () => {
+    const fetchMock = stubTokenAndProfileFetch();
+    const { redirectUri } = auth.startHeadlessOAuthLogin();
+    const pending = config.getPendingLogin()!;
+
+    const creds = await auth.completeHeadlessOAuthLogin(
+      `${redirectUri}?code=ac_good&state=${pending.state}`,
+    );
+
+    // Token exchange used the persisted verifier + the exact redirect_uri.
+    const tokenCall = fetchMock.mock.calls.find(([u]) => String(u).includes('/token'))!;
+    const body = JSON.parse((tokenCall[1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      grant_type: 'authorization_code',
+      code: 'ac_good',
+      redirect_uri: redirectUri,
+      code_verifier: pending.code_verifier,
+    });
+
+    expect(creds.access_token).toBe('at_test');
+    expect(creds.user.email).toBe('t@x.dev');
+
+    // Pending file is single-use; credentials are persisted 0600.
+    expect(config.getPendingLogin()).toBeNull();
+    const credFile = join(mocks.home, '.insforge', 'credentials.json');
+    expect(existsSync(credFile)).toBe(true);
+    expect(JSON.parse(readFileSync(credFile, 'utf-8')).access_token).toBe('at_test');
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,13 +1,20 @@
 import { createServer } from 'node:http';
-import { randomBytes, createHash } from 'node:crypto';
+import { randomBytes, randomInt, createHash } from 'node:crypto';
 import { URL } from 'node:url';
 import * as clack from '@clack/prompts';
 import pc from 'picocolors';
 import { isInteractive } from './prompts.js';
-import { getGlobalConfig, getPlatformApiUrl, saveCredentials } from './config.js';
+import {
+  getGlobalConfig,
+  getPlatformApiUrl,
+  saveCredentials,
+  getPendingLogin,
+  savePendingLogin,
+  clearPendingLogin,
+} from './config.js';
 import { getProfile } from './api/platform.js';
 import { formatFetchError } from './errors.js';
-import type { StoredCredentials } from '../types.js';
+import type { PendingOAuthLogin, StoredCredentials } from '../types.js';
 
 // Default OAuth client for InsForge CLI (pre-registered on the platform)
 export const DEFAULT_CLIENT_ID = 'clf_NK8cMUs41gm8ZcfdtSguVw';
@@ -230,6 +237,7 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
     // Non-TTY (agent shell): surface the URL prominently via stderr so it stays out of
     // any JSON stdout stream but is still visible to agents and humans.
     process.stderr.write(`\nTo sign in, open this URL in your browser:\n\n  ${pc.cyan(pc.underline(authUrl))}\n\n`);
+    process.stderr.write(`If the browser cannot reach this machine after sign-in (sandbox/SSH/container), cancel and use:\n  insforge login --no-browser\n\n`);
   }
 
   // 4. Open browser (best effort — often works even from agent shells since we're on the same machine)
@@ -291,4 +299,140 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
     if (!isInteractive) process.stderr.write('Authentication failed\n');
     throw err;
   }
+}
+
+// Matches the platform's authorization-code TTL (10 min) so a stale pending
+// login fails locally with a clear message instead of a server-side error.
+const PENDING_LOGIN_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Headless variant of the OAuth login, step 1 of 2 (`login --no-browser`).
+ *
+ * For environments where the browser can never reach a loopback listener in
+ * this process (agent sandboxes like the ChatGPT app, SSH sessions, CI): no
+ * server is started. PKCE verifier + state are persisted to
+ * ~/.insforge/pending-login.json so a *separate* CLI invocation
+ * (`login --callback-url`) can finish the exchange. The redirect still points
+ * at a loopback URL nothing listens on — the browser shows a connection
+ * error, but the code/state survive in the address bar for the user to copy.
+ */
+export function startHeadlessOAuthLogin(apiUrl?: string): { authUrl: string; redirectUri: string } {
+  const platformUrl = getPlatformApiUrl(apiUrl);
+  const config = getGlobalConfig();
+  const clientId = config.oauth_client_id ?? DEFAULT_CLIENT_ID;
+
+  const pkce = generatePKCE();
+  const state = generateState();
+  // Random loopback port (nothing listens on it): the platform allows any
+  // port on 127.0.0.1 redirects (RFC 8252 §7.3), and randomness avoids
+  // handing the code to whatever service might occupy a fixed port.
+  const redirectUri = `http://127.0.0.1:${randomInt(1024, 65536)}/callback`;
+
+  const pending: PendingOAuthLogin = {
+    code_verifier: pkce.code_verifier,
+    state,
+    redirect_uri: redirectUri,
+    platform_url: platformUrl,
+    client_id: clientId,
+    created_at: new Date().toISOString(),
+  };
+  savePendingLogin(pending);
+
+  const authUrl = buildAuthorizeUrl({
+    platformUrl,
+    clientId,
+    redirectUri,
+    codeChallenge: pkce.code_challenge,
+    state,
+    scopes: OAUTH_SCOPES,
+  });
+
+  return { authUrl, redirectUri };
+}
+
+/**
+ * Extract code + state from a pasted callback URL (or bare query string).
+ * Tolerates surrounding whitespace/quotes from copy-paste.
+ */
+export function parseCallbackInput(input: string): OAuthCallbackResult {
+  const cleaned = input.trim().replace(/^['"<]+|['">]+$/g, '');
+
+  let params: URLSearchParams;
+  if (cleaned.includes('://')) {
+    let url: URL;
+    try {
+      url = new URL(cleaned);
+    } catch {
+      throw new Error('Could not parse the callback URL. Paste the full URL from the browser address bar.');
+    }
+    params = url.searchParams;
+  } else if (cleaned.includes('code=')) {
+    params = new URLSearchParams(cleaned.replace(/^\?/, ''));
+  } else {
+    throw new Error(
+      'Expected the full callback URL (http://127.0.0.1:.../callback?code=...&state=...) from the browser address bar, not a bare code.',
+    );
+  }
+
+  const error = params.get('error');
+  if (error) {
+    throw new Error(params.get('error_description') ?? `Authorization failed: ${error}`);
+  }
+
+  const code = params.get('code');
+  const state = params.get('state');
+  if (!code || !state) {
+    throw new Error('Callback URL is missing code or state. Paste the full URL from the browser address bar.');
+  }
+  return { code, state };
+}
+
+/**
+ * Headless OAuth login, step 2 of 2 (`login --callback-url <url>`).
+ * Verifies the pasted callback against the pending login saved by
+ * startHeadlessOAuthLogin, exchanges the code, and stores credentials.
+ */
+export async function completeHeadlessOAuthLogin(
+  callbackInput: string,
+  apiUrl?: string,
+): Promise<StoredCredentials> {
+  const pending = getPendingLogin();
+  if (!pending) {
+    throw new Error('No login in progress. Run `insforge login --no-browser` first, then retry with the callback URL.');
+  }
+  if (Date.now() - new Date(pending.created_at).getTime() > PENDING_LOGIN_TTL_MS) {
+    clearPendingLogin();
+    throw new Error('The pending login expired (10 minutes). Run `insforge login --no-browser` again.');
+  }
+
+  const { code, state } = parseCallbackInput(callbackInput);
+  if (state !== pending.state) {
+    throw new Error('State mismatch — the callback URL does not belong to this login attempt. Run `insforge login --no-browser` again.');
+  }
+
+  const tokens = await exchangeCodeForTokens({
+    platformUrl: apiUrl ? getPlatformApiUrl(apiUrl) : pending.platform_url,
+    code,
+    redirectUri: pending.redirect_uri,
+    clientId: pending.client_id,
+    codeVerifier: pending.code_verifier,
+  });
+  clearPendingLogin();
+
+  const creds: StoredCredentials = {
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    user: { id: '', name: '', email: '', avatar_url: null, email_verified: true },
+  };
+  saveCredentials(creds);
+
+  try {
+    const profile = await getProfile(apiUrl);
+    creds.user = profile;
+    saveCredentials(creds);
+  } catch {
+    // Token is saved and valid; profile fetch is best-effort (same as performOAuthLogin).
+  }
+
+  return creds;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,11 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { GlobalConfig, ProjectConfig, StoredCredentials } from '../types.js';
+import type { GlobalConfig, PendingOAuthLogin, ProjectConfig, StoredCredentials } from '../types.js';
 
 const GLOBAL_DIR = join(homedir(), '.insforge');
 const CREDENTIALS_FILE = join(GLOBAL_DIR, 'credentials.json');
 const CONFIG_FILE = join(GLOBAL_DIR, 'config.json');
+const PENDING_LOGIN_FILE = join(GLOBAL_DIR, 'pending-login.json');
 
 const DEFAULT_PLATFORM_URL = 'https://api.insforge.dev';
 const DEFAULT_FRONTEND_URL = 'https://insforge.dev';
@@ -48,6 +49,27 @@ export function getCredentials(): StoredCredentials | null {
 export function saveCredentials(creds: StoredCredentials): void {
   ensureGlobalDir();
   writeFileSync(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), { mode: 0o600 });
+}
+
+// --- Pending headless OAuth login (login --no-browser) ---
+
+export function getPendingLogin(): PendingOAuthLogin | null {
+  if (!existsSync(PENDING_LOGIN_FILE)) {
+    return null;
+  }
+  const raw = readFileSync(PENDING_LOGIN_FILE, 'utf-8');
+  return JSON.parse(raw);
+}
+
+export function savePendingLogin(pending: PendingOAuthLogin): void {
+  ensureGlobalDir();
+  writeFileSync(PENDING_LOGIN_FILE, JSON.stringify(pending, null, 2), { mode: 0o600 });
+}
+
+export function clearPendingLogin(): void {
+  if (existsSync(PENDING_LOGIN_FILE)) {
+    unlinkSync(PENDING_LOGIN_FILE);
+  }
 }
 
 export function clearCredentials(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,21 @@ export interface StoredCredentials {
   user: User;
 }
 
+/**
+ * In-flight `login --no-browser` state persisted between the invocation that
+ * prints the authorize URL and the later `login --callback-url` invocation
+ * that redeems the pasted code. Holds the PKCE verifier, so it is stored
+ * 0600 and deleted as soon as the login completes (or expires).
+ */
+export interface PendingOAuthLogin {
+  code_verifier: string;
+  state: string;
+  redirect_uri: string;
+  platform_url: string;
+  client_id: string;
+  created_at: string;
+}
+
 // Global config
 export interface GlobalConfig {
   default_org_id?: string;


### PR DESCRIPTION
## Why

When the CLI runs inside a sandbox (ChatGPT app plugin, SSH, containers), `insforge login` opens the browser on the host, but the OAuth redirect goes to a loopback listener **inside the sandbox** that the host browser can never reach — login hangs until timeout. Seen live driving the InsForge plugin from the ChatGPT app (`npx @insforge/cli@latest orgs list --json` → auth URL → browser dead-ends on `http://127.0.0.1:38961/callback?...`).

## What

Two-step headless flow, following the gcloud `--no-launch-browser` pattern (no backend changes needed):

1. `insforge login --no-browser` — prints the authorize URL, persists PKCE verifier/state/redirect_uri to `~/.insforge/pending-login.json` (0600, 10-min TTL matching the server's code expiry), exits.
2. User signs in; the browser lands on the dead `127.0.0.1` redirect (expected — instructions say so) with code+state in the address bar.
3. `insforge login --callback-url "<pasted url>"` — parses code/state (tolerates quotes/whitespace, bare query strings; surfaces `error=` params), verifies state, exchanges the code with the persisted verifier, stores credentials, deletes the pending file.

Default browser flow unchanged; its non-TTY output now hints at the fallback. Telemetry `method` distinguishes `oauth_no_browser` / `oauth_callback_url`.

## Verification

- 11 new unit tests (parse, pending persistence, state mismatch, expiry, full exchange with mocked fetch); full suite 595 passing, eslint clean, build clean.
- Live smoke test against prod: `--no-browser` writes pending state + prints URL (human & `--json` modes); wrong state → local error; correct state + fake code reaches the real token endpoint and gets `invalid_grant` — full exchange wiring accepted server-side.

## Notes

- Companion docs PR needed in the skills repo (`skills/insforge-cli/references/login.md`) — will link.
- Longer-term we may want a Supabase-style poll-based login (no paste at all); this PR is the zero-backend-change unblock.
- No version bump included — will bump on release per DEVELOPMENT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcszudKMZBSm5RMP14h7fu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a headless OAuth login flow to the CLI with `--no-browser` and `--callback-url` so login works in sandboxes/SSH where loopback callbacks fail. Default browser login is unchanged; non-TTY mode now suggests the fallback.

- **New Features**
  - `insforge login --no-browser`: prints the auth URL and saves pending PKCE/state/redirect_uri to `~/.insforge/pending-login.json` (0600, 10‑min TTL).
  - `insforge login --callback-url "<url>"`: parses code/state (tolerates quotes/whitespace or bare query strings), surfaces provider errors, verifies state/expiry, exchanges the code, stores credentials, and clears the pending file.
  - Telemetry records `oauth_no_browser` and `oauth_callback_url` methods.
  - Non‑TTY browser flow now hints at using `--no-browser` if the callback can’t reach the process.

<sup>Written for commit 03f9a071a054a2f25f91abe0cf632f76a88efbb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add headless OAuth login via `--no-browser` and `--callback-url` flags
> - `--no-browser` generates PKCE/state, persists a pending login file, and prints an authorize URL with instructions instead of starting a local callback server.
> - `--callback-url <url>` completes a pending headless login by parsing the pasted callback URL, verifying state, exchanging the auth code, and storing credentials; enforces a 10-minute TTL on the pending login.
> - Pending login state is stored in a new `PENDING_LOGIN_FILE` in the global config directory with 0600 permissions via new helpers in [config.ts](https://github.com/InsForge/CLI/pull/198/files#diff-0b4f5977a52cef50ed20e7cdf9761795df9ee1cb3b5e5ea45edeb9394e8a47ff).
> - Non-interactive `performOAuthLogin` now prints extra stderr guidance suggesting the `--no-browser` flow when the browser cannot reach the machine.
> - Behavioral Change: telemetry `method` values now include `oauth_no_browser` and `oauth_callback_url` in addition to existing values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03f9a07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->