### PR TITLE
feat(login): --device login via RFC 8628 device flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.100",
+  "version": "0.2.0",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,7 +3,7 @@ import * as clack from '@clack/prompts';
 import * as prompts from '../lib/prompts.js';
 import { saveCredentials, getPlatformApiUrl } from '../lib/config.js';
 import { login as platformLogin } from '../lib/api/platform.js';
-import { performOAuthLogin } from '../lib/auth.js';
+import { performOAuthLogin, performDeviceLogin } from '../lib/auth.js';
 import { handleError, getRootOpts, CLIError, formatFetchError } from '../lib/errors.js';
 import { trackTopLevelUsage } from '../lib/command-telemetry.js';
 import type { StoredCredentials, User } from '../types.js';
@@ -15,17 +15,26 @@ export function registerLoginCommand(program: Command): void {
     .option('--email', 'Login with email and password instead of browser')
     .option('--client-id <id>', 'OAuth client ID (defaults to insforge-cli)')
     .option('--user-api-key <key>', 'Authenticate with a uak_ user API key')
+    .option('--device', 'Device login: approve a short code on the dashboard while the CLI polls — for sandboxes/SSH/containers where the browser cannot reach this process')
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       // Which auth path was taken — user_api_key logins are the signal the
       // dashboard's connect-agent onboarding funnel is measured by.
-      const method = opts.userApiKey ? 'user_api_key' : opts.email ? 'email' : 'oauth';
+      const method = opts.userApiKey
+        ? 'user_api_key'
+        : opts.email
+          ? 'email'
+          : opts.device
+            ? 'oauth_device'
+            : 'oauth';
 
       try {
         if (opts.userApiKey) {
           await loginWithUserApiKey(opts.userApiKey, json, apiUrl);
         } else if (opts.email) {
           await loginWithEmail(json, apiUrl);
+        } else if (opts.device) {
+          await loginWithDevice(json, apiUrl);
         } else {
           await loginWithOAuth(json, apiUrl);
         }
@@ -96,6 +105,25 @@ async function loginWithEmail(json: boolean, apiUrl?: string): Promise<void> {
     };
     saveCredentials(creds);
     console.log(JSON.stringify({ success: true, user: result.user }));
+  }
+}
+
+/**
+ * Device login (RFC 8628): the user approves a short code on the dashboard
+ * while the CLI polls. No loopback callback — works in agent sandboxes
+ * (ChatGPT app), SSH sessions, and containers.
+ */
+async function loginWithDevice(json: boolean, apiUrl?: string): Promise<void> {
+  if (!json) {
+    clack.intro('InsForge CLI');
+  }
+
+  const creds = await performDeviceLogin(apiUrl);
+
+  if (!json) {
+    clack.outro('Done');
+  } else {
+    console.log(JSON.stringify({ success: true, user: creds.user }));
   }
 }
 

--- a/src/lib/auth.device.resume.test.ts
+++ b/src/lib/auth.device.resume.test.ts
@@ -1,0 +1,186 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+
+// Resume behavior of `login --device`: a killed poller's pending device code
+// is reused by the next invocation instead of minting a fresh one.
+
+// GLOBAL_DIR in config.ts is derived from homedir() at import time, so the
+// mock must be in place before auth.js/config.js are (dynamically) imported.
+import type * as AuthModule from './auth.js';
+import type * as ConfigModule from './config.js';
+import type * as OsModule from 'node:os';
+import type { PendingDeviceLogin } from '../types.js';
+
+const mocks = vi.hoisted(() => ({ home: '' }));
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof OsModule>();
+  return { ...actual, homedir: () => mocks.home || actual.homedir() };
+});
+vi.mock('open', () => ({ default: vi.fn(async () => undefined) }));
+
+let auth: typeof AuthModule;
+let config: typeof ConfigModule;
+
+const PLATFORM = 'https://api.example.dev';
+
+beforeAll(async () => {
+  mocks.home = mkdtempSync(join(tmpdir(), 'insforge-device-resume-'));
+  auth = await import('./auth.js');
+  config = await import('./config.js');
+});
+
+afterAll(() => {
+  rmSync(mocks.home, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  config.clearPendingDeviceLogin();
+  config.clearCredentials();
+  config.saveGlobalConfig({ platform_api_url: PLATFORM });
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(handlers: {
+  deviceAuthorization?: () => Response;
+  token: (body: Record<string, string>) => Response;
+}) {
+  const calls = { deviceAuthorization: 0, token: 0 };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/device_authorization')) {
+        calls.deviceAuthorization++;
+        if (!handlers.deviceAuthorization) throw new Error('unexpected device_authorization call');
+        return handlers.deviceAuthorization();
+      }
+      if (url.includes('/oauth/v1/token')) {
+        calls.token++;
+        return handlers.token(JSON.parse((init?.body as string) ?? '{}'));
+      }
+      if (url.includes('/auth/v1/profile')) {
+        return new Response(
+          JSON.stringify({ user: { id: 'u1', name: 'T', email: 't@x.dev', avatar_url: null, email_verified: true } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }),
+  );
+  return calls;
+}
+
+const tokens = () =>
+  new Response(JSON.stringify({ access_token: 'at', refresh_token: 'rt', expires_in: 3600 }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const oauthError = (error: string) =>
+  new Response(JSON.stringify({ error }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+const pendingFixture = (overrides: Partial<PendingDeviceLogin> = {}) => ({
+  device_code: 'dvc_previous',
+  user_code: 'BCDF-GHJK',
+  verification_uri_complete: 'https://insforge.dev/auth/device?user_code=BCDF-GHJK',
+  interval: 0.01,
+  expires_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+  platform_url: PLATFORM,
+  client_id: 'clf_NK8cMUs41gm8ZcfdtSguVw',
+  ...overrides,
+});
+
+describe('performDeviceLogin pending-state lifecycle', () => {
+  it('fresh login persists pending state, then clears it on success', async () => {
+    let firstPoll = true;
+    const calls = stubFetch({
+      deviceAuthorization: () =>
+        new Response(
+          JSON.stringify({
+            device_code: 'dvc_fresh',
+            user_code: 'MNPQ-RSTV',
+            verification_uri: 'https://insforge.dev/auth/device',
+            verification_uri_complete: 'https://insforge.dev/auth/device?user_code=MNPQ-RSTV',
+            expires_in: 900,
+            interval: 0.01,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      token: () => {
+        if (firstPoll) {
+          firstPoll = false;
+          // Pending state must exist WHILE polling (that's what a killed
+          // process leaves behind for the next run).
+          expect(config.getPendingDeviceLogin()?.device_code).toBe('dvc_fresh');
+          return oauthError('authorization_pending');
+        }
+        return tokens();
+      },
+    });
+
+    const creds = await auth.performDeviceLogin();
+    expect(creds.access_token).toBe('at');
+    expect(calls.deviceAuthorization).toBe(1);
+    expect(config.getPendingDeviceLogin()).toBeNull();
+  });
+
+  it('resumes a still-valid pending attempt: no new code minted, same device_code polled', async () => {
+    config.savePendingDeviceLogin(pendingFixture());
+
+    const polledCodes: string[] = [];
+    stubFetch({
+      // deviceAuthorization handler intentionally omitted — calling it fails the test
+      token: (body) => {
+        polledCodes.push(body.device_code);
+        return tokens();
+      },
+    });
+
+    const creds = await auth.performDeviceLogin();
+    expect(creds.access_token).toBe('at');
+    expect(polledCodes).toEqual(['dvc_previous']);
+    expect(config.getPendingDeviceLogin()).toBeNull();
+  });
+
+  it('ignores pending state that is nearly expired or from another server', async () => {
+    config.savePendingDeviceLogin(pendingFixture({ expires_at: new Date(Date.now() + 30_000).toISOString() }));
+
+    stubFetch({
+      deviceAuthorization: () =>
+        new Response(
+          JSON.stringify({
+            device_code: 'dvc_fresh2',
+            user_code: 'WXZB-CDFG',
+            verification_uri: 'https://insforge.dev/auth/device',
+            verification_uri_complete: 'https://insforge.dev/auth/device?user_code=WXZB-CDFG',
+            expires_in: 900,
+            interval: 0.01,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      token: () => tokens(),
+    });
+
+    await auth.performDeviceLogin();
+    // A fresh code replaced the nearly-expired one.
+    expect(config.getPendingDeviceLogin()).toBeNull();
+  });
+
+  it('clears pending state on denial so the next run starts fresh', async () => {
+    config.savePendingDeviceLogin(pendingFixture());
+    stubFetch({ token: () => oauthError('access_denied') });
+
+    await expect(auth.performDeviceLogin()).rejects.toThrow(/denied/i);
+    expect(config.getPendingDeviceLogin()).toBeNull();
+  });
+
+  it('keeps pending state on transient poll failure so a rerun can resume', async () => {
+    config.savePendingDeviceLogin(pendingFixture({ expires_at: new Date(Date.now() + 2 * 60 * 1000).toISOString() }));
+    stubFetch({ token: () => oauthError('server_error') });
+
+    await expect(auth.performDeviceLogin()).rejects.toThrow();
+    expect(config.getPendingDeviceLogin()?.device_code).toBe('dvc_previous');
+  });
+});

--- a/src/lib/auth.device.test.ts
+++ b/src/lib/auth.device.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requestDeviceAuthorization, pollForDeviceTokens } from './auth.js';
+
+const PLATFORM = 'https://api.example.dev';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('requestDeviceAuthorization', () => {
+  it('posts client_id + scope and returns the device authorization', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        device_code: 'dvc_abc',
+        user_code: 'BCDF-GHJK',
+        verification_uri: 'https://insforge.dev/auth/device',
+        verification_uri_complete: 'https://insforge.dev/auth/device?user_code=BCDF-GHJK',
+        expires_in: 900,
+        interval: 5,
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await requestDeviceAuthorization({
+      platformUrl: PLATFORM,
+      clientId: 'clf_test',
+      scopes: 'user:read',
+    });
+
+    expect(result.user_code).toBe('BCDF-GHJK');
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`${PLATFORM}/api/oauth/v1/device_authorization`);
+    expect(JSON.parse(init.body as string)).toEqual({ client_id: 'clf_test', scope: 'user:read' });
+  });
+
+  it('explains when the server does not support device login', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ error: 'unauthorized_client' }, 400)));
+
+    await expect(
+      requestDeviceAuthorization({ platformUrl: PLATFORM, clientId: 'clf_test', scopes: 's' })
+    ).rejects.toThrow(/not enabled/i);
+  });
+});
+
+describe('pollForDeviceTokens', () => {
+  const params = {
+    platformUrl: PLATFORM,
+    clientId: 'clf_test',
+    deviceCode: 'dvc_abc',
+    interval: 0.01,
+    expiresIn: 5,
+  };
+
+  it('keeps polling through authorization_pending, then returns tokens', async () => {
+    const responses = [
+      jsonResponse({ error: 'authorization_pending' }, 400),
+      jsonResponse({ error: 'authorization_pending' }, 400),
+      jsonResponse({ access_token: 'at', refresh_token: 'rt', expires_in: 3600 }),
+    ];
+    const fetchMock = vi.fn(async () => responses.shift()!);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tokens = await pollForDeviceTokens(params);
+    expect(tokens.access_token).toBe('at');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.grant_type).toBe('urn:ietf:params:oauth:grant-type:device_code');
+    expect(body.device_code).toBe('dvc_abc');
+  });
+
+  it('backs off on slow_down and still completes', async () => {
+    const responses = [
+      jsonResponse({ error: 'slow_down' }, 400),
+      jsonResponse({ access_token: 'at', refresh_token: 'rt', expires_in: 3600 }),
+    ];
+    vi.stubGlobal('fetch', vi.fn(async () => responses.shift()!));
+
+    // slow_down adds 5s; keep the test fast by capping expiresIn so failure
+    // would surface as an expiry error if backoff logic breaks the loop.
+    const tokens = await pollForDeviceTokens({ ...params, expiresIn: 30 });
+    expect(tokens.access_token).toBe('at');
+  }, 15_000);
+
+  it('stops with a clear error when the user denies', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ error: 'access_denied' }, 400)));
+    await expect(pollForDeviceTokens(params)).rejects.toThrow(/denied/i);
+  });
+
+  it('stops with a clear error when the code expires server-side', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ error: 'expired_token' }, 400)));
+    await expect(pollForDeviceTokens(params)).rejects.toThrow(/expired/i);
+  });
+
+  it('gives up at the local deadline if approval never happens', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ error: 'authorization_pending' }, 400)));
+    await expect(pollForDeviceTokens({ ...params, expiresIn: 0.05 })).rejects.toThrow(/expired/i);
+  });
+
+  it('survives transient network errors and keeps polling', async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new Error('ECONNRESET');
+        return jsonResponse({ access_token: 'at', refresh_token: 'rt', expires_in: 3600 });
+      })
+    );
+
+    const tokens = await pollForDeviceTokens(params);
+    expect(tokens.access_token).toBe('at');
+    expect(calls).toBe(2);
+  });
+});

--- a/src/lib/auth.device.test.ts
+++ b/src/lib/auth.device.test.ts
@@ -104,6 +104,28 @@ describe('pollForDeviceTokens', () => {
     await expect(pollForDeviceTokens({ ...params, expiresIn: 0.05 })).rejects.toThrow(/expired/i);
   });
 
+  it('defaults to a 5s interval when the server omits it (RFC 8628 §3.2)', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({ access_token: 'at', refresh_token: 'rt', expires_in: 3600 })
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const promise = pollForDeviceTokens({ ...params, interval: undefined });
+
+      // A missing interval must NOT collapse to a zero-delay hammer loop.
+      await vi.advanceTimersByTimeAsync(4900);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(200);
+      await expect(promise).resolves.toMatchObject({ access_token: 'at' });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('survives transient network errors and keeps polling', async () => {
     let calls = 0;
     vi.stubGlobal(

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -360,7 +360,10 @@ export async function pollForDeviceTokens(params: {
   let intervalMs = Math.max(params.interval, 1) * 1000;
 
   while (Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, intervalMs).unref?.());
+    // Deliberately NOT unref'd: this timer is often the only thing on the
+    // event loop (no callback server in this flow), and unref'ing it lets
+    // the process exit mid-poll with an unsettled top-level await.
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
     params.onPoll?.();
 
     let res: Response;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -328,7 +328,7 @@ export async function requestDeviceAuthorization(params: {
       body: JSON.stringify({ client_id: params.clientId, scope: params.scopes }),
     });
   } catch (err) {
-    throw new Error(formatFetchError(err, url), { cause: err });
+    throw new Error(`Device authorization failed — ${formatFetchError(err, url)}`, { cause: err });
   }
 
   if (!res.ok) {
@@ -351,20 +351,19 @@ export async function pollForDeviceTokens(params: {
   platformUrl: string;
   clientId: string;
   deviceCode: string;
-  interval: number;
+  /** RFC 8628 §3.2 makes this optional in the server response; defaults to 5s. */
+  interval?: number;
   expiresIn: number;
-  onPoll?: () => void;
 }): Promise<{ access_token: string; refresh_token: string; expires_in: number }> {
   const tokenUrl = `${params.platformUrl}/api/oauth/v1/token`;
   const deadline = Date.now() + params.expiresIn * 1000;
-  let intervalMs = Math.max(params.interval, 1) * 1000;
+  let intervalMs = Math.max(params.interval || 5, 1) * 1000;
 
   while (Date.now() < deadline) {
     // Deliberately NOT unref'd: this timer is often the only thing on the
     // event loop (no callback server in this flow), and unref'ing it lets
     // the process exit mid-poll with an unsettled top-level await.
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    params.onPoll?.();
 
     let res: Response;
     try {
@@ -441,7 +440,7 @@ export async function performDeviceLogin(apiUrl?: string): Promise<StoredCredent
   }
 
   const s = isInteractive ? clack.spinner() : null;
-  s?.start(`Waiting for approval in the browser (code ${device.user_code})...`);
+  s?.start(`Waiting for approval (code ${device.user_code})...`);
 
   try {
     const tokens = await pollForDeviceTokens({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,10 +4,17 @@ import { URL } from 'node:url';
 import * as clack from '@clack/prompts';
 import pc from 'picocolors';
 import { isInteractive } from './prompts.js';
-import { getGlobalConfig, getPlatformApiUrl, saveCredentials } from './config.js';
+import {
+  getGlobalConfig,
+  getPlatformApiUrl,
+  saveCredentials,
+  getPendingDeviceLogin,
+  savePendingDeviceLogin,
+  clearPendingDeviceLogin,
+} from './config.js';
 import { getProfile } from './api/platform.js';
 import { formatFetchError } from './errors.js';
-import type { StoredCredentials } from '../types.js';
+import type { PendingDeviceLogin, StoredCredentials } from '../types.js';
 
 // Default OAuth client for InsForge CLI (pre-registered on the platform)
 export const DEFAULT_CLIENT_ID = 'clf_NK8cMUs41gm8ZcfdtSguVw';
@@ -405,29 +412,69 @@ export async function pollForDeviceTokens(params: {
 }
 
 /**
- * Full device login: request codes, show the verification URL + user code,
- * poll until approved, store credentials.
+ * A prior `login --device` attempt that can still complete: same server and
+ * client, with a meaningful amount of its 15-minute lifetime left. Used to
+ * RESUME polling the same code after the process was killed mid-poll (agent
+ * sandboxes with command timeouts) — if the user already approved while no
+ * poller was alive, the resumed poll redeems immediately.
+ */
+function getResumableDeviceLogin(platformUrl: string, clientId: string): PendingDeviceLogin | null {
+  try {
+    const pending = getPendingDeviceLogin();
+    if (
+      pending &&
+      pending.platform_url === platformUrl &&
+      pending.client_id === clientId &&
+      new Date(pending.expires_at).getTime() - Date.now() > 60_000
+    ) {
+      return pending;
+    }
+  } catch {
+    /* corrupt file — fall through to a fresh attempt */
+  }
+  return null;
+}
+
+/**
+ * Full device login: request codes (or resume a still-valid pending attempt),
+ * show the verification URL + user code, poll until approved, store
+ * credentials.
  */
 export async function performDeviceLogin(apiUrl?: string): Promise<StoredCredentials> {
   const platformUrl = getPlatformApiUrl(apiUrl);
   const config = getGlobalConfig();
   const clientId = config.oauth_client_id ?? DEFAULT_CLIENT_ID;
 
-  const device = await requestDeviceAuthorization({
-    platformUrl,
-    clientId,
-    scopes: OAUTH_SCOPES,
-  });
+  const resumed = getResumableDeviceLogin(platformUrl, clientId);
+  const device = resumed ?? await (async () => {
+    const fresh = await requestDeviceAuthorization({
+      platformUrl,
+      clientId,
+      scopes: OAUTH_SCOPES,
+    });
+    const pending: PendingDeviceLogin = {
+      device_code: fresh.device_code,
+      user_code: fresh.user_code,
+      verification_uri_complete: fresh.verification_uri_complete,
+      interval: fresh.interval ?? 5,
+      expires_at: new Date(Date.now() + fresh.expires_in * 1000).toISOString(),
+      platform_url: platformUrl,
+      client_id: clientId,
+    };
+    savePendingDeviceLogin(pending);
+    return pending;
+  })();
 
+  const resumeNote = resumed ? ' (resuming the previous login attempt — same code)' : '';
   const instructions =
     `Open ${pc.cyan(pc.underline(device.verification_uri_complete))}\n` +
-    `and confirm this code: ${pc.bold(device.user_code)}`;
+    `and confirm this code: ${pc.bold(device.user_code)}${resumeNote}`;
 
   if (isInteractive) {
     clack.log.info(`To sign in:\n${instructions}`);
   } else {
     // Agent shells: stderr so JSON stdout stays clean, but agents and humans see it.
-    process.stderr.write(`\nTo sign in, ask the user to open:\n\n  ${device.verification_uri_complete}\n\nand confirm the code ${device.user_code}. Waiting for approval...\n`);
+    process.stderr.write(`\nTo sign in, ask the user to open:\n\n  ${device.verification_uri_complete}\n\nand confirm the code ${device.user_code}${resumeNote}. If they already approved, this completes immediately. Waiting for approval...\n`);
   }
 
   // Best-effort browser open — on a local machine this lands the user
@@ -448,8 +495,9 @@ export async function performDeviceLogin(apiUrl?: string): Promise<StoredCredent
       clientId,
       deviceCode: device.device_code,
       interval: device.interval,
-      expiresIn: device.expires_in,
+      expiresIn: Math.max((new Date(device.expires_at).getTime() - Date.now()) / 1000, 1),
     });
+    clearPendingDeviceLogin();
 
     const creds: StoredCredentials = {
       access_token: tokens.access_token,
@@ -471,6 +519,11 @@ export async function performDeviceLogin(apiUrl?: string): Promise<StoredCredent
 
     return creds;
   } catch (err) {
+    // Denied/expired codes are dead — a rerun must mint a fresh one. On
+    // transient failures keep the pending file so a rerun resumes this code.
+    if (err instanceof Error && /denied|expired/i.test(err.message)) {
+      clearPendingDeviceLogin();
+    }
     s?.stop('Authentication failed');
     if (!isInteractive) process.stderr.write('Authentication failed\n');
     throw err;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -292,3 +292,185 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
     throw err;
   }
 }
+
+// ============================================================================
+// Device Authorization Grant (RFC 8628) — `insforge login --device`
+//
+// For environments where the browser can never reach a loopback listener in
+// this process (agent sandboxes like the ChatGPT app, SSH, containers, CI).
+// No callback and nothing to paste: the user approves a short code on the
+// dashboard while this process polls the token endpoint over outbound HTTPS.
+// ============================================================================
+
+export interface DeviceAuthorization {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+const DEVICE_CODE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
+
+/** Request a device_code + user_code pair from the platform. */
+export async function requestDeviceAuthorization(params: {
+  platformUrl: string;
+  clientId: string;
+  scopes: string;
+}): Promise<DeviceAuthorization> {
+  const url = `${params.platformUrl}/api/oauth/v1/device_authorization`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: params.clientId, scope: params.scopes }),
+    });
+  } catch (err) {
+    throw new Error(formatFetchError(err, url), { cause: err });
+  }
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as { error?: string; message?: string };
+    if (err.error === 'unauthorized_client') {
+      throw new Error('Device login is not enabled for this OAuth client (server too old or grant not enabled). Use `insforge login` or `insforge login --user-api-key` instead.');
+    }
+    throw new Error(err.message ?? err.error ?? `Device authorization failed (HTTP ${res.status})`);
+  }
+
+  return await res.json() as DeviceAuthorization;
+}
+
+/**
+ * Poll the token endpoint until the user approves/denies or the code expires.
+ * Follows RFC 8628 §3.5: keep waiting on authorization_pending, add 5s on
+ * slow_down, stop on access_denied / expired_token.
+ */
+export async function pollForDeviceTokens(params: {
+  platformUrl: string;
+  clientId: string;
+  deviceCode: string;
+  interval: number;
+  expiresIn: number;
+  onPoll?: () => void;
+}): Promise<{ access_token: string; refresh_token: string; expires_in: number }> {
+  const tokenUrl = `${params.platformUrl}/api/oauth/v1/token`;
+  const deadline = Date.now() + params.expiresIn * 1000;
+  let intervalMs = Math.max(params.interval, 1) * 1000;
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs).unref?.());
+    params.onPoll?.();
+
+    let res: Response;
+    try {
+      res = await fetch(tokenUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: DEVICE_CODE_GRANT,
+          device_code: params.deviceCode,
+          client_id: params.clientId,
+        }),
+      });
+    } catch {
+      // Transient network error mid-poll — keep polling until the deadline.
+      continue;
+    }
+
+    if (res.ok) {
+      return await res.json() as { access_token: string; refresh_token: string; expires_in: number };
+    }
+
+    const err = await res.json().catch(() => ({})) as { error?: string };
+    switch (err.error) {
+      case 'authorization_pending':
+        continue;
+      case 'slow_down':
+        intervalMs += 5000;
+        continue;
+      case 'access_denied':
+        throw new Error('Login request was denied in the dashboard.');
+      case 'expired_token':
+        throw new Error('The device code expired before the login was approved. Run `insforge login --device` again.');
+      default:
+        throw new Error(err.error ?? `Token polling failed (HTTP ${res.status})`);
+    }
+  }
+
+  throw new Error('The device code expired before the login was approved. Run `insforge login --device` again.');
+}
+
+/**
+ * Full device login: request codes, show the verification URL + user code,
+ * poll until approved, store credentials.
+ */
+export async function performDeviceLogin(apiUrl?: string): Promise<StoredCredentials> {
+  const platformUrl = getPlatformApiUrl(apiUrl);
+  const config = getGlobalConfig();
+  const clientId = config.oauth_client_id ?? DEFAULT_CLIENT_ID;
+
+  const device = await requestDeviceAuthorization({
+    platformUrl,
+    clientId,
+    scopes: OAUTH_SCOPES,
+  });
+
+  const instructions =
+    `Open ${pc.cyan(pc.underline(device.verification_uri_complete))}\n` +
+    `and confirm this code: ${pc.bold(device.user_code)}`;
+
+  if (isInteractive) {
+    clack.log.info(`To sign in:\n${instructions}`);
+  } else {
+    // Agent shells: stderr so JSON stdout stays clean, but agents and humans see it.
+    process.stderr.write(`\nTo sign in, ask the user to open:\n\n  ${device.verification_uri_complete}\n\nand confirm the code ${device.user_code}. Waiting for approval...\n`);
+  }
+
+  // Best-effort browser open — on a local machine this lands the user
+  // directly on the confirm page; in a sandbox it silently fails.
+  try {
+    const open = (await import('open')).default;
+    await open(device.verification_uri_complete);
+  } catch {
+    /* URL is already printed */
+  }
+
+  const s = isInteractive ? clack.spinner() : null;
+  s?.start(`Waiting for approval in the browser (code ${device.user_code})...`);
+
+  try {
+    const tokens = await pollForDeviceTokens({
+      platformUrl,
+      clientId,
+      deviceCode: device.device_code,
+      interval: device.interval,
+      expiresIn: device.expires_in,
+    });
+
+    const creds: StoredCredentials = {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      user: { id: '', name: '', email: '', avatar_url: null, email_verified: true },
+    };
+    saveCredentials(creds);
+
+    try {
+      const profile = await getProfile(apiUrl);
+      creds.user = profile;
+      saveCredentials(creds);
+      s?.stop(`Authenticated as ${profile.email}`);
+      if (!isInteractive) process.stderr.write(`Authenticated as ${profile.email}\n`);
+    } catch {
+      s?.stop('Authenticated successfully');
+      if (!isInteractive) process.stderr.write('Authenticated successfully\n');
+    }
+
+    return creds;
+  } catch (err) {
+    s?.stop('Authentication failed');
+    if (!isInteractive) process.stderr.write('Authentication failed\n');
+    throw err;
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { GlobalConfig, ProjectConfig, StoredCredentials } from '../types.js';
+import type { GlobalConfig, PendingDeviceLogin, ProjectConfig, StoredCredentials } from '../types.js';
 
 const GLOBAL_DIR = join(homedir(), '.insforge');
 const CREDENTIALS_FILE = join(GLOBAL_DIR, 'credentials.json');
@@ -50,10 +50,33 @@ export function saveCredentials(creds: StoredCredentials): void {
   writeFileSync(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), { mode: 0o600 });
 }
 
+// --- Pending device login (login --device) ---
+
+const PENDING_DEVICE_FILE = join(GLOBAL_DIR, 'pending-device.json');
+
+export function getPendingDeviceLogin(): PendingDeviceLogin | null {
+  if (!existsSync(PENDING_DEVICE_FILE)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(PENDING_DEVICE_FILE, 'utf-8'));
+}
+
+export function savePendingDeviceLogin(pending: PendingDeviceLogin): void {
+  ensureGlobalDir();
+  writeFileSync(PENDING_DEVICE_FILE, JSON.stringify(pending, null, 2), { mode: 0o600 });
+}
+
+export function clearPendingDeviceLogin(): void {
+  if (existsSync(PENDING_DEVICE_FILE)) {
+    unlinkSync(PENDING_DEVICE_FILE);
+  }
+}
+
 export function clearCredentials(): void {
   if (existsSync(CREDENTIALS_FILE)) {
     unlinkSync(CREDENTIALS_FILE);
   }
+  clearPendingDeviceLogin();
   // Clear session-related config (default_org_id) but keep platform_api_url etc.
   const config = getGlobalConfig();
   if (config.default_org_id) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,24 @@ export interface StoredCredentials {
   user: User;
 }
 
+/**
+ * In-flight device login (`login --device`) persisted so a re-run can resume
+ * polling the SAME code instead of minting a new one — critical in agent
+ * sandboxes that may kill the polling process before the user approves (the
+ * approval still lands, and the re-run redeems it immediately). The
+ * device_code is the bearer secret for this attempt, so the file is 0600 and
+ * cleared on completion, denial, or expiry.
+ */
+export interface PendingDeviceLogin {
+  device_code: string;
+  user_code: string;
+  verification_uri_complete: string;
+  interval: number;
+  expires_at: string;
+  platform_url: string;
+  client_id: string;
+}
+
 // Global config
 export interface GlobalConfig {
   default_org_id?: string;


### PR DESCRIPTION
## Why

In sandboxed environments (ChatGPT app plugin, SSH, containers) browser login hangs forever: the OAuth redirect targets a loopback listener the host browser can never reach. The industry norm (gh, az, Codex `--device-auth`, Stripe, Railway) is a device/pairing flow — the user approves a short code in the browser and the CLI polls; nothing is pasted, no callback needed.

## What

`insforge login --device`:

1. Requests a `device_code` + `user_code` from `POST /oauth/v1/device_authorization`.
2. Prints (and best-effort opens) `insforge.dev/auth/device?user_code=XXXX-XXXX`; the user just clicks **Authorize**.
3. Polls the token endpoint per RFC 8628 §3.5 (`authorization_pending` → keep waiting, `slow_down` → +5s backoff, `access_denied`/`expired_token` → clear errors, transient network errors → keep polling, local deadline at `expires_in`).
4. Saves credentials exactly like the browser flow.

Default browser flow unchanged — on a normal desktop it remains the best UX; `--device` is for everywhere else. Telemetry method: `oauth_device`.

## Depends on

- InsForge/insforge-cloud-backend#733 (grant + endpoints) — **merge first**
- InsForge/insforge-cloud#590 (dashboard approve page)

Branched from main, independent of #198 (paste-back) so that PR can ship or be dropped freely.

## Verification

- 8 unit tests: request/poll state machine incl. slow_down backoff, denial, expiry (server + local deadline), transient network faults. Full suite + eslint + build clean.
- Smoke vs prod: fails fast with a clean error while the backend endpoint isn't deployed (no hang). Full e2e on staging once #733 lands; skill docs update follows the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcszudKMZBSm5RMP14h7fu

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--device` login option to the CLI using RFC 8628 device authorization flow
> - Adds a `--device` flag to the `login` command that triggers the OAuth 2.0 device authorization flow (RFC 8628), allowing login on devices without a browser.
> - `requestDeviceAuthorization` POSTs to `/api/oauth/v1/device_authorization` and returns a user code and verification URI; `pollForDeviceTokens` polls `/api/oauth/v1/token` with backoff and error handling for `slow_down`, `access_denied`, and `expired_token`.
> - `performDeviceLogin` orchestrates the full flow: displays the user code, attempts to open a browser, polls for tokens, saves credentials, and fetches the user profile.
> - Outputs an interactive spinner/outro in terminal mode or `{ success, user }` JSON when `--json` is passed; telemetry records `method: oauth_device`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #199 opened
>
> - Made `interval` parameter optional in `pollForDeviceTokens` with a default of 5 seconds [6f23cb7]
> - Removed `onPoll` callback parameter from `pollForDeviceTokens` [6f23cb7]
> - Updated user-facing error and status messages in device login flow [6f23cb7]
> - Implemented RFC 8628 device flow resume capability in `performDeviceLogin` function [7632f21]
> - Added persistence layer for pending device login state in `config` module and defined `PendingDeviceLogin` type [7632f21]
> - Added comprehensive test suite for device login resume behavior in `auth.device.resume.test.ts` [7632f21]
> - Bumped version from `0.1.100` to `0.2.0` in `package.json` [edf4407]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d02189b. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `insforge login --device` using the OAuth 2.0 device authorization flow (RFC 8628) for sandboxes, SSH, and containers where loopback browser login fails. Default browser login is unchanged; bumps `@insforge/cli` to 0.2.0.

- **New Features**
  - `insforge login --device` prints a verification URL with a short code, tries to open it in the browser, stores tokens, fetches the user profile, supports `--json`, and records telemetry `method: oauth_device`.
  - Polls `/api/oauth/v1/token` per RFC 8628: waits on `authorization_pending`, backs off `+5s` on `slow_down`, stops on `access_denied`/`expired_token`, tolerates transient network errors, respects `expires_in`, defaults to a 5s interval when omitted, and keeps the process alive during polling.
  - Resumable logins: persists in-flight state to `~/.insforge/pending-device.json` and resumes the same code on the next run if it’s for the same server/client and not near expiry; cleared on success/denial/expiry and on logout, retained on transient failures. Unit tests cover resume lifecycle in addition to interval, backoff, denial, expiry, and network faults.

- **Dependencies**
  - Requires backend support for device authorization and token endpoints, plus a dashboard approval page.
  - If the grant is not enabled, the CLI fails fast with a clear error.

<sup>Written for commit edf44079216fba271c4e4d5fea02dcdb54a4c892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--device` login support using a device authorization flow.
  * Displays a verification URL and code, with optional browser launch.
  * Automatically resumes pending device logins after interruptions.
  * Provides JSON success output for device-based authentication.

* **Bug Fixes**
  * Improved handling of login approval delays, denials, expiration, and transient connection failures.

* **Tests**
  * Added coverage for device authorization, polling, retries, resuming, and cleanup behavior.

* **Chores**
  * Updated the package version to `0.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->