### PR TITLE
feat(payments): add Razorpay webhook setup and secret rotation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,9 +665,25 @@ Create or recreate the InsForge-managed Stripe webhook endpoint for an environme
 npx @insforge/cli payments stripe webhooks configure --environment test
 ```
 
-#### Razorpay webhook setup
+#### `npx @insforge/cli payments razorpay webhooks setup --environment <environment>`
 
-Razorpay webhooks are configured manually in the Razorpay dashboard. Use the InsForge dashboard payments settings dialog to copy the webhook URL and webhook secret, then select the recommended events on Razorpay's website.
+Show the webhook URL and secret to use when manually creating the webhook in Razorpay Dashboard.
+
+```bash
+npx @insforge/cli payments razorpay webhooks setup --environment test
+npx @insforge/cli payments razorpay webhooks setup --environment live --json
+```
+
+#### `npx @insforge/cli payments razorpay webhooks rotate-secret --environment <environment>`
+
+Rotate the webhook secret for an environment. Existing Razorpay webhook deliveries fail until the new secret is updated in Razorpay Dashboard. The command asks for confirmation; use `--yes` to skip the prompt. JSON mode requires `--yes`.
+
+```bash
+npx @insforge/cli payments razorpay webhooks rotate-secret --environment test
+npx @insforge/cli payments razorpay webhooks rotate-secret --environment live --yes --json
+```
+
+Razorpay webhooks must still be created manually in Razorpay Dashboard. Copy the URL and secret returned by `webhooks setup`, select the recommended events, and save the webhook for the matching environment.
 
 #### `npx @insforge/cli payments <provider> catalog --environment <environment>`
 

--- a/src/commands/payments/index.ts
+++ b/src/commands/payments/index.ts
@@ -21,7 +21,7 @@ export function registerPaymentsCommands(paymentsCmd: Command): void {
   registerPaymentsStatusCommand(stripeCmd, "stripe");
   registerPaymentsConfigCommand(stripeCmd, "stripe");
   registerPaymentsSyncCommand(stripeCmd, "stripe");
-  registerPaymentsWebhooksCommand(stripeCmd);
+  registerPaymentsWebhooksCommand(stripeCmd, "stripe");
   registerPaymentsCatalogCommand(stripeCmd, "stripe");
   registerPaymentsCustomersCommand(stripeCmd, "stripe");
   registerPaymentsProductsCommand(stripeCmd);
@@ -35,6 +35,7 @@ export function registerPaymentsCommands(paymentsCmd: Command): void {
   registerPaymentsStatusCommand(razorpayCmd, "razorpay");
   registerPaymentsConfigCommand(razorpayCmd, "razorpay");
   registerPaymentsSyncCommand(razorpayCmd, "razorpay");
+  registerPaymentsWebhooksCommand(razorpayCmd, "razorpay");
   registerPaymentsCatalogCommand(razorpayCmd, "razorpay");
   registerPaymentsCustomersCommand(razorpayCmd, "razorpay");
   registerPaymentsItemsCommand(razorpayCmd);

--- a/src/commands/payments/webhooks.test.ts
+++ b/src/commands/payments/webhooks.test.ts
@@ -167,6 +167,7 @@ describe("payments webhooks commands", () => {
     );
 
     expect(apiMocks.rotateRazorpayWebhookSecret).not.toHaveBeenCalled();
+    expect(authMocks.requireAuth).not.toHaveBeenCalled();
     expect(telemetryMocks.trackPaymentUsage).toHaveBeenCalledWith(
       "webhooks.rotate-secret",
       false,

--- a/src/commands/payments/webhooks.test.ts
+++ b/src/commands/payments/webhooks.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+
+const apiMocks = vi.hoisted(() => ({
+  configureStripeWebhook: vi.fn(),
+  getRazorpayWebhookSetup: vi.fn(),
+  rotateRazorpayWebhookSecret: vi.fn(),
+}));
+const authMocks = vi.hoisted(() => ({ requireAuth: vi.fn() }));
+const promptMocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+}));
+const outputMocks = vi.hoisted(() => ({
+  outputInfo: vi.fn(),
+  outputJson: vi.fn(),
+  outputSuccess: vi.fn(),
+  outputTable: vi.fn(),
+}));
+const telemetryMocks = vi.hoisted(() => ({ trackPaymentUsage: vi.fn() }));
+const errorMocks = vi.hoisted(() => ({ handleError: vi.fn() }));
+
+vi.mock("../../lib/api/payments.js", () => apiMocks);
+vi.mock("../../lib/credentials.js", () => authMocks);
+vi.mock("../../lib/prompts.js", () => promptMocks);
+vi.mock("../../lib/output.js", () => outputMocks);
+vi.mock("../../lib/errors.js", async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  handleError: errorMocks.handleError,
+}));
+vi.mock("./utils.js", async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  trackPaymentUsage: telemetryMocks.trackPaymentUsage,
+}));
+
+import { registerPaymentsWebhooksCommand } from "./webhooks.js";
+
+const webhookSetup = {
+  connection: { environment: "test" },
+  webhookUrl: "https://example.com/webhooks/razorpay",
+  webhookSecret: "webhook_secret",
+};
+
+function makeProgram(provider: "stripe" | "razorpay"): Command {
+  const program = new Command().exitOverride();
+  program
+    .option("--json")
+    .option("--api-url <url>")
+    .option("-y, --yes");
+  registerPaymentsWebhooksCommand(program, provider);
+  return program;
+}
+
+describe("payments webhooks commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.requireAuth.mockResolvedValue({ accessToken: "token" });
+    apiMocks.configureStripeWebhook.mockResolvedValue({
+      connection: { environment: "test" },
+    });
+    apiMocks.getRazorpayWebhookSetup.mockResolvedValue(webhookSetup);
+    apiMocks.rotateRazorpayWebhookSecret.mockResolvedValue(webhookSetup);
+    promptMocks.confirm.mockResolvedValue(true);
+    promptMocks.isCancel.mockReturnValue(false);
+    telemetryMocks.trackPaymentUsage.mockResolvedValue(undefined);
+    errorMocks.handleError.mockImplementation((error: unknown) => {
+      throw error;
+    });
+  });
+
+  it("retrieves Razorpay webhook setup values", async () => {
+    const program = makeProgram("razorpay");
+
+    await program.parseAsync(
+      ["--json", "webhooks", "setup", "--environment", "test"],
+      { from: "user" },
+    );
+
+    expect(authMocks.requireAuth).toHaveBeenCalledWith(undefined);
+    expect(apiMocks.getRazorpayWebhookSetup).toHaveBeenCalledWith("test");
+    expect(outputMocks.outputJson).toHaveBeenCalledWith(webhookSetup);
+    expect(telemetryMocks.trackPaymentUsage).toHaveBeenCalledWith(
+      "webhooks.setup",
+      true,
+      { provider: "razorpay", environment: "test" },
+    );
+  });
+
+  it("rotates the Razorpay webhook secret with --yes", async () => {
+    const program = makeProgram("razorpay");
+
+    await program.parseAsync(
+      [
+        "--json",
+        "--yes",
+        "webhooks",
+        "rotate-secret",
+        "--environment",
+        "live",
+      ],
+      { from: "user" },
+    );
+
+    expect(promptMocks.confirm).not.toHaveBeenCalled();
+    expect(apiMocks.rotateRazorpayWebhookSecret).toHaveBeenCalledWith("live");
+    expect(outputMocks.outputJson).toHaveBeenCalledWith(webhookSetup);
+    expect(telemetryMocks.trackPaymentUsage).toHaveBeenCalledWith(
+      "webhooks.rotate-secret",
+      true,
+      { provider: "razorpay", environment: "live" },
+    );
+  });
+
+  it("prompts before rotating and prints the new setup values", async () => {
+    const program = makeProgram("razorpay");
+
+    await program.parseAsync(
+      ["webhooks", "rotate-secret", "--environment", "test"],
+      { from: "user" },
+    );
+
+    expect(promptMocks.confirm).toHaveBeenCalledWith({
+      message:
+        "Rotate the Razorpay test webhook secret? Existing webhook deliveries will fail until the new secret is updated in Razorpay Dashboard.",
+    });
+    expect(outputMocks.outputTable).toHaveBeenCalledWith(
+      ["Env", "Webhook URL", "Webhook Secret"],
+      [["test", webhookSetup.webhookUrl, webhookSetup.webhookSecret]],
+    );
+    expect(outputMocks.outputSuccess).toHaveBeenCalledWith(
+      "Razorpay test webhook secret rotated.",
+    );
+    expect(outputMocks.outputInfo).toHaveBeenCalledWith(
+      "Update the secret in Razorpay Dashboard before webhook deliveries resume.",
+    );
+  });
+
+  it("does not rotate when confirmation is declined", async () => {
+    promptMocks.confirm.mockResolvedValue(false);
+    const program = makeProgram("razorpay");
+
+    await program.parseAsync(
+      ["webhooks", "rotate-secret", "--environment", "test"],
+      { from: "user" },
+    );
+
+    expect(apiMocks.rotateRazorpayWebhookSecret).not.toHaveBeenCalled();
+    expect(outputMocks.outputInfo).toHaveBeenCalledWith("Cancelled.");
+  });
+
+  it("requires --yes for JSON secret rotation", async () => {
+    const program = makeProgram("razorpay");
+
+    await expect(
+      program.parseAsync(
+        [
+          "--json",
+          "webhooks",
+          "rotate-secret",
+          "--environment",
+          "test",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(
+      "Use --yes with --json to rotate the Razorpay webhook secret non-interactively.",
+    );
+
+    expect(apiMocks.rotateRazorpayWebhookSecret).not.toHaveBeenCalled();
+    expect(telemetryMocks.trackPaymentUsage).toHaveBeenCalledWith(
+      "webhooks.rotate-secret",
+      false,
+      { provider: "razorpay", environment: "test" },
+      expect.any(Error),
+    );
+  });
+
+  it("rejects invalid Razorpay environments before calling the API", async () => {
+    const program = makeProgram("razorpay");
+
+    await expect(
+      program.parseAsync(
+        ["--json", "webhooks", "setup", "--environment", "staging"],
+        { from: "user" },
+      ),
+    ).rejects.toThrow('Environment must be "test" or "live".');
+
+    expect(authMocks.requireAuth).not.toHaveBeenCalled();
+    expect(apiMocks.getRazorpayWebhookSetup).not.toHaveBeenCalled();
+  });
+
+  it("keeps the Stripe configure command unchanged", async () => {
+    const program = makeProgram("stripe");
+
+    await program.parseAsync(
+      ["--json", "webhooks", "configure", "--environment", "test"],
+      { from: "user" },
+    );
+
+    expect(apiMocks.configureStripeWebhook).toHaveBeenCalledWith("test");
+    expect(outputMocks.outputJson).toHaveBeenCalled();
+    expect(telemetryMocks.trackPaymentUsage).toHaveBeenCalledWith(
+      "webhooks.configure",
+      true,
+      { provider: "stripe", environment: "test" },
+    );
+  });
+});

--- a/src/commands/payments/webhooks.ts
+++ b/src/commands/payments/webhooks.ts
@@ -147,13 +147,14 @@ function registerRazorpayWebhookCommands(webhooksCmd: Command): void {
       const { json, yes, apiUrl } = getRootOpts(cmd);
       try {
         const environment = parseEnvironment(opts.environment);
-        await requireAuth(apiUrl);
 
         if (json && !yes) {
           throw new CLIError(
             "Use --yes with --json to rotate the Razorpay webhook secret non-interactively.",
           );
         }
+
+        await requireAuth(apiUrl);
 
         if (!yes) {
           const confirm = await prompts.confirm({

--- a/src/commands/payments/webhooks.ts
+++ b/src/commands/payments/webhooks.ts
@@ -1,15 +1,41 @@
 import type { Command } from "commander";
-import { configureStripeWebhook } from "../../lib/api/payments.js";
+import type {
+  GetRazorpayWebhookSetupResponse,
+  PaymentProvider,
+} from "@insforge/shared-schemas";
+import * as prompts from "../../lib/prompts.js";
+import {
+  configureStripeWebhook,
+  getRazorpayWebhookSetup,
+  rotateRazorpayWebhookSecret,
+} from "../../lib/api/payments.js";
 import { requireAuth } from "../../lib/credentials.js";
-import { getRootOpts, handleError } from "../../lib/errors.js";
-import { outputJson, outputSuccess, outputTable } from "../../lib/output.js";
+import { CLIError, getRootOpts, handleError } from "../../lib/errors.js";
+import {
+  outputInfo,
+  outputJson,
+  outputSuccess,
+  outputTable,
+} from "../../lib/output.js";
 import { formatDate, parseEnvironment, trackPaymentUsage } from "./utils.js";
 
-export function registerPaymentsWebhooksCommand(paymentsCmd: Command): void {
+export function registerPaymentsWebhooksCommand(
+  paymentsCmd: Command,
+  provider: PaymentProvider,
+): void {
+  const providerLabel = provider === "stripe" ? "Stripe" : "Razorpay";
   const webhooksCmd = paymentsCmd
     .command("webhooks")
-    .description("Manage Stripe webhooks");
+    .description(`Manage ${providerLabel} webhooks`);
 
+  if (provider === "stripe") {
+    registerStripeWebhookConfigureCommand(webhooksCmd);
+  } else {
+    registerRazorpayWebhookCommands(webhooksCmd);
+  }
+}
+
+function registerStripeWebhookConfigureCommand(webhooksCmd: Command): void {
   webhooksCmd
     .command("configure")
     .description("Create or recreate the managed Stripe webhook endpoint")
@@ -52,6 +78,115 @@ export function registerPaymentsWebhooksCommand(paymentsCmd: Command): void {
           false,
           {
             provider: "stripe",
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+}
+
+function outputRazorpayWebhookSetup(
+  data: GetRazorpayWebhookSetupResponse,
+): void {
+  outputTable(
+    ["Env", "Webhook URL", "Webhook Secret"],
+    [[data.connection.environment, data.webhookUrl, data.webhookSecret]],
+  );
+}
+
+function registerRazorpayWebhookCommands(webhooksCmd: Command): void {
+  webhooksCmd
+    .command("setup")
+    .description("Show the URL and secret for manual Razorpay webhook setup")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .action(async (opts, cmd) => {
+      const { json, apiUrl } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth(apiUrl);
+
+        const data = await getRazorpayWebhookSetup(environment);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputRazorpayWebhookSetup(data);
+        }
+
+        await trackPaymentUsage("webhooks.setup", true, {
+          provider: "razorpay",
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "webhooks.setup",
+          false,
+          {
+            provider: "razorpay",
+            environment: opts.environment,
+          },
+          err,
+        );
+        handleError(err, json);
+      }
+    });
+
+  webhooksCmd
+    .command("rotate-secret")
+    .description("Rotate the Razorpay webhook secret")
+    .requiredOption(
+      "--environment <environment>",
+      "Razorpay environment: test or live",
+    )
+    .action(async (opts, cmd) => {
+      const { json, yes, apiUrl } = getRootOpts(cmd);
+      try {
+        const environment = parseEnvironment(opts.environment);
+        await requireAuth(apiUrl);
+
+        if (json && !yes) {
+          throw new CLIError(
+            "Use --yes with --json to rotate the Razorpay webhook secret non-interactively.",
+          );
+        }
+
+        if (!yes) {
+          const confirm = await prompts.confirm({
+            message: `Rotate the Razorpay ${environment} webhook secret? Existing webhook deliveries will fail until the new secret is updated in Razorpay Dashboard.`,
+          });
+          if (prompts.isCancel(confirm) || !confirm) {
+            outputInfo("Cancelled.");
+            return;
+          }
+        }
+
+        const data = await rotateRazorpayWebhookSecret(environment);
+
+        if (json) {
+          outputJson(data);
+        } else {
+          outputRazorpayWebhookSetup(data);
+          outputSuccess(`Razorpay ${environment} webhook secret rotated.`);
+          outputInfo(
+            "Update the secret in Razorpay Dashboard before webhook deliveries resume.",
+          );
+        }
+
+        await trackPaymentUsage("webhooks.rotate-secret", true, {
+          provider: "razorpay",
+          environment,
+        });
+      } catch (err) {
+        await trackPaymentUsage(
+          "webhooks.rotate-secret",
+          false,
+          {
+            provider: "razorpay",
             environment: opts.environment,
           },
           err,

--- a/src/lib/api/payments.test.ts
+++ b/src/lib/api/payments.test.ts
@@ -9,11 +9,13 @@ import {
   createRazorpayItem,
   createRazorpayPlan,
   createStripePrice,
+  getRazorpayWebhookSetup,
   getStripeProduct,
   getStripePaymentsStatus,
   listPaymentTransactions,
   listRazorpayCatalog,
   listStripePrices,
+  rotateRazorpayWebhookSecret,
   syncRazorpayPayments,
   syncStripePayments,
   updateRazorpayItem,
@@ -59,6 +61,35 @@ describe("payments API client", () => {
     await listStripePrices("live", "prod_123");
     expect(ossFetchMock).toHaveBeenLastCalledWith(
       "/api/payments/stripe/live/catalog/prices?productId=prod_123",
+    );
+  });
+
+  it("builds Razorpay webhook setup and secret rotation paths", async () => {
+    const setup = {
+      connection: { environment: "test" },
+      webhookUrl: "https://example.com/webhooks/razorpay",
+      webhookSecret: "secret_test",
+    };
+    ossFetchMock.mockResolvedValueOnce(mockJsonResponse(setup));
+
+    await expect(getRazorpayWebhookSetup("test")).resolves.toEqual(setup);
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/razorpay/test/webhook",
+    );
+
+    const rotated = {
+      ...setup,
+      connection: { environment: "live" },
+      webhookSecret: "secret_live_rotated",
+    };
+    ossFetchMock.mockResolvedValueOnce(mockJsonResponse(rotated));
+
+    await expect(rotateRazorpayWebhookSecret("live")).resolves.toEqual(
+      rotated,
+    );
+    expect(ossFetchMock).toHaveBeenLastCalledWith(
+      "/api/payments/razorpay/live/webhook/rotate-secret",
+      { method: "POST" },
     );
   });
 

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -7,6 +7,7 @@ import type {
   CreateStripePriceBody,
   CreateStripeProductBody,
   DeleteStripeProductResponse,
+  GetRazorpayWebhookSetupResponse,
   GetRazorpayStatusResponse,
   GetStripePriceResponse,
   GetStripeProductResponse,
@@ -29,6 +30,7 @@ import type {
   MutateStripeProductResponse,
   PaymentEnvironment,
   PaymentProvider,
+  RegenerateRazorpayWebhookSecretResponse,
   SyncRazorpayPaymentsRequest,
   SyncRazorpayPaymentsResponse,
   SyncStripePaymentsRequest,
@@ -158,6 +160,31 @@ export async function configureStripeWebhook(
       {
         method: "POST",
       },
+    ),
+  );
+}
+
+export async function getRazorpayWebhookSetup(
+  environment: PaymentEnvironment,
+): Promise<GetRazorpayWebhookSetupResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath("razorpay", environment, "/webhook"),
+    ),
+  );
+}
+
+export async function rotateRazorpayWebhookSecret(
+  environment: PaymentEnvironment,
+): Promise<RegenerateRazorpayWebhookSecretResponse> {
+  return readJson(
+    await ossFetch(
+      withProviderEnvironmentPath(
+        "razorpay",
+        environment,
+        "/webhook/rotate-secret",
+      ),
+      { method: "POST" },
     ),
   );
 }

--- a/src/lib/guard/risk-registry.test.ts
+++ b/src/lib/guard/risk-registry.test.ts
@@ -129,6 +129,18 @@ describe('assess — command-path classification', () => {
     expect(assess(cmd('secrets delete', ['KEY'])).severity).toBe('high');
   });
 
+  it('flags Razorpay webhook secret rotation as high risk', () => {
+    const risk = assess({
+      path: 'payments razorpay webhooks rotate-secret',
+      args: [],
+      opts: { environment: 'live' },
+    });
+
+    expect(risk.severity).toBe('high');
+    expect(risk.kind).toBe('payments.razorpay_webhook.rotate_secret');
+    expect(risk.whatHappens).toContain('live');
+  });
+
   it('catches unregistered destructive verbs (defense in depth)', () => {
     const r = assess(cmd('widgets destroy', ['x']));
     expect(r.severity).toBe('high');

--- a/src/lib/guard/risk-registry.ts
+++ b/src/lib/guard/risk-registry.ts
@@ -317,6 +317,15 @@ const REGISTRY: Record<string, (ctx: OperationContext) => RiskAssessment> = {
     blastRadius: 'Clients still using the old key fail once the grace period ends.',
     risk: 'Update every consumer of the old key before the grace window closes.',
   }),
+
+  'payments razorpay webhooks rotate-secret': (ctx) => ({
+    severity: 'high',
+    kind: 'payments.razorpay_webhook.rotate_secret',
+    title: 'Rotate a Razorpay webhook secret',
+    whatHappens: `Replaces the Razorpay ${String(ctx.opts.environment ?? '?')} webhook secret immediately.`,
+    blastRadius: 'Existing Razorpay webhook deliveries fail until the new secret is configured in Razorpay Dashboard.',
+    risk: 'Update the matching Razorpay webhook immediately after rotation.',
+  }),
 };
 
 /**


### PR DESCRIPTION
Closes #185 

## Summary

  Adds CLI support for managing Razorpay webhook configuration:

  - insforge payments razorpay webhooks setup --environment <test|live>
  - insforge payments razorpay webhooks rotate-secret --environment <test|live>

  ## Changes

  - Added typed API clients for retrieving webhook setup values and rotating secrets.

  - Registered Razorpay webhook commands while preserving Stripe behavior.

  - Added table and JSON output containing the webhook URL and secret.
  - Added confirmation before rotation; --json rotation requires --yes.
  - Classified secret rotation as a high-risk operation in the CLI guard.

  - Added API, command, and guard regression tests.
  - Updated the README with usage examples and rotation guidance.

  Razorpay webhook creation remains manual in Razorpay Dashboard; the new commands expose and manage the InsForge-side URL and secret.

  ## Verification

  - 582 tests passed, 13 skipped.
  - ESLint passed with one unrelated pre-existing warning.
  - Production build passed.
  - Built CLI help exposes both new Razorpay commands.
  - Stripe webhook command behavior remains unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Razorpay webhook setup and secret rotation CLI commands
> - Adds two new CLI commands under `payments razorpay webhooks`: `setup` returns the webhook URL and secret for an environment; `rotate-secret` rotates the webhook secret with confirmation prompt or `--yes` flag.
> - Adds `getRazorpayWebhookSetup` and `rotateRazorpayWebhookSecret` API client functions hitting `/api/payments/razorpay/{env}/webhook` and `/api/payments/razorpay/{env}/webhook/rotate-secret`.
> - Registers `payments razorpay webhooks rotate-secret` as a high-severity operation in the risk registry, noting webhook failures until the new secret is updated in the Razorpay Dashboard.
> - Updates [README.md](https://github.com/InsForge/CLI/pull/200/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with CLI usage examples including JSON output and manual Razorpay Dashboard steps.
> - Risk: `--json` mode for `rotate-secret` requires `--yes`; omitting it throws a `CLIError` rather than prompting interactively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32e9501.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Razorpay webhook management commands for setup details and secret rotation.
  - Supports table and JSON output formats.
  - Secret rotation includes confirmation prompts and requires `--yes` for non-interactive JSON usage.
  - Added environment validation and clear cancellation/error handling.
  - Stripe webhook configuration remains supported.

- **Documentation**
  - Expanded CLI documentation with setup, rotation, examples, confirmation behavior, and dashboard guidance.

- **Safety**
  - Live secret rotations are identified as high-risk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Razorpay webhook setup and secret rotation to the payments CLI, so teams can view the InsForge webhook URL/secret and rotate the secret safely. Stripe webhook behavior is unchanged.

- **New Features**
  - Adds `payments razorpay webhooks setup` and `payments razorpay webhooks rotate-secret` (env: `test` or `live`).
  - Implements `GET /api/payments/razorpay/:env/webhook` and `POST /api/payments/razorpay/:env/webhook/rotate-secret`.
  - Supports table and `--json` output; `--json` rotation requires `--yes`.
  - Validates flags and environment before auth to fail fast (enforces `--json` + `--yes`, rejects invalid envs).
  - Marks rotation as high-risk in the guard; adds tests for API, commands, and guard.
  - Updates docs with examples and guidance.

- **Migration**
  - Create the webhook in Razorpay Dashboard using values from `npx @insforge/cli payments razorpay webhooks setup --environment <test|live>`.
  - To rotate: `npx @insforge/cli payments razorpay webhooks rotate-secret --environment <test|live> [--yes] [--json]`, then update the secret in Razorpay Dashboard immediately.

<sup>Written for commit 32e9501fa456d2307435a3435ab954a6de5066eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

