### PR TITLE
fix(branch): make `branch create` success mean the branch is usable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.1.99",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.1.99",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/src/commands/branch/create.test.ts
+++ b/src/commands/branch/create.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { Command } from 'commander';
 import { registerBranchCreateCommand } from './create.js';
+import { CLIError } from '../../lib/errors.js';
 
 vi.mock('../../lib/api/platform.js', () => ({
   createBranchApi: vi.fn(async (_parentId: string, body: { mode: string; name: string }) => ({
@@ -26,6 +27,7 @@ vi.mock('../../lib/api/platform.js', () => ({
     branch_metadata: { mode: 'full' },
   })),
   listBranchesApi: vi.fn(async () => []),
+  NETWORK_ERROR_CODE: 'NETWORK_ERROR',
 }));
 
 // The data-plane readiness probe. It MUST be mocked: unmocked it makes a real
@@ -334,7 +336,7 @@ describe('branch create', () => {
     });
     const { createBranchApi, listBranchesApi } = await import('../../lib/api/platform.js');
     (createBranchApi as Mock).mockRejectedValueOnce(
-      new Error('Connection to api.insforge.dev was reset.'),
+      new CLIError('Connection to api.insforge.dev was reset.', 1, 'NETWORK_ERROR'),
     );
     (listBranchesApi as Mock).mockResolvedValueOnce([
       {
@@ -368,7 +370,9 @@ describe('branch create', () => {
       org_id: 'o1',
     });
     const { createBranchApi, listBranchesApi } = await import('../../lib/api/platform.js');
-    (createBranchApi as Mock).mockRejectedValueOnce(new Error('boom'));
+    (createBranchApi as Mock).mockRejectedValueOnce(
+      new CLIError('Connection to api.insforge.dev was reset.', 1, 'NETWORK_ERROR'),
+    );
     (listBranchesApi as Mock).mockResolvedValueOnce([]);
     const program = new Command().exitOverride();
     program.option('--json').option('--api-url <url>').option('-y, --yes');
@@ -389,6 +393,137 @@ describe('branch create', () => {
       process.exit = origExit;
       process.stderr.write = origStderr;
     }
+    expect(exitCode).toBe(1);
+  });
+  it('does NOT adopt on an API rejection — a duplicate name is a refusal, not a lost response', async () => {
+    // Adopting here would switch the caller into a pre-existing branch with a
+    // different mode and different data. Only a transport failure is ambiguous.
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { createBranchApi, listBranchesApi } = await import('../../lib/api/platform.js');
+    (createBranchApi as Mock).mockRejectedValueOnce(
+      new CLIError("Branch name 'feat-x' already exists on this parent", 1),
+    );
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    let exitCode: number | undefined;
+    const origExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await program
+        .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+        .catch(() => {});
+    } finally {
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+    }
+    expect(listBranchesApi as Mock).not.toHaveBeenCalled();
+    expect(exitCode).toBe(1);
+  });
+
+  it('does NOT adopt a branch that predates the request', async () => {
+    // Same name, but it existed before we asked — so it is not ours.
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { createBranchApi, listBranchesApi } = await import('../../lib/api/platform.js');
+    (createBranchApi as Mock).mockRejectedValueOnce(
+      new CLIError('Connection to api.insforge.dev was reset.', 1, 'NETWORK_ERROR'),
+    );
+    (listBranchesApi as Mock).mockResolvedValueOnce([
+      {
+        id: 'someone-elses',
+        parent_project_id: 'p1',
+        organization_id: 'o1',
+        name: 'feat-x',
+        appkey: 'p1ky-old',
+        region: 'us-east',
+        branch_state: 'ready',
+        branch_created_at: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+        branch_metadata: { mode: 'full' },
+      },
+    ]);
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    let exitCode: number | undefined;
+    const origExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await program
+        .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+        .catch(() => {});
+    } finally {
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it('exits non-zero when the branch never serves, but still emits its identity first', async () => {
+    // The branch exists and is billing: automation must be able to find and
+    // delete it even though the command is failing.
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { probeBackendHealth } = await import('../../lib/api/oss.js');
+    (probeBackendHealth as Mock).mockResolvedValue({ reachable: false, status: null });
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = ((...args: unknown[]) => {
+      lines.push(args.join(' '));
+    }) as typeof console.log;
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    let exitCode: number | undefined;
+    const origExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    vi.useFakeTimers();
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    try {
+      const run = program
+        .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch', '--json'], {
+          from: 'user',
+        })
+        .catch(() => {});
+      await vi.runAllTimersAsync();
+      await run;
+    } finally {
+      vi.useRealTimers();
+      console.log = origLog;
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+    }
+    const payload = lines.join('\n');
+    expect(payload).toContain('branch-id');
+    expect(payload).toContain('"serving"');
+    expect(payload).toContain('false');
     expect(exitCode).toBe(1);
   });
 });

--- a/src/commands/branch/create.test.ts
+++ b/src/commands/branch/create.test.ts
@@ -70,6 +70,27 @@ vi.mock('@clack/prompts', () => ({
   spinner: () => spinnerMock,
 }));
 
+// Run `fn` with process.exit + stderr captured, and always restore them. Returns
+// the exit code fn triggered (undefined if it never exited). Timer/mock lifecycle
+// stays with the caller — this only owns the exit/stderr swap.
+async function withCapturedExit(fn: () => Promise<void>): Promise<number | undefined> {
+  let exitCode: number | undefined;
+  const origExit = process.exit;
+  const origStderr = process.stderr.write.bind(process.stderr);
+  process.exit = ((code?: number) => {
+    exitCode = code;
+    throw new Error('__exit__');
+  }) as typeof process.exit;
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.exit = origExit;
+    process.stderr.write = origStderr;
+  }
+  return exitCode;
+}
+
 describe('branch create', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -352,27 +373,20 @@ describe('branch create', () => {
       branch_metadata: { mode: 'schema-only' },
     });
     let exitCode: number | undefined;
-    const origExit = process.exit;
-    process.exit = ((code?: number) => {
-      exitCode = code;
-      throw new Error('__exit__');
-    }) as typeof process.exit;
-    const origStderr = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (() => true) as typeof process.stderr.write;
     vi.useFakeTimers();
     try {
-      const program = new Command().exitOverride();
-      program.option('--json').option('--api-url <url>').option('-y, --yes');
-      registerBranchCreateCommand(program);
-      const run = program
-        .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
-        .catch(() => {});
-      await vi.runAllTimersAsync();
-      await run;
+      exitCode = await withCapturedExit(async () => {
+        const program = new Command().exitOverride();
+        program.option('--json').option('--api-url <url>').option('-y, --yes');
+        registerBranchCreateCommand(program);
+        const run = program
+          .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+          .catch(() => {});
+        await vi.runAllTimersAsync();
+        await run;
+      });
     } finally {
       vi.useRealTimers();
-      process.exit = origExit;
-      process.stderr.write = origStderr;
       // Restore the shared 'ready' impl — clearAllMocks keeps implementations, so
       // leaving this 'creating' would make every later test poll the full budget.
       (getBranchApi as Mock).mockImplementation(originalImpl!);
@@ -415,6 +429,47 @@ describe('branch create', () => {
     expect(listBranchesApi as Mock).toHaveBeenCalledWith('p1', undefined);
     // The run continued instead of exiting as a failed creation.
     expect(String(spinnerMock.stop.mock.calls.at(-1)?.[0])).not.toContain('creation failed');
+  });
+
+  it('does NOT adopt a same-name branch created with a DIFFERENT mode', async () => {
+    // A collaborator's same-name branch landing in the skew window — at the same
+    // moment our own request loses its response leg — must not be adopted, or a
+    // default --switch would move local context onto their branch. Requiring a
+    // matching mode narrows that collision. (cubic P2, InsForge/CLI#201.)
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { createBranchApi, listBranchesApi } = await import('../../lib/api/platform.js');
+    (createBranchApi as Mock).mockRejectedValueOnce(
+      new CLIError('Connection to api.insforge.dev was reset.', 1, 'NETWORK_ERROR'),
+    );
+    // Same name, freshly created (inside the window), but the WRONG mode.
+    (listBranchesApi as Mock).mockResolvedValueOnce([
+      {
+        id: 'someone-elses-branch',
+        parent_project_id: 'p1',
+        organization_id: 'o1',
+        name: 'feat-x',
+        appkey: 'p1ky-x9p',
+        region: 'us-east',
+        branch_state: 'creating',
+        branch_created_at: new Date().toISOString(),
+        branch_metadata: { mode: 'full' },
+      },
+    ]);
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    const exitCode = await withCapturedExit(() =>
+      program
+        .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+        .catch(() => {})
+    );
+    // No adoption → the original transport error propagates → non-zero exit.
+    expect(exitCode).toBe(1);
   });
 
   it('rethrows the original error when nothing was actually created', async () => {

--- a/src/commands/branch/create.test.ts
+++ b/src/commands/branch/create.test.ts
@@ -25,6 +25,13 @@ vi.mock('../../lib/api/platform.js', () => ({
     branch_created_at: new Date().toISOString(),
     branch_metadata: { mode: 'full' },
   })),
+  listBranchesApi: vi.fn(async () => []),
+}));
+
+// The data-plane readiness probe. It MUST be mocked: unmocked it makes a real
+// request to a fake host and then polls for minutes.
+vi.mock('../../lib/api/oss.js', () => ({
+  probeBackendHealth: vi.fn(async () => ({ reachable: true, status: 200 })),
 }));
 
 vi.mock('../../lib/credentials.js', () => ({
@@ -32,6 +39,7 @@ vi.mock('../../lib/credentials.js', () => ({
 }));
 
 vi.mock('../../lib/config.js', () => ({
+  buildOssHost: (appkey: string, region: string) => `https://${appkey}.${region}.insforge.app`,
   getProjectConfig: vi.fn(),
   saveProjectConfig: vi.fn(),
   getLocalConfigDir: () => '/tmp/.insforge',
@@ -61,11 +69,16 @@ vi.mock('@clack/prompts', () => ({
 }));
 
 describe('branch create', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     spinnerMock.start.mockReset();
     spinnerMock.message.mockReset();
     spinnerMock.stop.mockReset();
+    // clearAllMocks clears CALLS but keeps implementations, so a test that made
+    // the branch unreachable would otherwise leave every later test polling for
+    // the full readiness budget.
+    const { probeBackendHealth } = await import('../../lib/api/oss.js');
+    (probeBackendHealth as Mock).mockResolvedValue({ reachable: true, status: 200 });
   });
 
   it('rejects when no project linked', async () => {
@@ -279,5 +292,103 @@ describe('branch create', () => {
     expect(runBranchSwitch).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'feat-x', json: false, silent: true }),
     );
+  });
+  it('does not report success while the branch host is not serving yet', async () => {
+    // 'ready' is a control-plane state. Reporting success on it alone is what
+    // makes the user's NEXT command fail against a host that resets.
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { probeBackendHealth } = await import('../../lib/api/oss.js');
+    (probeBackendHealth as Mock).mockResolvedValue({
+      reachable: false,
+      status: null,
+      detail: 'Connection to p1ky-x9p.us-east.insforge.app was reset.',
+    });
+    vi.useFakeTimers();
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    const run = program
+      .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+      .catch(() => {});
+    await vi.runAllTimersAsync();
+    await run;
+    vi.useRealTimers();
+    const stopped = spinnerMock.stop.mock.calls.at(-1);
+    expect(String(stopped?.[0])).toContain('not serving yet');
+    expect(stopped?.[1]).toBe(1);
+  });
+
+  it('adopts a branch that was created despite a transport failure', async () => {
+    // createBranchApi carries no idempotency key, so a reset on the RESPONSE
+    // leg leaves a real, billing branch behind. Giving up here orphans it.
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { createBranchApi, listBranchesApi } = await import('../../lib/api/platform.js');
+    (createBranchApi as Mock).mockRejectedValueOnce(
+      new Error('Connection to api.insforge.dev was reset.'),
+    );
+    (listBranchesApi as Mock).mockResolvedValueOnce([
+      {
+        id: 'branch-id',
+        parent_project_id: 'p1',
+        organization_id: 'o1',
+        name: 'feat-x',
+        appkey: 'p1ky-x9p',
+        region: 'us-east',
+        branch_state: 'creating',
+        branch_created_at: new Date().toISOString(),
+        branch_metadata: { mode: 'schema-only' },
+      },
+    ]);
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    await program
+      .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+      .catch(() => {});
+    expect(listBranchesApi as Mock).toHaveBeenCalledWith('p1', undefined);
+    // The run continued instead of exiting as a failed creation.
+    expect(String(spinnerMock.stop.mock.calls.at(-1)?.[0])).not.toContain('creation failed');
+  });
+
+  it('rethrows the original error when nothing was actually created', async () => {
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { createBranchApi, listBranchesApi } = await import('../../lib/api/platform.js');
+    (createBranchApi as Mock).mockRejectedValueOnce(new Error('boom'));
+    (listBranchesApi as Mock).mockResolvedValueOnce([]);
+    const program = new Command().exitOverride();
+    program.option('--json').option('--api-url <url>').option('-y, --yes');
+    registerBranchCreateCommand(program);
+    let exitCode: number | undefined;
+    const origExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await program
+        .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+        .catch(() => {});
+    } finally {
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+    }
+    expect(exitCode).toBe(1);
   });
 });

--- a/src/commands/branch/create.test.ts
+++ b/src/commands/branch/create.test.ts
@@ -325,6 +325,61 @@ describe('branch create', () => {
     expect(stopped?.[1]).toBe(1);
   });
 
+  it('exits non-zero when the branch never finishes provisioning', async () => {
+    // The sibling of "ready but not serving": if the branch is stuck in a
+    // non-terminal state past the poll budget it is equally unusable, so
+    // automation reading the exit code must not see success. (Review suggestion,
+    // InsForge/CLI#201.)
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'parent',
+      org_id: 'o1',
+    });
+    const { getBranchApi } = await import('../../lib/api/platform.js');
+    const originalImpl = (getBranchApi as Mock).getMockImplementation();
+    // Never reaches 'ready' — pollUntilReady exhausts its budget and returns the
+    // last 'creating' snapshot.
+    (getBranchApi as Mock).mockResolvedValue({
+      id: 'branch-id',
+      parent_project_id: 'p1',
+      organization_id: 'o1',
+      name: 'feat-x',
+      appkey: 'p1ky-x9p',
+      region: 'us-east',
+      branch_state: 'creating',
+      branch_created_at: new Date().toISOString(),
+      branch_metadata: { mode: 'schema-only' },
+    });
+    let exitCode: number | undefined;
+    const origExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    vi.useFakeTimers();
+    try {
+      const program = new Command().exitOverride();
+      program.option('--json').option('--api-url <url>').option('-y, --yes');
+      registerBranchCreateCommand(program);
+      const run = program
+        .parseAsync(['create', 'feat-x', '--mode', 'schema-only', '--no-switch'], { from: 'user' })
+        .catch(() => {});
+      await vi.runAllTimersAsync();
+      await run;
+    } finally {
+      vi.useRealTimers();
+      process.exit = origExit;
+      process.stderr.write = origStderr;
+      // Restore the shared 'ready' impl — clearAllMocks keeps implementations, so
+      // leaving this 'creating' would make every later test poll the full budget.
+      (getBranchApi as Mock).mockImplementation(originalImpl!);
+    }
+    expect(exitCode).toBe(1);
+  });
+
   it('adopts a branch that was created despite a transport failure', async () => {
     // createBranchApi carries no idempotency key, so a reset on the RESPONSE
     // leg leaves a real, billing branch behind. Giving up here orphans it.

--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -1,6 +1,11 @@
 import type { Command } from 'commander';
 import * as clack from '@clack/prompts';
-import { createBranchApi, getBranchApi, listBranchesApi } from '../../lib/api/platform.js';
+import {
+  createBranchApi,
+  getBranchApi,
+  listBranchesApi,
+  NETWORK_ERROR_CODE,
+} from '../../lib/api/platform.js';
 import { probeBackendHealth } from '../../lib/api/oss.js';
 import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
 import { requireAuth } from '../../lib/credentials.js';
@@ -21,6 +26,11 @@ const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
 // passes, every subsequent command against the branch fails.
 const HEALTH_TIMEOUT_MS = 10 * 60 * 1_000;
 const HEALTH_INTERVAL_MS = 5_000;
+// Tolerance for clock skew when deciding whether a branch is the one we just
+// asked for. Generous on purpose: the cost of being slightly wide is adopting a
+// branch someone created seconds ago under the same name; the cost of being too
+// narrow is orphaning a billing resource, which is the bug this exists to fix.
+const CREATED_AT_SKEW_MS = 60_000;
 
 export function registerBranchCreateCommand(branch: Command): void {
   branch
@@ -56,6 +66,10 @@ export function registerBranchCreateCommand(branch: Command): void {
         // ready })` below remains the sole authoritative output.
         const spinner = !json ? clack.spinner() : null;
         let ready: Branch;
+        // Whether the branch's own host answered. Separate from `provisioned`
+        // because the branch can be genuinely created and genuinely unusable,
+        // and the exit status has to reflect the second one.
+        let serving = false;
         // Tracks whether the branch reached `ready` state in the cloud — once
         // true, any later throw is a switch failure (local), not a creation
         // failure. Lets the catch render an accurate message instead of the
@@ -63,7 +77,13 @@ export function registerBranchCreateCommand(branch: Command): void {
         let provisioned = false;
         try {
           spinner?.start(`Creating branch '${name}'...`);
-          const created = await createBranchOrAdopt(project.project_id, { mode, name }, apiUrl);
+          const requestedAt = Date.now() - CREATED_AT_SKEW_MS;
+          const created = await createBranchOrAdopt(
+            project.project_id,
+            { mode, name },
+            apiUrl,
+            requestedAt,
+          );
           captureEvent(project.project_id, 'cli_branch_create', {
             mode,
             parent_project_id: project.project_id,
@@ -78,11 +98,8 @@ export function registerBranchCreateCommand(branch: Command): void {
           // runs — including the auto-switch below — hits a host that resets.
           if (provisioned) {
             spinner?.message('Branch ready. Waiting for it to start serving...');
-            const serving = await waitUntilServing(ready, spinner);
-            if (!serving) {
-              provisioned = false;
-              ready = { ...ready, branch_state: ready.branch_state };
-            }
+            serving = await waitUntilServing(ready, spinner);
+            if (!serving) provisioned = false;
           }
 
           if (provisioned && opts.switch) {
@@ -114,17 +131,35 @@ export function registerBranchCreateCommand(branch: Command): void {
           throw err;
         }
 
+        // Emit the branch identity BEFORE any failure is raised: the branch
+        // exists and is billing, so a caller must be able to find and delete it
+        // even when this command is about to exit non-zero.
         if (json) {
-          outputJson({ branch: ready });
-        } else if (ready.branch_state === 'ready') {
+          outputJson({ branch: ready, serving });
+        } else if (ready.branch_state === 'ready' && serving) {
           if (opts.switch) {
             outputInfo(
               '⚠ Re-source your dev server env (.env) to pick up the new INSFORGE_URL / ANON_KEY.',
             );
           }
+        } else if (ready.branch_state === 'ready') {
+          outputInfo(
+            `Branch '${name}' exists but its host is not serving yet. Run \`insforge branch list\` to check, or \`insforge branch delete ${name}\` to remove it.`,
+          );
         } else {
           outputInfo(
             `Branch '${name}' is still in '${ready.branch_state}' state. Run \`insforge branch list\` to check.`,
+          );
+        }
+
+        // Exit non-zero when the branch cannot be used. Reporting success here
+        // is what lets automation continue straight into a host that resets —
+        // the failure mode this whole change exists to remove.
+        if (ready.branch_state === 'ready' && !serving) {
+          throw new CLIError(
+            `Branch '${name}' was created but its host did not start serving within ${
+              Math.round(HEALTH_TIMEOUT_MS / 60_000)
+            } minutes.`,
           );
         }
       } catch (err) {
@@ -145,17 +180,38 @@ export function registerBranchCreateCommand(branch: Command): void {
  * anything exists — so the branch is silently orphaned. `branch list` is
  * authoritative here, and it is a control-plane call, so it still works while
  * the branch's own host is unreachable.
+ *
+ * Two guards keep this from adopting something it did not create — a duplicate
+ * name is a REJECTION, not a lost response, and adopting on it would switch the
+ * caller into someone else's branch with a different mode and different data:
+ *
+ *   1. only a tagged transport failure is eligible; every HTTP/API rejection
+ *      (duplicate name, quota, auth) rethrows untouched;
+ *   2. the branch must have been created at or after the moment we sent the
+ *      request, so a pre-existing same-name branch is never a candidate.
  */
+function isTransportFailure(err: unknown): boolean {
+  return err instanceof CLIError && err.code === NETWORK_ERROR_CODE;
+}
+
 async function createBranchOrAdopt(
   parentId: string,
   body: { mode: BranchMode; name: string },
   apiUrl: string | undefined,
+  requestedAt: number,
 ): Promise<Branch> {
   try {
     return await createBranchApi(parentId, body, apiUrl);
   } catch (err) {
+    if (!isTransportFailure(err)) throw err;
     const existing = await listBranchesApi(parentId, apiUrl)
-      .then(branches => branches.find(branch => branch.name === body.name))
+      .then(branches =>
+        branches.find(
+          branch =>
+            branch.name === body.name &&
+            Date.parse(branch.branch_created_at) >= requestedAt,
+        ),
+      )
       .catch(() => undefined);
     if (!existing) throw err;
     return existing;

--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -198,7 +198,18 @@ export function registerBranchCreateCommand(branch: Command): void {
  *   1. only a tagged transport failure is eligible; every HTTP/API rejection
  *      (duplicate name, quota, auth) rethrows untouched;
  *   2. the branch must have been created at or after the moment we sent the
- *      request, so a pre-existing same-name branch is never a candidate.
+ *      request, so a pre-existing same-name branch is never a candidate;
+ *   3. the branch's mode must match what we asked for.
+ *
+ * Guard 3 narrows a residual collision the timestamp window alone cannot close:
+ * a collaborator creating a same-name branch inside the skew window, at the same
+ * moment our own request loses its response leg, would otherwise be adoptable —
+ * and with the default `--switch` that would silently move local context onto
+ * their branch. Requiring a mode match makes that require an even more specific
+ * coincidence (same name AND same mode AND the same ~60s AND our transport
+ * failure). The real fix is a server-issued idempotency/request token on
+ * `createBranchApi`; until that exists, this is the tightest client-side guard.
+ * Reported upstream: InsForge/InsForge#1790.
  */
 function isTransportFailure(err: unknown): boolean {
   return err instanceof CLIError && err.code === NETWORK_ERROR_CODE;
@@ -219,6 +230,7 @@ async function createBranchOrAdopt(
         branches.find(
           branch =>
             branch.name === body.name &&
+            branch.branch_metadata?.mode === body.mode &&
             Date.parse(branch.branch_created_at) >= requestedAt,
         ),
       )

--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -154,8 +154,18 @@ export function registerBranchCreateCommand(branch: Command): void {
 
         // Exit non-zero when the branch cannot be used. Reporting success here
         // is what lets automation continue straight into a host that resets —
-        // the failure mode this whole change exists to remove.
-        if (ready.branch_state === 'ready' && !serving) {
+        // the failure mode this whole change exists to remove. Two outcomes are
+        // "not usable", and both must fail: the branch never finished
+        // provisioning (still non-'ready' after the poll budget), and the branch
+        // is 'ready' but its host never started serving.
+        if (ready.branch_state !== 'ready') {
+          throw new CLIError(
+            `Branch '${name}' was created but did not finish provisioning (still '${ready.branch_state}') within ${
+              Math.round(POLL_TIMEOUT_MS / 60_000)
+            } minutes.`,
+          );
+        }
+        if (!serving) {
           throw new CLIError(
             `Branch '${name}' was created but its host did not start serving within ${
               Math.round(HEALTH_TIMEOUT_MS / 60_000)

--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -1,16 +1,26 @@
 import type { Command } from 'commander';
 import * as clack from '@clack/prompts';
-import { createBranchApi, getBranchApi } from '../../lib/api/platform.js';
+import { createBranchApi, getBranchApi, listBranchesApi } from '../../lib/api/platform.js';
+import { probeBackendHealth } from '../../lib/api/oss.js';
 import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
 import { requireAuth } from '../../lib/credentials.js';
-import { getProjectConfig } from '../../lib/config.js';
+import { buildOssHost, getProjectConfig } from '../../lib/config.js';
 import { outputJson, outputInfo } from '../../lib/output.js';
 import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 import { runBranchSwitch } from './switch.js';
 import type { Branch, BranchMode } from '../../types.js';
 
 const POLL_INTERVAL_MS = 3_000;
-const POLL_TIMEOUT_MS = 5 * 60 * 1_000;
+// `branch_state` reaching 'ready' and the branch's own host answering are two
+// different events, and the gap between them has been measured in MINUTES
+// (2 min and 11.5 min on ap-southeast). A 5-minute ceiling reported the slower
+// one as "still creating" when it was simply not finished yet, so the budget
+// now covers the observed range with headroom.
+const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
+// Once the control plane says ready, wait for the data plane too. Until this
+// passes, every subsequent command against the branch fails.
+const HEALTH_TIMEOUT_MS = 10 * 60 * 1_000;
+const HEALTH_INTERVAL_MS = 5_000;
 
 export function registerBranchCreateCommand(branch: Command): void {
   branch
@@ -53,7 +63,7 @@ export function registerBranchCreateCommand(branch: Command): void {
         let provisioned = false;
         try {
           spinner?.start(`Creating branch '${name}'...`);
-          const created = await createBranchApi(project.project_id, { mode, name }, apiUrl);
+          const created = await createBranchOrAdopt(project.project_id, { mode, name }, apiUrl);
           captureEvent(project.project_id, 'cli_branch_create', {
             mode,
             parent_project_id: project.project_id,
@@ -61,6 +71,19 @@ export function registerBranchCreateCommand(branch: Command): void {
           spinner?.message(`Branch '${name}' created (appkey: ${created.appkey}). Provisioning...`);
           ready = await pollUntilReady(created.id, apiUrl, spinner);
           provisioned = ready.branch_state === 'ready';
+
+          // 'ready' is a control-plane state: it means the provisioning job
+          // returned, not that the branch answers. Confirm the data plane
+          // before reporting success, otherwise the very next command the user
+          // runs — including the auto-switch below — hits a host that resets.
+          if (provisioned) {
+            spinner?.message('Branch ready. Waiting for it to start serving...');
+            const serving = await waitUntilServing(ready, spinner);
+            if (!serving) {
+              provisioned = false;
+              ready = { ...ready, branch_state: ready.branch_state };
+            }
+          }
 
           if (provisioned && opts.switch) {
             spinner?.message('Branch ready. Switching context...');
@@ -71,6 +94,11 @@ export function registerBranchCreateCommand(branch: Command): void {
             spinner?.stop(`Branch '${name}' is ready and active`);
           } else if (provisioned) {
             spinner?.stop(`Branch '${name}' is ready`);
+          } else if (ready.branch_state === 'ready') {
+            spinner?.stop(
+              `Branch '${name}' reports ready but is not serving yet — retry your next command shortly`,
+              1,
+            );
           } else {
             spinner?.stop(`Branch '${name}' is in '${ready.branch_state}' state`);
           }
@@ -105,6 +133,59 @@ export function registerBranchCreateCommand(branch: Command): void {
         await shutdownAnalytics();
       }
     });
+}
+
+/**
+ * Create the branch, and if the request fails at the TRANSPORT layer, check
+ * whether it was created anyway before giving up.
+ *
+ * `createBranchApi` carries no idempotency key, and a reset on the RESPONSE leg
+ * leaves a fully created, billing branch behind while the CLI exits non-zero.
+ * The caller then has no id, no name in the output, and no reason to believe
+ * anything exists — so the branch is silently orphaned. `branch list` is
+ * authoritative here, and it is a control-plane call, so it still works while
+ * the branch's own host is unreachable.
+ */
+async function createBranchOrAdopt(
+  parentId: string,
+  body: { mode: BranchMode; name: string },
+  apiUrl: string | undefined,
+): Promise<Branch> {
+  try {
+    return await createBranchApi(parentId, body, apiUrl);
+  } catch (err) {
+    const existing = await listBranchesApi(parentId, apiUrl)
+      .then(branches => branches.find(branch => branch.name === body.name))
+      .catch(() => undefined);
+    if (!existing) throw err;
+    return existing;
+  }
+}
+
+/**
+ * Poll the branch's own host until it serves, so 'ready' means usable.
+ *
+ * Returns false rather than throwing when the budget runs out: the branch DOES
+ * exist and is billing, so the command must still report its name and id and
+ * must not look like a failed creation.
+ */
+async function waitUntilServing(
+  branch: Branch,
+  spinner: ReturnType<typeof clack.spinner> | null,
+): Promise<boolean> {
+  const baseUrl = buildOssHost(branch.appkey, branch.region);
+  const start = Date.now();
+  let announced = false;
+  while (Date.now() - start < HEALTH_TIMEOUT_MS) {
+    const health = await probeBackendHealth(baseUrl);
+    if (health.reachable) return true;
+    if (spinner && !announced) {
+      spinner.message(`Branch is provisioning its instance (${baseUrl} not answering yet)...`);
+      announced = true;
+    }
+    await new Promise(r => setTimeout(r, HEALTH_INTERVAL_MS));
+  }
+  return false;
 }
 
 async function pollUntilReady(

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -1,5 +1,5 @@
 import { getProjectConfig } from '../config.js';
-import { CLIError, ProjectNotLinkedError } from '../errors.js';
+import { CLIError, formatFetchError, ProjectNotLinkedError } from '../errors.js';
 import type {
   ProjectConfig,
   RotateKeyResponse,
@@ -226,4 +226,27 @@ export async function ossFetch(
   }
 
   return res;
+}
+
+/**
+ * Probe an InsForge backend's `/api/health` on an EXPLICIT base URL.
+ *
+ * Unlike `ossFetch`, this deliberately does not read the linked project: a
+ * freshly created branch is not linked yet, and the whole point is to ask
+ * whether ITS host is answering before we tell the user it is usable.
+ *
+ * Unauthenticated and non-throwing — callers poll it, so a connection reset
+ * while the instance boots is an expected answer ("not yet"), not an error.
+ */
+export async function probeBackendHealth(
+  baseUrl: string,
+  timeoutMs = 10_000,
+): Promise<{ reachable: boolean; status: number | null; detail?: string }> {
+  const url = `${baseUrl.replace(/\/$/, '')}/api/health`;
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    return { reachable: res.ok, status: res.status };
+  } catch (err) {
+    return { reachable: false, status: null, detail: formatFetchError(err, url) };
+  }
 }

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -1,10 +1,6 @@
 import { getAccessToken, getCredentials, getPlatformApiUrl } from '../config.js';
-import { AuthError, CLIError, formatFetchError } from '../errors.js';
-
-// Marks a CLIError that came from a failed fetch rather than an HTTP response:
-// the request may still have been received and acted on by the server.
-export const NETWORK_ERROR_CODE = 'NETWORK_ERROR';
 import { refreshAccessToken } from '../credentials.js';
+import { AuthError, CLIError, formatFetchError } from '../errors.js';
 import type {
   ApiKeyResponse,
   Backup,
@@ -33,6 +29,10 @@ import type {
   UpgradeInstanceResult,
   User,
 } from '../../types.js';
+
+// Marks a CLIError that came from a failed fetch rather than an HTTP response:
+// the request may still have been received and acted on by the server.
+export const NETWORK_ERROR_CODE = 'NETWORK_ERROR';
 
 export interface PlatformFetchOptions extends RequestInit {
   /**

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -1,5 +1,9 @@
 import { getAccessToken, getCredentials, getPlatformApiUrl } from '../config.js';
 import { AuthError, CLIError, formatFetchError } from '../errors.js';
+
+// Marks a CLIError that came from a failed fetch rather than an HTTP response:
+// the request may still have been received and acted on by the server.
+export const NETWORK_ERROR_CODE = 'NETWORK_ERROR';
 import { refreshAccessToken } from '../credentials.js';
 import type {
   ApiKeyResponse,
@@ -97,7 +101,7 @@ export async function platformFetch(
   try {
     res = await fetch(fullUrl, { ...fetchOptions, headers });
   } catch (err) {
-    throw new CLIError(formatFetchError(err, fullUrl));
+    throw new CLIError(formatFetchError(err, fullUrl), 1, NETWORK_ERROR_CODE);
   }
 
   // Auto-refresh on 401
@@ -108,7 +112,7 @@ export async function platformFetch(
     try {
       retryRes = await fetch(fullUrl, { ...fetchOptions, headers });
     } catch (err) {
-      throw new CLIError(formatFetchError(err, fullUrl));
+      throw new CLIError(formatFetchError(err, fullUrl), 1, NETWORK_ERROR_CODE);
     }
     if (passThroughStatuses?.includes(retryRes.status)) {
       return retryRes;


### PR DESCRIPTION
Follow-up to [InsForge/InsForge#1790](https://github.com/InsForge/InsForge/issues/1790), fixing the half of it that lives in this repo. The root cause of the readiness gap is cloud-side, but the CLI is where it becomes a broken user experience, and all three of these are fixable here.

Found while automating branch creation on `ap-southeast`. Every measurement below is from real branches, all of which were deleted afterwards.

## 1. `ready` is a control-plane state, not readiness

`pollUntilReady` returns the moment `branch_state === 'ready'` and never contacts the branch's own host. But `branch_state` flips when the provisioning job returns, while the instance is still coming up — every request to `https://<appkey>.<region>.insforge.app` resets until it does.

**Measured: the host started serving at t+2m in one case and t+11.5m in another, with `branch_state` reading `ready` the whole time.**

Because `create` then auto-switches the directory onto that host, the failure surfaces on the user's *next* command rather than here:

```
$ insforge db query "select 1"
{"error":"fetch failed","code":"UNKNOWN_ERROR"}
```

Now: once the control plane says ready, poll `GET /api/health` on the branch itself until it answers, and say so in the spinner. If it never answers within the budget, the command reports that honestly instead of claiming success — the branch's name and id are still printed, because it is real and it is billing.

## 2. The 5-minute poll ceiling was below the observed provisioning time

`POLL_TIMEOUT_MS` was 5 minutes, so the 11.5-minute branch was reported as *"still in 'creating' state"* when it was simply not finished yet. Raised to 15, with a separate 10-minute budget for the data-plane wait.

## 3. A failed `create` can leave a live branch behind

`createBranchApi` carries no idempotency key. A transport failure on the **response** leg — the POST arrived and the branch was created — throws before `created` is bound, so the CLI exits non-zero with no id and no name while a branch exists and bills. We hit exactly this:

```
$ insforge branch create <name> --mode schema-only --no-switch
{"error":"Connection to api.insforge.dev was reset. A proxy, VPN, or firewall may be interfering."}
# exit 1
$ insforge branch list
# the branch is there, branch_state "creating"
```

It then refused `delete` for about five minutes with `"Branch is currently busy (creating or merging)."` before the state flipped and the delete succeeded.

Now: on a create failure, ask `branch list` — a control-plane call, so it still works while the branch's own host is unreachable — whether a branch exists under that name, and adopt it if so. The original error is rethrown unchanged when nothing was created.

## Also

`ossFetch` called `fetch` unguarded, unlike `platformFetch`, so a dead data plane surfaced as the generic `UNKNOWN_ERROR` instead of naming the host. The new `probeBackendHealth` routes its errors through `formatFetchError`, so `Connection to <host> was reset` is what a caller sees. That one line cost us a lot of triage time.

## Notes for review

- **New tests** cover the not-serving path, the adopt path, and that a genuine failure with nothing created still exits non-zero.
- **The existing create tests needed a mock** for the new probe: unmocked, it makes a real request to a fake host and then polls. `beforeEach` resets it explicitly, because `clearAllMocks` keeps implementations and an unreachable branch would otherwise leak into every later test.
- `npm run build` passes; `vitest` passes for everything I touched. Four unrelated failures (`flyctl` ×3, `migrations` ×1) reproduce on a clean `main` on this machine (Windows) and are untouched by this change.
- **Behaviour change worth calling out:** a branch that reports `ready` but never serves now stops the spinner with an error frame instead of a success line. That seemed right — it is the case where continuing would break the user's next command — but say the word if you would rather it warn and exit 0.

## Agent skills

`insforge-cli/references/branch/overview.md` says a branch takes 30–120s and that `ready` means *"usable — can be switched, modified, merged, or reset"*, and its post-create checklist goes straight to `functions deploy`. Both look worth updating in `InsForge/agent-skills` once you have confirmed the timing on your side — happy to open that PR alongside this one.

## Open question this does not answer

Is there a branch-scoped signal that reflects the branch's own data plane rather than the provisioning job — or would you accept `waitForCompletion=true` on `POST /projects/v1/{id}/branches`, matching the convention already used by `projects restart` and `backups create`? `/api/health` is the best thing available to a client today, but it is a static handler that never touches Postgres, so it proves the process is listening rather than that the branch is usable. If a better signal exists or is planned, this polling should key off that instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `branch create` report success only when the branch is actually usable. It now waits for the branch host to serve, fails on stuck provisioning, and adopts an existing branch only in safe, verified cases after transport errors.

- **Bug Fixes**
  - Wait for the data plane: after control‑plane `ready`, poll the branch host’s `/api/health`; include `serving` in `--json`, print the branch identity first, and exit non‑zero if not serving within 10 min.
  - Honest exit on stuck provisioning: exit non‑zero if the branch never reaches `ready` within the 15‑minute poll budget.
  - Longer budgets: control‑plane poll raised to 15 min; health probe every 5s with a 10‑min cap.
  - Safe adoption on transport failures: only adopt after a tagged network error (`NETWORK_ERROR_CODE`), only if a same‑name branch was created at/after the request time (60s skew) and with a matching mode. Never adopt on API rejections (e.g., duplicate name) or pre‑existing branches.
  - Clearer connectivity errors: new `probeBackendHealth` routes through `formatFetchError`, so messages name the branch host.

<sup>Written for commit ea18b8122e2897b91cd6dd7a660a65fe4705902c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `branch create` by adopting a matching existing branch when failures are due to transient connection issues.
  * Added stricter readiness checks: the CLI now confirms the branch host is actually reachable before reporting success or switching.
  * Updated outcomes and messaging when the branch is “ready” but not yet serving, including correct non-zero exit behavior for timeout/failed provisioning.
  * Preserved original failures when adoption isn’t applicable (e.g., duplicate-name rejections or no existing branch found).
* **Tests**
  * Expanded coverage for edge cases around provisioning/adoption and serving reachability timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `branch create` to only report success when the branch is ready and serving
> - Adds a `waitUntilServing` step after provisioning completes: polls `/api/health` on the branch host every 5 seconds for up to 10 minutes before reporting success.
> - Increases the provisioning poll timeout from 5 to 15 minutes and exits non-zero if the branch never becomes ready or never starts serving.
> - Introduces `createBranchOrAdopt`: on a transport-layer failure during creation, lists branches and adopts a matching one (by name, mode, and `created_at`) instead of failing immediately.
> - Tags fetch-level errors with `NETWORK_ERROR_CODE` in `platformFetch` so callers can distinguish transport failures from HTTP errors.
> - In JSON mode, emits branch identity before raising any failure so callers still get the branch reference on non-zero exit.
> - Behavioral Change: `branch create` now exits non-zero if the branch provisions but never serves within the health timeout, where previously it would exit zero after provisioning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea18b81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->