### PR TITLE
Fix : --forger terminal size guard, stdin TTY check, and subcommand enforcement  

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ All commands support the following flags:
 | `--json`            | Output in JSON format (useful for scripts and AI agents) |
 | `--api-url <url>`   | Override the Platform API URL                            |
 | `-y, --yes`         | Skip confirmation prompts                                |
-| `--forger`          | Play the Insforge forger animation              |
+| `--forger`          | Play the Forger animation (root command only: `insforge --forger`) |
+
+`--forger` cannot be combined with a subcommand (e.g. `insforge login --forger` errors).
 
 The `--project-id <id>` flag is command-specific and is supported by `link`
 when you want to link a directory directly to a known project.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npx @insforge/cli logout
 
 ## Global Options
 
-All commands support the following flags:
+Global flags (available on all commands unless noted otherwise):
 
 | Flag                | Description                                              |
 | ------------------- | -------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Global flags (available on all commands unless noted otherwise):
 | `-y, --yes`         | Skip confirmation prompts                                |
 | `--forger`          | Play the Forger animation (root command only: `insforge --forger`) |
 
-`--forger` cannot be combined with a subcommand (e.g. `insforge login --forger` errors).
+`--forger` is ignored with a warning when combined with a subcommand (e.g. `insforge login --forger`).
 
 The `--project-id <id>` flag is command-specific and is supported by `link`
 when you want to link a directory directly to a known project.

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ program
   .option('--flag-destructive [reason]', 'Agent: flag this op as destructive for human approval even if InsForge\'s rules consider it safe (escalate-only — cannot downgrade the verdict)');
 
 program.hook('preAction', async (_thisCommand, actionCommand) => {
-  if (!process.stdout.isTTY || didPlayForgerAnimation) return;
+  if (!prompts.isInteractive || didPlayForgerAnimation) return;
   if (actionCommand !== program) return;
 
   const opts = actionCommand.optsWithGlobals() as { forger?: boolean };
@@ -292,8 +292,7 @@ registerSchedulesLogsCommand(schedulesCmd);
 registerConfigCommand(program);
 
 program.action(async (options: { forger?: boolean; json?: boolean }) => {
-  const isInteractive = process.stdout.isTTY;
-  if (isInteractive) {
+  if (prompts.isInteractive) {
     await showInteractiveMenu();
   } else if (options.forger) {
     const message = 'The --forger animation requires an interactive terminal. Run insforge in a TTY or omit --forger.';

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ program
 // Global options
 program
   .option('--json', 'Output in JSON format')
-  .option('--forger', 'Play the Forger animation and return to the interactive menu')
+  .option('--forger', 'Play the Forger animation (root command only) and return to the interactive menu')
   .option('--api-url <url>', 'Override Platform API URL')
   .option('-y, --yes', 'Skip confirmation prompts')
   .option('--reason <text>', 'Agent: what the operation does and why (intent) — shown to the human approver for destructive operations')
@@ -124,11 +124,24 @@ program
   .option('--flag-destructive [reason]', 'Agent: flag this op as destructive for human approval even if InsForge\'s rules consider it safe (escalate-only — cannot downgrade the verdict)');
 
 program.hook('preAction', async (_thisCommand, actionCommand) => {
-  if (!prompts.isInteractive || didPlayForgerAnimation) return;
-  if (actionCommand !== program) return;
+  if (didPlayForgerAnimation) return;
 
-  const opts = actionCommand.optsWithGlobals() as { forger?: boolean };
+  const opts = actionCommand.optsWithGlobals() as { forger?: boolean; json?: boolean };
   if (!opts.forger) return;
+
+  // --forger is root-only: reject `insforge <subcommand> --forger` in every context
+  // (TTY, piped, CI) instead of silently dropping the flag.
+  if (actionCommand !== program) {
+    const message = 'Error: --forger can only be used without a subcommand.';
+    if (opts.json) {
+      outputJson({ error: message });
+    } else {
+      console.error(message);
+    }
+    process.exit(1);
+  }
+
+  if (!prompts.isInteractive) return;
 
   didPlayForgerAnimation = true;
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,11 +132,12 @@ program.hook('preAction', async (_thisCommand, actionCommand) => {
   // --forger is root-only: reject `insforge <subcommand> --forger` in every context
   // (TTY, piped, CI) instead of silently dropping the flag.
   if (actionCommand !== program) {
-    const message = 'Error: --forger can only be used without a subcommand.';
+    const jsonMessage = 'Error: --forger can only be used without a subcommand.';
+    const humanMessage = `Error: ${jsonMessage}`;
     if (opts.json) {
-      outputJson({ error: message });
+      outputJson({ error: jsonMessage });
     } else {
-      console.error(message);
+      console.error(humanMessage);
     }
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ program.hook('preAction', async (_thisCommand, actionCommand) => {
   // --forger is root-only: reject `insforge <subcommand> --forger` in every context
   // (TTY, piped, CI) instead of silently dropping the flag.
   if (actionCommand !== program) {
-    const jsonMessage = 'Error: --forger can only be used without a subcommand.';
+    const jsonMessage = '--forger can only be used without a subcommand.';
     const humanMessage = `Error: ${jsonMessage}`;
     if (opts.json) {
       outputJson({ error: jsonMessage });

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,20 +126,14 @@ program
 program.hook('preAction', async (_thisCommand, actionCommand) => {
   if (didPlayForgerAnimation) return;
 
-  const opts = actionCommand.optsWithGlobals() as { forger?: boolean; json?: boolean };
+  const opts = actionCommand.optsWithGlobals() as { forger?: boolean };
   if (!opts.forger) return;
 
-  // --forger is root-only: reject `insforge <subcommand> --forger` in every context
-  // (TTY, piped, CI) instead of silently dropping the flag.
+  // --forger only plays on the root command. With a subcommand, warn and continue
+  // so wrappers/CI that forward global flags are not hard-failed.
   if (actionCommand !== program) {
-    const jsonMessage = '--forger can only be used without a subcommand.';
-    const humanMessage = `Error: ${jsonMessage}`;
-    if (opts.json) {
-      outputJson({ error: jsonMessage });
-    } else {
-      console.error(humanMessage);
-    }
-    process.exit(1);
+    console.error('Warning: --forger is ignored with a subcommand. Use `insforge --forger` alone.');
+    return;
   }
 
   if (!prompts.isInteractive) return;

--- a/src/lib/forger.ts
+++ b/src/lib/forger.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { isInteractive } from './prompts.js';
 
 const HIDE_CURSOR = '\x1b[?25l';
 const SHOW_CURSOR = '\x1b[?25h';
@@ -89,7 +90,7 @@ function buildFrameLines(
 }
 
 export async function playForgerAnimation(): Promise<void> {
-  if (!process.stdout.isTTY) return;
+  if (!isInteractive) return;
 
   const cols = process.stdout.columns ?? 0;
   const rows = process.stdout.rows ?? 0;

--- a/src/lib/forger.ts
+++ b/src/lib/forger.ts
@@ -94,7 +94,9 @@ export async function playForgerAnimation(): Promise<void> {
 
   const cols = process.stdout.columns ?? 0;
   const rows = process.stdout.rows ?? 0;
-  if ((cols > 0 && cols < MIN_TERMINAL_COLUMNS) || (rows > 0 && rows < MIN_TERMINAL_ROWS)) {
+  // Unknown size (0) can happen in pseudo-TTYs where isTTY is true but
+  // dimensions are absent — skip rather than risk mid-frame wrapping.
+  if (cols === 0 || rows === 0 || cols < MIN_TERMINAL_COLUMNS || rows < MIN_TERMINAL_ROWS) {
     process.stdout.write(
       `Skipping Forger animation: terminal must be at least ${MIN_TERMINAL_COLUMNS}x${MIN_TERMINAL_ROWS}.\n`,
     );

--- a/src/lib/forger.ts
+++ b/src/lib/forger.ts
@@ -8,6 +8,9 @@ const CURSOR_HOME = '\x1b[H';
 const CLEAR_SCREEN = '\x1b[2J';
 const RESET = '\x1b[0m';
 const FORGER_ASSET_URL = new URL('./assets/forger.json', import.meta.url);
+/** Minimum terminal size that renders the animation cleanly. */
+const MIN_TERMINAL_COLUMNS = 80;
+const MIN_TERMINAL_ROWS = 14;
 
 type Frame = {
   duration?: number;
@@ -87,6 +90,15 @@ function buildFrameLines(
 
 export async function playForgerAnimation(): Promise<void> {
   if (!process.stdout.isTTY) return;
+
+  const cols = process.stdout.columns ?? 0;
+  const rows = process.stdout.rows ?? 0;
+  if ((cols > 0 && cols < MIN_TERMINAL_COLUMNS) || (rows > 0 && rows < MIN_TERMINAL_ROWS)) {
+    process.stdout.write(
+      `Please resize the terminal to at least ${MIN_TERMINAL_COLUMNS}x${MIN_TERMINAL_ROWS}.\n`,
+    );
+    return;
+  }
 
   const animation = JSON.parse(readFileSync(FORGER_ASSET_URL, 'utf-8')) as AnimationFile;
   const width = animation.canvas.width;

--- a/src/lib/forger.ts
+++ b/src/lib/forger.ts
@@ -96,7 +96,7 @@ export async function playForgerAnimation(): Promise<void> {
   const rows = process.stdout.rows ?? 0;
   if ((cols > 0 && cols < MIN_TERMINAL_COLUMNS) || (rows > 0 && rows < MIN_TERMINAL_ROWS)) {
     process.stdout.write(
-      `Please resize the terminal to at least ${MIN_TERMINAL_COLUMNS}x${MIN_TERMINAL_ROWS}.\n`,
+      `Skipping Forger animation: terminal must be at least ${MIN_TERMINAL_COLUMNS}x${MIN_TERMINAL_ROWS}.\n`,
     );
     return;
   }


### PR DESCRIPTION
Closes #204 
### Branch frgr-fixing addresses the three --forger issues through four commits (README.md, index.ts, index.ts, forger.ts):   
                                                                                                                            
 -  Root-Only Command Restriction (index.ts):                                                                              
      • Explicitly checks actionCommand !== program when --forger is passed.                                                
      • If passed to any subcommand (e.g. insforge login --forger), it prints --forger can only be used without a    
         subcommand. (formatted as JSON if --json is active) and exits immediately with code 1.                                
  -  Interactive TTY Enforcement (index.ts & forger.ts):                                                                    
      • Replaced single process.stdout.isTTY checks with prompts.isInteractive (which validates that both stdin and stdout  
      are interactive TTY streams).                                                                                         
  - Terminal Size Fallback Guard (forger.ts):                                                                              
      • Added boundaries MIN_TERMINAL_COLUMNS = 80 and MIN_TERMINAL_ROWS = 14.                                              
      • If the window size is smaller than 80×14, playForgerAnimation() outputs Skipping Forger animation: terminal must be at least      
         80x14.\n without entering alternate screen mode, avoiding screen garbling while allowing the CLI interactive menu to  
         load safely.                                                                                                          
  - Documentation (README.md):                                                                                             
      • Updated the --forger option description and added clear notes indicating --forger is a root-only flag.     

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `--forger` safer by ignoring it with a warning on subcommands, requiring an interactive TTY, and skipping the animation on small or unknown-size terminals to prevent garbled output.

- **Bug Fixes**
  - Root-only behavior: when used with a subcommand, print a warning and continue; the flag is ignored (no exit).
  - Interactivity: use `prompts.isInteractive` to ensure both stdin and stdout are TTY before running the animation or menu.
  - Terminal size guard: require at least 80x14; if columns/rows are 0 or below minimum, skip with a clear message without switching screens.

<sup>Written for commit ce3bcebbafa386f50f719d34b22c9fa61fe93986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Forger animation now runs only for interactive sessions and is skipped when the terminal is too small (based on minimum rows/columns).
  - `--forger` is enforced as root-command-only: when used with subcommands, the CLI warns and ignores it.
  - Interactive menu behavior now consistently respects session interactivity.
- **Documentation**
  - Updated CLI “Global Options” documentation for `--forger`, including root-only guidance and explicit incompatibility with subcommands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `--forger` terminal size guard, stdin TTY check, and subcommand enforcement
> - Replaces `process.stdout.isTTY` checks with `prompts.isInteractive` in both the preAction hook and root action handler for consistent interactivity detection.
> - Adds a terminal size guard in `playForgerAnimation` ([src/lib/forger.ts](https://github.com/InsForge/CLI/pull/205/files#diff-18f165295acc2f5a551fb499f83c671ef7ddabd4b62d24f5a269eb99dddeb15e)): skips the animation and prints a message when the terminal is smaller than 80×14 columns/rows.
> - When `--forger` is passed alongside a subcommand, the CLI now emits a warning to stderr and skips the animation instead of attempting to run it.
> - Behavioral Change: `--forger` on a subcommand previously had undefined behavior; it now explicitly warns and exits the animation path early.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce3bceb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->