### PR TITLE
feat: add feedback command for reporting InsForge-side hurdles

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,3 +139,24 @@ silently disabled in published artifacts.
 If a release goes wrong, deprecate the bad version with `npm deprecate` rather
 than unpublishing — unpublishing breaks downstream users who already installed
 that version.
+
+## 6. Feedback backend
+
+The `insforge feedback` command submits reports to a dedicated InsForge
+project via a public edge function — no login required, spam contained
+server-side (RLS-locked table, allow-list validation, per-IP rate limit,
+duplicate folding). The endpoint URL and anon key are deliberately
+hardcoded in `src/lib/api/feedback.ts` (public client credentials
+protected by RLS + function-side rate limiting), overridable via
+`INSFORGE_FEEDBACK_URL` / `INSFORGE_FEEDBACK_ANON_KEY` for testing and
+rotation.
+
+The backend itself (the `feedback` table, the `submit-feedback` edge
+function, and its secrets) lives in the feedback project — it is not
+versioned in this repo. To inspect or maintain it, link a scratch
+directory to that project with the admin key, then use
+`insforge functions code submit-feedback`, `db query`, and
+`functions deploy` as usual; the project's agent memory
+(`insforge memory list`) records the design decisions and triage
+workflow. If you change the CLI's feedback payload shape, update the
+function's allow-list and the table schema in the same change set.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { registerFeedbackCommand } from './feedback.js';
+import { resetTelemetryOutcomeForTests } from '../lib/command-telemetry.js';
+
+vi.mock('../lib/api/feedback.js', () => ({
+  submitFeedback: vi.fn(async () => ({ id: 'fb_123', status: 'received' })),
+}));
+vi.mock('../lib/config.js', () => ({
+  FAKE_PROJECT_ID: 'fa4e0000-1234-5678-90ab-cd1234567890',
+  getProjectConfig: vi.fn(() => ({
+    project_id: 'p1',
+    project_name: 'demo',
+    org_id: 'o1',
+    appkey: 'k',
+    region: 'us-east',
+    api_key: 'key',
+    oss_host: 'http://localhost',
+  })),
+}));
+vi.mock('../lib/analytics.js', () => ({
+  trackGroupCommand: vi.fn(),
+  trackTopLevelCommand: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>');
+  registerFeedbackCommand(program);
+  return program;
+}
+
+async function run(argv: string[]) {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  try {
+    await makeProgram().parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+}
+
+describe('feedback command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTelemetryOutcomeForTests();
+  });
+
+  it('submits a structured payload with auto-attached context', async () => {
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+
+    await run([
+      'feedback',
+      '--type', 'bug',
+      '--component', 'backend',
+      '--title', 'db policies create 500s on uppercase table names',
+      '--detail', 'Creating an RLS policy on table "Users" returns 500. Lowercase names work.',
+      '--area', 'db',
+      '--command', 'insforge db policies create ...',
+      '--severity', 'major',
+    ]);
+
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload).toMatchObject({
+      type: 'bug',
+      component: 'backend',
+      severity: 'major',
+      area: 'db',
+      project_id: 'p1',
+      org_id: 'o1',
+      region: 'us-east',
+    });
+    expect(payload.client_info).toMatchObject({
+      source: 'cli',
+      node_version: process.version,
+    });
+    expect(payload.client_info.os).toContain(process.platform);
+  });
+
+  it('redacts PII from free-text fields before sending', async () => {
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+
+    await run([
+      'feedback',
+      '--type', 'bug',
+      '--component', 'backend',
+      '--title', 'auth fails for jane@example.com',
+      '--detail', 'Login with key uak_a1b2c3d4e5f6 under /Users/jane/app fails.',
+      '--error', 'Error: invalid token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.abc123def456',
+    ]);
+
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload.title).toBe('auth fails for [REDACTED_EMAIL]');
+    expect(payload.detail).toBe('Login with key [REDACTED_KEY] under ~/app fails.');
+    expect(payload.error).toContain('[REDACTED_JWT]');
+    expect(JSON.stringify(payload)).not.toContain('jane');
+  });
+
+  it('rejects a missing type in non-interactive mode with a usage hint', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as never);
+    try {
+      await expect(
+        run(['feedback', '--component', 'cli', '--title', 't', '--detail', 'd']),
+      ).rejects.toThrow('exit');
+      expect(errSpy.mock.calls.flat().join('\n')).toContain('--type is required');
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('rejects a missing component in non-interactive mode with a usage hint', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as never);
+    try {
+      await expect(
+        run(['feedback', '--type', 'bug', '--title', 't', '--detail', 'd']),
+      ).rejects.toThrow('exit');
+      const output = errSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('--component is required');
+      expect(output).toContain('backend, sdk, cli, skills, docs, other');
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('requires --language for SDK feedback and passes it through lowercased', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as never);
+    try {
+      await expect(
+        run(['feedback', '--type', 'bug', '--component', 'sdk', '--title', 't', '--detail', 'd']),
+      ).rejects.toThrow('exit');
+      expect(errSpy.mock.calls.flat().join('\n')).toContain('--language is required for SDK feedback');
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+    await run([
+      'feedback',
+      '--type', 'bug',
+      '--component', 'sdk',
+      '--language', 'Python',
+      '--title', 'storage upload hangs',
+      '--detail', 'upload() never resolves for files over 5MB',
+      '--area', 'storage',
+    ]);
+
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload).toMatchObject({ component: 'sdk', language: 'python', area: 'storage' });
+  });
+
+  it('rejects an invalid severity', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as never);
+    try {
+      await expect(
+        run(['feedback', '--type', 'bug', '--component', 'cli', '--title', 't', '--detail', 'd', '--severity', 'urgent']),
+      ).rejects.toThrow('exit');
+      expect(errSpy.mock.calls.flat().join('\n')).toContain('--severity must be one of');
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('files a docs-vs-behavior discrepancy as a bug with doc_ref and workaround', async () => {
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+
+    await run([
+      'feedback',
+      '--type', 'bug',
+      '--component', 'skills',
+      '--title', 'skill documents a --wait flag that does not exist',
+      '--detail', 'insforge-cli skill says deployments deploy supports --wait; the CLI rejects it.',
+      '--doc', 'insforge-cli skill, Deployments section',
+      '--expected', 'deploy blocks until the deployment finishes',
+      '--workaround', 'polled deployments status in a loop instead',
+    ]);
+
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload).toMatchObject({
+      type: 'bug',
+      component: 'skills',
+      doc_ref: 'insforge-cli skill, Deployments section',
+      workaround: 'polled deployments status in a loop instead',
+    });
+  });
+
+  it('rejects retired type values', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as never);
+    try {
+      await expect(
+        run(['feedback', '--type', 'discrepancy', '--component', 'cli', '--title', 't', '--detail', 'd']),
+      ).rejects.toThrow('exit');
+      expect(errSpy.mock.calls.flat().join('\n')).toContain(
+        'bug, feature-request, friction, other',
+      );
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('omits project context in OSS mode (fake project id)', async () => {
+    const { getProjectConfig } = await import('../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'fa4e0000-1234-5678-90ab-cd1234567890',
+      project_name: 'oss',
+      org_id: 'o1',
+      appkey: 'k',
+      region: '',
+      api_key: 'key',
+      oss_host: 'http://localhost',
+    });
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+
+    await run(['feedback', '--type', 'bug', '--component', 'docs', '--title', 't', '--detail', 'd']);
+
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload.project_id).toBeUndefined();
+    expect(payload.org_id).toBeUndefined();
+  });
+
+  it('sends only metadata to analytics, never free text', async () => {
+    const { trackTopLevelCommand } = await import('../lib/analytics.js');
+
+    await run([
+      'feedback',
+      '--type', 'friction',
+      '--component', 'skills',
+      '--title', 'secret title with jane@example.com',
+      '--detail', 'sensitive detail text',
+    ]);
+
+    const calls = JSON.stringify((trackTopLevelCommand as Mock).mock.calls);
+    expect(calls).toContain('feedback');
+    expect(calls).not.toContain('secret title');
+    expect(calls).not.toContain('sensitive detail');
+    expect(calls).not.toContain('example.com');
+  });
+
+  it('truncates oversized error output but keeps head and tail', async () => {
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+    const bigError = 'START ' + 'x'.repeat(5000) + ' END';
+
+    await run(['feedback', '--type', 'bug', '--component', 'cli', '--title', 't', '--detail', 'd', '--error', bigError]);
+
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload.error.length).toBeLessThan(2200);
+    expect(payload.error).toContain('START');
+    expect(payload.error).toContain('END');
+    expect(payload.error).toContain('chars truncated');
+  });
+});

--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Command } from 'commander';
 import { registerFeedbackCommand } from './feedback.js';
 import { resetTelemetryOutcomeForTests } from '../lib/command-telemetry.js';
@@ -6,17 +9,19 @@ import { resetTelemetryOutcomeForTests } from '../lib/command-telemetry.js';
 vi.mock('../lib/api/feedback.js', () => ({
   submitFeedback: vi.fn(async () => ({ id: 'fb_123', status: 'received' })),
 }));
+const PROJECT_CONFIG = {
+  project_id: 'p1',
+  project_name: 'demo',
+  org_id: 'o1',
+  appkey: 'k',
+  region: 'us-east',
+  api_key: 'key',
+  oss_host: 'http://localhost',
+};
+
 vi.mock('../lib/config.js', () => ({
   FAKE_PROJECT_ID: 'fa4e0000-1234-5678-90ab-cd1234567890',
-  getProjectConfig: vi.fn(() => ({
-    project_id: 'p1',
-    project_name: 'demo',
-    org_id: 'o1',
-    appkey: 'k',
-    region: 'us-east',
-    api_key: 'key',
-    oss_host: 'http://localhost',
-  })),
+  getProjectConfig: vi.fn(),
 }));
 vi.mock('../lib/analytics.js', () => ({
   trackGroupCommand: vi.fn(),
@@ -41,9 +46,12 @@ async function run(argv: string[]) {
 }
 
 describe('feedback command', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     resetTelemetryOutcomeForTests();
+    // Reset per test so a mockReturnValue override in one test can't leak
+    const { getProjectConfig } = await import('../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue(PROJECT_CONFIG);
   });
 
   it('submits a structured payload with auto-attached context', async () => {
@@ -214,6 +222,48 @@ describe('feedback command', () => {
     } finally {
       errSpy.mockRestore();
       exitSpy.mockRestore();
+    }
+  });
+
+  it('reads the detail text from --file and still redacts it', async () => {
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+    const path = join(tmpdir(), `feedback-detail-${process.pid}.txt`);
+    writeFileSync(path, 'detail from a file, reported by jane@example.com');
+    try {
+      await run(['feedback', '--type', 'bug', '--component', 'cli', '--title', 't', '--file', path]);
+      const [payload] = (submitFeedback as Mock).mock.calls[0];
+      expect(payload.detail).toBe('detail from a file, reported by [REDACTED_EMAIL]');
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+
+  it('omits project context when no project is linked at all', async () => {
+    const { getProjectConfig } = await import('../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue(null);
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+
+    await run(['feedback', '--type', 'bug', '--component', 'cli', '--title', 't', '--detail', 'd']);
+
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload.project_id).toBeUndefined();
+    expect(payload.org_id).toBeUndefined();
+    expect(payload.region).toBeUndefined();
+  });
+
+  it('tells the user when a report folded into an existing one', async () => {
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+    (submitFeedback as Mock).mockResolvedValueOnce({ id: 'fb1', status: 'duplicate' });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await makeProgram().parseAsync(
+        ['feedback', '--type', 'bug', '--component', 'cli', '--title', 't', '--detail', 'd'],
+        { from: 'user' },
+      );
+      expect(logSpy.mock.calls.flat().join('\n')).toContain('already reported');
+    } finally {
+      logSpy.mockRestore();
     }
   });
 

--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -255,6 +255,29 @@ describe('feedback command', () => {
     expect(calls).not.toContain('example.com');
   });
 
+  it('reports free-text --area/--language to analytics as "other", not verbatim', async () => {
+    const { trackTopLevelCommand } = await import('../lib/analytics.js');
+
+    await run([
+      'feedback',
+      '--type', 'bug',
+      '--component', 'sdk',
+      '--language', 'my proprietary language',
+      '--area', 'the whole storage subsystem honestly',
+      '--title', 't',
+      '--detail', 'd',
+    ]);
+
+    const props = (trackTopLevelCommand as Mock).mock.calls[0][2];
+    expect(props.language).toBe('other');
+    expect(props.area).toBe('other');
+    // Known values still pass through for real analytics value
+    const { submitFeedback } = await import('../lib/api/feedback.js');
+    const [payload] = (submitFeedback as Mock).mock.calls[0];
+    expect(payload.language).toBe('my proprietary language');
+    expect(payload.area).toBe('the whole storage subsystem honestly');
+  });
+
   it('truncates oversized error output but keeps head and tail', async () => {
     const { submitFeedback } = await import('../lib/api/feedback.js');
     const bigError = 'START ' + 'x'.repeat(5000) + ' END';

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,0 +1,253 @@
+import type { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as prompts from '../lib/prompts.js';
+import { submitFeedback, type FeedbackPayload } from '../lib/api/feedback.js';
+import { getProjectConfig, FAKE_PROJECT_ID } from '../lib/config.js';
+import { trackTopLevelUsage } from '../lib/command-telemetry.js';
+import { CLIError, handleError, getRootOpts } from '../lib/errors.js';
+import { outputJson, outputSuccess, outputInfo } from '../lib/output.js';
+import { redactSensitive, truncateMiddle } from '../lib/redact.js';
+
+const TYPES = ['bug', 'feature-request', 'friction', 'other'] as const;
+const COMPONENTS = ['backend', 'sdk', 'cli', 'skills', 'docs', 'other'] as const;
+const SEVERITIES = ['blocker', 'major', 'minor'] as const;
+type FeedbackType = (typeof TYPES)[number];
+type FeedbackComponent = (typeof COMPONENTS)[number];
+type FeedbackSeverity = (typeof SEVERITIES)[number];
+
+// Per-field caps keep reports triage-able: enough room for a real repro,
+// not enough for a full log dump. Long error output is truncated head+tail.
+const LIMITS = {
+  title: 200,
+  detail: 4000,
+  error: 2000,
+  expected: 1000,
+  command: 500,
+  workaround: 1000,
+  doc: 300,
+  area: 100,
+  language: 40,
+} as const;
+
+interface FeedbackOpts {
+  type?: string;
+  component?: string;
+  language?: string;
+  title?: string;
+  detail?: string;
+  file?: string;
+  area?: string;
+  command?: string;
+  error?: string;
+  expected?: string;
+  workaround?: string;
+  doc?: string;
+  severity: string;
+}
+
+/** Redact PII/credentials first, then cap length — redacting after truncation
+ *  could leave a half-visible token fragment at the cut point. */
+function clean(text: string, max: number): string {
+  return truncateMiddle(redactSensitive(text.trim()), max);
+}
+
+function cleanOptional(text: string | undefined, max: number): string | undefined {
+  const out = text ? clean(text, max) : undefined;
+  return out || undefined;
+}
+
+interface RequiredFields {
+  type?: string;
+  component?: string;
+  language?: string;
+  title?: string;
+  detail?: string;
+}
+
+async function promptMissing(fields: RequiredFields): Promise<RequiredFields> {
+  let { type, component, language, title, detail } = fields;
+
+  if (!type) {
+    const picked = await prompts.select<FeedbackType>({
+      message: 'What kind of hurdle did you hit?',
+      options: [
+        { value: 'bug', label: 'Bug', hint: 'it should work — per contract or docs — but it does not' },
+        { value: 'feature-request', label: 'Feature request', hint: 'what I needed is not supported' },
+        { value: 'friction', label: 'Friction', hint: 'works, but confusing or awkward (bad error, forced detour)' },
+        { value: 'other', label: 'Other' },
+      ],
+    });
+    if (prompts.isCancel(picked)) throw new CLIError('Feedback cancelled.');
+    type = picked;
+  }
+
+  if (!component) {
+    const picked = await prompts.select<FeedbackComponent>({
+      message: 'Where in the InsForge toolkit is the issue?',
+      options: [
+        { value: 'backend', label: 'Backend', hint: 'the InsForge platform / hosted services' },
+        { value: 'sdk', label: 'SDK', hint: '@insforge/sdk or another language SDK' },
+        { value: 'cli', label: 'CLI', hint: '@insforge/cli itself' },
+        { value: 'skills', label: 'Agent skills', hint: 'insforge / insforge-cli skill content' },
+        { value: 'docs', label: 'Docs', hint: 'documentation site or `docs` command content' },
+        { value: 'other', label: 'Other' },
+      ],
+    });
+    if (prompts.isCancel(picked)) throw new CLIError('Feedback cancelled.');
+    component = picked;
+  }
+
+  if (component === 'sdk' && !language) {
+    const entered = await prompts.text({
+      message: 'Which SDK language? (js, python, flutter, swift, kotlin, …)',
+      validate: (v) => (v.trim() ? undefined : 'A language is required for SDK feedback'),
+    });
+    if (prompts.isCancel(entered)) throw new CLIError('Feedback cancelled.');
+    language = entered;
+  }
+
+  if (!title) {
+    const entered = await prompts.text({
+      message: 'One-line summary of the issue',
+      validate: (v) => (v.trim() ? undefined : 'A summary is required'),
+    });
+    if (prompts.isCancel(entered)) throw new CLIError('Feedback cancelled.');
+    title = entered;
+  }
+
+  if (!detail) {
+    const entered = await prompts.text({
+      message: 'What happened, and what did you expect?',
+      validate: (v) => (v.trim() ? undefined : 'Details are required'),
+    });
+    if (prompts.isCancel(entered)) throw new CLIError('Feedback cancelled.');
+    detail = entered;
+  }
+
+  return { type, component, language, title, detail };
+}
+
+export function registerFeedbackCommand(program: Command): void {
+  program
+    .command('feedback')
+    .description(
+      'Report an InsForge-side hurdle — a bug (including docs-vs-behavior discrepancies), a missing ' +
+      'capability, or DX friction — to the InsForge team. For agents: use this whenever any part of ' +
+      'the InsForge toolkit (backend, an SDK, the CLI, agent skills, docs) got in your way — not the ' +
+      'app you are building. Emails, tokens, keys, and usernames are redacted locally before submission.',
+    )
+    .option('--type <type>', 'Hurdle kind: bug (should work per contract or docs, but does not) | feature-request (needed something unsupported) | friction (works but confusing/awkward) | other')
+    .option('--component <component>', `Toolkit component the issue lives in: ${COMPONENTS.join(' | ')}`)
+    .option('--language <language>', 'Language/variant for SDK or docs feedback, e.g. js, python, flutter, swift, kotlin, rest-api (required with --component sdk)')
+    .option('--title <title>', `One-line summary (max ${LIMITS.title} chars)`)
+    .option('--detail <text>', `What happened vs what you expected; include repro steps if known (max ${LIMITS.detail} chars)`)
+    .option('--file <path>', 'Read the detail text from a file instead of --detail')
+    .option('--area <area>', 'Product area, e.g. db | auth | storage | functions | deployments | billing | ai | realtime | payments')
+    .option('--command <command>', 'The CLI command or SDK call that surfaced the issue')
+    .option('--error <text>', 'Verbatim error output (redacted and truncated automatically)')
+    .option('--expected <text>', 'What the docs/skill instructed, or what you expected to happen')
+    .option('--workaround <text>', 'The alternative you used to get past the hurdle, if any')
+    .option('--doc <ref>', 'Doc page or skill section that instructed it (when docs/skill contradict actual behavior)')
+    .option('--severity <severity>', `${SEVERITIES.join(' | ')}`, 'minor')
+    .action(async (opts: FeedbackOpts, cmd) => {
+      // No auth required: the feedback endpoint is public (anon key) so OSS
+      // and logged-out users can report hurdles too. Anti-spam lives
+      // server-side in the submit-feedback edge function.
+      const { json } = getRootOpts(cmd);
+      try {
+        let detail = opts.file ? readFileSync(opts.file, 'utf8') : opts.detail;
+        let { type, component, language, title } = opts;
+
+        // Humans get prompted for missing required fields; agents (non-TTY or
+        // --json) get a precise error instead so nothing hangs on a prompt.
+        const missingRequired =
+          !type || !component || !title || !detail || (component === 'sdk' && !language);
+        if (missingRequired && prompts.isInteractive && !json) {
+          ({ type, component, language, title, detail } = await promptMissing({
+            type, component, language, title, detail,
+          }));
+        }
+
+        if (!type || !(TYPES as readonly string[]).includes(type)) {
+          throw new CLIError(`--type is required and must be one of: ${TYPES.join(', ')}`);
+        }
+        if (!component || !(COMPONENTS as readonly string[]).includes(component)) {
+          throw new CLIError(
+            `--component is required and must be one of: ${COMPONENTS.join(', ')} — where in the InsForge toolkit the issue lives.`,
+          );
+        }
+        if (component === 'sdk' && !language?.trim()) {
+          throw new CLIError(
+            '--language is required for SDK feedback, e.g. js, python, flutter, swift, kotlin — or "multiple" if it spans SDKs.',
+          );
+        }
+        if (!title?.trim()) {
+          throw new CLIError('--title is required: a one-line summary of the issue.');
+        }
+        if (!detail?.trim()) {
+          throw new CLIError('--detail (or --file) is required: what happened and what you expected.');
+        }
+        if (!(SEVERITIES as readonly string[]).includes(opts.severity)) {
+          throw new CLIError(`--severity must be one of: ${SEVERITIES.join(', ')}`);
+        }
+
+        const config = getProjectConfig();
+        const ossMode = !config || config.project_id === FAKE_PROJECT_ID;
+
+        const payload: FeedbackPayload = {
+          type: type as FeedbackType,
+          component: component as FeedbackComponent,
+          severity: opts.severity as FeedbackSeverity,
+          title: clean(title, LIMITS.title),
+          detail: clean(detail, LIMITS.detail),
+          language: cleanOptional(language?.toLowerCase(), LIMITS.language),
+          area: cleanOptional(opts.area, LIMITS.area),
+          command: cleanOptional(opts.command, LIMITS.command),
+          error: cleanOptional(opts.error, LIMITS.error),
+          expected: cleanOptional(opts.expected, LIMITS.expected),
+          workaround: cleanOptional(opts.workaround, LIMITS.workaround),
+          doc_ref: cleanOptional(opts.doc, LIMITS.doc),
+          // Platform identifiers InsForge already holds — context, not PII.
+          project_id: !ossMode ? config?.project_id : undefined,
+          org_id: !ossMode ? config?.org_id : undefined,
+          region: !ossMode ? config?.region : undefined,
+          client_info: {
+            source: 'cli',
+            cli_version: process.env.CLI_VERSION || 'unknown',
+            node_version: process.version,
+            os: `${os.platform()} ${os.release()}`,
+          },
+        };
+
+        const { id, status } = await submitFeedback(payload);
+
+        // Metadata only — never the free-text fields (see DEVELOPMENT.md §2).
+        await trackTopLevelUsage('feedback', true, {
+          type,
+          component,
+          language: payload.language,
+          severity: opts.severity,
+          area: payload.area,
+          status,
+          has_command: Boolean(payload.command),
+          has_error: Boolean(payload.error),
+          has_workaround: Boolean(payload.workaround),
+          detail_length: payload.detail.length,
+          oss_mode: ossMode,
+        });
+
+        if (json) {
+          outputJson({ id, status });
+        } else if (status === 'duplicate') {
+          outputSuccess('This issue was already reported — bumped its count instead. Thank you!');
+        } else {
+          outputSuccess(`Feedback submitted${id ? ` (id: ${id})` : ''}. Thank you!`);
+          outputInfo('PII (emails, tokens, keys, usernames) was redacted before sending.');
+        }
+      } catch (err) {
+        await trackTopLevelUsage('feedback', false, {}, err);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -12,6 +12,24 @@ import { redactSensitive, truncateMiddle } from '../lib/redact.js';
 const TYPES = ['bug', 'feature-request', 'friction', 'other'] as const;
 const COMPONENTS = ['backend', 'sdk', 'cli', 'skills', 'docs', 'other'] as const;
 const SEVERITIES = ['blocker', 'major', 'minor'] as const;
+
+// --area and --language stay free text toward the feedback backend (that is
+// their home), but PostHog must only ever see fixed values — never
+// user-entered text (DEVELOPMENT.md §2). Unknown values report as 'other'.
+const TELEMETRY_AREAS = new Set([
+  'db', 'auth', 'storage', 'functions', 'deployments', 'billing', 'ai',
+  'realtime', 'payments', 'docs', 'cli',
+]);
+const TELEMETRY_LANGUAGES = new Set([
+  'js', 'ts', 'javascript', 'typescript', 'python', 'flutter', 'dart',
+  'swift', 'kotlin', 'java', 'go', 'rust', 'ruby', 'php', 'csharp',
+  'rest-api', 'rest', 'multiple',
+]);
+
+function telemetryEnum(value: string | undefined, known: Set<string>): string | undefined {
+  if (!value) return undefined;
+  return known.has(value.toLowerCase()) ? value.toLowerCase() : 'other';
+}
 type FeedbackType = (typeof TYPES)[number];
 type FeedbackComponent = (typeof COMPONENTS)[number];
 type FeedbackSeverity = (typeof SEVERITIES)[number];
@@ -226,9 +244,9 @@ export function registerFeedbackCommand(program: Command): void {
         await trackTopLevelUsage('feedback', true, {
           type,
           component,
-          language: payload.language,
+          language: telemetryEnum(payload.language, TELEMETRY_LANGUAGES),
           severity: opts.severity,
-          area: payload.area,
+          area: telemetryEnum(payload.area, TELEMETRY_AREAS),
           status,
           has_command: Boolean(payload.command),
           has_error: Boolean(payload.error),

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import { registerDeploymentsMetadataCommand } from './commands/deployments/metad
 import { registerDeploymentsSlugCommand } from './commands/deployments/slug.js';
 
 import { registerDocsCommand } from './commands/docs.js';
+import { registerFeedbackCommand } from './commands/feedback.js';
 import { registerSecretsListCommand } from './commands/secrets/list.js';
 import { registerSecretsGetCommand } from './commands/secrets/get.js';
 import { registerSecretsAddCommand } from './commands/secrets/add.js';
@@ -152,6 +153,7 @@ registerCreateCommand(program);
 registerContextCommand(program);
 registerListCommand(program);
 registerDocsCommand(program);
+registerFeedbackCommand(program);
 registerProjectLinkCommand(program);
 
 // Orgs commands

--- a/src/lib/api/feedback.test.ts
+++ b/src/lib/api/feedback.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { submitFeedback, type FeedbackPayload } from './feedback.js';
+import { CLIError } from '../errors.js';
+
+const PAYLOAD: FeedbackPayload = {
+  type: 'bug',
+  component: 'cli',
+  severity: 'minor',
+  title: 't',
+  detail: 'd',
+  client_info: { source: 'cli', cli_version: 'test', node_version: 'v22', os: 'darwin' },
+};
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('submitFeedback', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the payload with the anon key and a timeout signal', async () => {
+    (fetch as Mock).mockResolvedValue(mockResponse(201, { id: 'fb1', status: 'received' }));
+
+    const result = await submitFeedback(PAYLOAD);
+
+    expect(result).toEqual({ id: 'fb1', status: 'received' });
+    const [url, init] = (fetch as Mock).mock.calls[0];
+    expect(String(url)).toContain('/functions/submit-feedback');
+    expect(init.headers.Authorization).toMatch(/^Bearer anon_/);
+    expect(JSON.parse(init.body)).toMatchObject({ type: 'bug', component: 'cli' });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('maps duplicate responses', async () => {
+    (fetch as Mock).mockResolvedValue(mockResponse(200, { id: 'fb1', status: 'duplicate' }));
+    await expect(submitFeedback(PAYLOAD)).resolves.toEqual({ id: 'fb1', status: 'duplicate' });
+  });
+
+  it('surfaces server error messages as CLIError', async () => {
+    (fetch as Mock).mockResolvedValue(
+      mockResponse(429, { error: 'Rate limit exceeded — try again later' }),
+    );
+    await expect(submitFeedback(PAYLOAD)).rejects.toThrow('Rate limit exceeded');
+    await expect(
+      submitFeedback(PAYLOAD).catch((e) => Promise.reject(e)),
+    ).rejects.toBeInstanceOf(CLIError);
+  });
+
+  it('maps timeouts to an actionable message', async () => {
+    const timeoutErr = new Error('The operation was aborted due to timeout');
+    timeoutErr.name = 'TimeoutError';
+    (fetch as Mock).mockRejectedValue(timeoutErr);
+    await expect(submitFeedback(PAYLOAD)).rejects.toThrow('timed out after 10s');
+  });
+
+  it('wraps network failures in CLIError', async () => {
+    (fetch as Mock).mockRejectedValue(new Error('fetch failed'));
+    await expect(submitFeedback(PAYLOAD)).rejects.toBeInstanceOf(CLIError);
+  });
+});

--- a/src/lib/api/feedback.ts
+++ b/src/lib/api/feedback.ts
@@ -1,0 +1,96 @@
+import { CLIError, formatFetchError } from '../errors.js';
+
+/**
+ * The InsForge-hosted feedback project (dogfooding: InsForge stores its own
+ * product feedback on InsForge). Both values below are public client
+ * credentials by design: the anon key can only invoke the submit-feedback
+ * edge function — the feedback table is RLS-locked with zero anon policies,
+ * and the function enforces validation, per-IP rate limiting, and duplicate
+ * folding server-side (see DEVELOPMENT.md §6 for the backend's home).
+ *
+ * Hardcoded rather than injected from CI secrets so feedback works in every
+ * build — local, fork, and release — with no silent no-op failure mode
+ * (the POSTHOG_API_KEY lesson from DEVELOPMENT.md). Env overrides exist for
+ * testing and emergency rotation.
+ */
+const FEEDBACK_ENDPOINT =
+  process.env.INSFORGE_FEEDBACK_URL ||
+  'https://3yzf3pzs.us-east.insforge.app/functions/submit-feedback';
+const FEEDBACK_ANON_KEY =
+  process.env.INSFORGE_FEEDBACK_ANON_KEY ||
+  'anon_d6bd647caa3988037271f3e00661c014c12c3a8be6a01f66c6efa30afe03d0f8';
+
+export interface FeedbackPayload {
+  /**
+   * The kind of hurdle hit: bug (should work — per contract or docs — but
+   * doesn't; docs-vs-behavior discrepancies file here with doc_ref/expected
+   * set), feature-request (needed something unsupported), friction (works
+   * but confusing/awkward).
+   */
+  type: 'bug' | 'feature-request' | 'friction' | 'other';
+  /** Which part of the InsForge toolkit the issue lives in. */
+  component: 'backend' | 'sdk' | 'cli' | 'skills' | 'docs' | 'other';
+  severity: 'blocker' | 'major' | 'minor';
+  title: string;
+  detail: string;
+  /** Language/variant for sdk or docs feedback, e.g. js, python, flutter, swift, kotlin, rest-api. */
+  language?: string;
+  area?: string;
+  command?: string;
+  error?: string;
+  expected?: string;
+  /** The alternative the reporter used to get past the hurdle, if any. */
+  workaround?: string;
+  doc_ref?: string;
+  project_id?: string;
+  org_id?: string;
+  region?: string;
+  client_info: {
+    source: 'cli';
+    cli_version: string;
+    node_version: string;
+    os: string;
+  };
+}
+
+export interface FeedbackResult {
+  id: string | null;
+  /** 'received' for a new report, 'duplicate' when folded into an existing one. */
+  status: 'received' | 'duplicate';
+}
+
+/**
+ * Submit structured product feedback (bug / feature request / friction)
+ * to the InsForge team's feedback backend. No login required — the endpoint
+ * is public (anon key) so OSS and logged-out users can report too. Free-text
+ * fields must already be PII-scrubbed by the caller (see src/lib/redact.ts);
+ * the backend re-validates and enforces its own caps.
+ */
+export async function submitFeedback(payload: FeedbackPayload): Promise<FeedbackResult> {
+  let res: Response;
+  try {
+    res = await fetch(FEEDBACK_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${FEEDBACK_ANON_KEY}`,
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    throw new CLIError(formatFetchError(err, FEEDBACK_ENDPOINT));
+  }
+
+  const data = await res.json().catch(() => ({})) as {
+    id?: string;
+    status?: string;
+    error?: string;
+  };
+  if (!res.ok) {
+    throw new CLIError(data.error ?? `Feedback submission failed: ${res.status}`);
+  }
+  return {
+    id: data.id ?? null,
+    status: data.status === 'duplicate' ? 'duplicate' : 'received',
+  };
+}

--- a/src/lib/api/feedback.ts
+++ b/src/lib/api/feedback.ts
@@ -20,6 +20,9 @@ const FEEDBACK_ANON_KEY =
   process.env.INSFORGE_FEEDBACK_ANON_KEY ||
   'anon_d6bd647caa3988037271f3e00661c014c12c3a8be6a01f66c6efa30afe03d0f8';
 
+// Feedback is a side quest — never let a hung endpoint hang the CLI.
+const FEEDBACK_TIMEOUT_MS = 10_000;
+
 export interface FeedbackPayload {
   /**
    * The kind of hurdle hit: bug (should work — per contract or docs — but
@@ -76,8 +79,14 @@ export async function submitFeedback(payload: FeedbackPayload): Promise<Feedback
         Authorization: `Bearer ${FEEDBACK_ANON_KEY}`,
       },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(FEEDBACK_TIMEOUT_MS),
     });
   } catch (err) {
+    if (err instanceof Error && err.name === 'TimeoutError') {
+      throw new CLIError(
+        `Feedback submission timed out after ${FEEDBACK_TIMEOUT_MS / 1000}s. Try again later.`,
+      );
+    }
     throw new CLIError(formatFetchError(err, FEEDBACK_ENDPOINT));
   }
 

--- a/src/lib/redact.test.ts
+++ b/src/lib/redact.test.ts
@@ -31,6 +31,12 @@ describe('redactSensitive', () => {
     expect(redactSensitive('ghp_16C7e42F292c6912E7710c838347Ae178B4a')).toBe('[REDACTED_KEY]');
     expect(redactSensitive('AKIAIOSFODNN7EXAMPLE')).toBe('[REDACTED_KEY]');
     expect(redactSensitive('xoxb-1234567890-abcdefg')).toBe('[REDACTED_KEY]');
+    // Fixtures deliberately shorter than the real key formats so they stay
+    // below GitHub push-protection detector thresholds
+    expect(redactSensitive('AIzaSyA1b2C3d4E5f6G7h8I9j0K1')).toBe('[REDACTED_KEY]');
+    expect(redactSensitive('npm_a1B2c3D4e5F6g7H8i9J0k1L2')).toBe('[REDACTED_KEY]');
+    expect(redactSensitive('phc_a1B2c3D4e5F6g7H8i9J0k1L2')).toBe('[REDACTED_KEY]');
+    expect(redactSensitive('phx_a1B2c3D4e5F6g7H8i9J0k1L2')).toBe('[REDACTED_KEY]');
   });
 
   it('redacts generic secret assignments but keeps the key name', () => {

--- a/src/lib/redact.test.ts
+++ b/src/lib/redact.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { redactSensitive, truncateMiddle } from './redact.js';
+
+describe('redactSensitive', () => {
+  it('redacts emails', () => {
+    expect(redactSensitive('user can.lyu@example.dev hit a 500')).toBe(
+      'user [REDACTED_EMAIL] hit a 500',
+    );
+  });
+
+  it('redacts JWTs', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.SflKxwRJSMeKKF2QT4fwpM';
+    expect(redactSensitive(`token was ${jwt} in the header`)).toBe(
+      'token was [REDACTED_JWT] in the header',
+    );
+  });
+
+  it('redacts bearer tokens', () => {
+    expect(redactSensitive('Authorization: Bearer abc123def456ghi')).toBe(
+      'Authorization: Bearer [REDACTED]',
+    );
+  });
+
+  it('redacts known key formats', () => {
+    expect(redactSensitive('used uak_a1b2c3d4e5f6 to auth')).toBe('used [REDACTED_KEY] to auth');
+    // Short fixture on purpose: long enough for our redaction pattern (8+),
+    // too short for GitHub push protection's Stripe detector (24+).
+    expect(redactSensitive('sk_live_a1b2c3d4e5f6')).toBe('[REDACTED_KEY]');
+    expect(redactSensitive('sk-proj-abcdefghijklmnop1234')).toBe('[REDACTED_KEY]');
+    expect(redactSensitive('ghp_16C7e42F292c6912E7710c838347Ae178B4a')).toBe('[REDACTED_KEY]');
+    expect(redactSensitive('AKIAIOSFODNN7EXAMPLE')).toBe('[REDACTED_KEY]');
+    expect(redactSensitive('xoxb-1234567890-abcdefg')).toBe('[REDACTED_KEY]');
+  });
+
+  it('redacts generic secret assignments but keeps the key name', () => {
+    expect(redactSensitive('set password=hunter42! and retry')).toBe(
+      'set password=[REDACTED] and retry',
+    );
+    expect(redactSensitive('config has api_key: "abc123xyz"')).toBe(
+      'config has api_key: "[REDACTED]"',
+    );
+    expect(redactSensitive('ANON_TOKEN=abcdef123456')).toBe('ANON_TOKEN=[REDACTED]');
+  });
+
+  it('redacts credentials embedded in connection strings', () => {
+    expect(redactSensitive('postgres://admin:s3cret@db.insforge.dev:5432/app')).toBe(
+      'postgres://[REDACTED_CREDENTIALS]@db.insforge.dev:5432/app',
+    );
+  });
+
+  it('rewrites home directories to ~', () => {
+    expect(redactSensitive('read /Users/jane.doe/Documents/app/.env failed')).toBe(
+      'read ~/Documents/app/.env failed',
+    );
+    expect(redactSensitive('read /home/jdoe/app/.env failed')).toBe('read ~/app/.env failed');
+    expect(redactSensitive('read C:\\Users\\jdoe\\app\\.env failed')).toBe(
+      'read ~\\app\\.env failed',
+    );
+  });
+
+  it('redacts public IPs but keeps private/loopback ones', () => {
+    expect(redactSensitive('connect to 8.8.8.8 failed')).toBe('connect to [REDACTED_IP] failed');
+    expect(redactSensitive('listening on 127.0.0.1 and 192.168.1.5')).toBe(
+      'listening on 127.0.0.1 and 192.168.1.5',
+    );
+    expect(redactSensitive('pod 10.0.3.17 unreachable')).toBe('pod 10.0.3.17 unreachable');
+  });
+
+  it('leaves version-like dotted numbers alone', () => {
+    expect(redactSensitive('node 22.11.0 on darwin 25.2.0')).toBe('node 22.11.0 on darwin 25.2.0');
+    // Four segments with an out-of-range octet is a version, not an IP
+    expect(redactSensitive('chrome 131.0.6778.85')).toBe('chrome 131.0.6778.85');
+  });
+
+  it('leaves ordinary prose untouched', () => {
+    const text =
+      'insforge db policies create returns 500 when the table name contains uppercase letters';
+    expect(redactSensitive(text)).toBe(text);
+  });
+});
+
+describe('truncateMiddle', () => {
+  it('returns short text unchanged', () => {
+    expect(truncateMiddle('hello', 100)).toBe('hello');
+  });
+
+  it('keeps head and tail with a marker in between', () => {
+    const text = 'A'.repeat(600) + 'MIDDLE' + 'Z'.repeat(600);
+    const out = truncateMiddle(text, 100);
+    expect(out.startsWith('A'.repeat(60))).toBe(true);
+    expect(out.endsWith('Z'.repeat(40))).toBe(true);
+    expect(out).toContain('chars truncated');
+    expect(out).not.toContain('MIDDLE');
+  });
+});

--- a/src/lib/redact.test.ts
+++ b/src/lib/redact.test.ts
@@ -57,6 +57,8 @@ describe('redactSensitive', () => {
     expect(redactSensitive('read C:\\Users\\jdoe\\app\\.env failed')).toBe(
       'read ~\\app\\.env failed',
     );
+    // Windows paths often arrive with normalized forward slashes
+    expect(redactSensitive('read C:/Users/jdoe/app/.env failed')).toBe('read ~/app/.env failed');
   });
 
   it('redacts public IPs but keeps private/loopback ones', () => {

--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -1,0 +1,80 @@
+/**
+ * Scrub likely PII and credentials from free text before it leaves the
+ * machine (e.g. `insforge feedback` payloads).
+ *
+ * Deliberately conservative: over-redacting a value the InsForge team could
+ * have used is fine; shipping someone's email, token, or username off the
+ * device is not. The platform re-scrubs server-side — this is the first line
+ * of defense, not the only one. IPv6 and phone numbers are intentionally not
+ * matched: their patterns overlap UUIDs/hashes/timestamps too often to redact
+ * without destroying diagnostic value.
+ */
+
+const REDACTIONS: Array<[RegExp, string]> = [
+  // Credentials embedded in URLs: postgres://user:pass@host → keep scheme+host
+  [/(\w+:\/\/)([^\s/:@]+):([^\s@]+)@/g, '$1[REDACTED_CREDENTIALS]@'],
+  // JWTs: three dot-separated base64url segments, header always starts with eyJ
+  [/\beyJ[\w-]{4,}\.[\w-]{4,}\.[\w-]*/g, '[REDACTED_JWT]'],
+  // Authorization header values
+  [/\b[Bb]earer\s+[\w.~+/=-]{8,}/g, 'Bearer [REDACTED]'],
+  // Known key formats: InsForge uak_, Stripe sk_/pk_/rk_(live|test)/whsec_,
+  // OpenAI/Anthropic-style sk-, GitHub gh*_/github_pat_, AWS AKIA, Slack xox*-
+  [/\b(?:uak|whsec|(?:sk|pk|rk)_(?:live|test))_[\w-]{8,}/g, '[REDACTED_KEY]'],
+  [/\bsk-[\w-]{16,}/g, '[REDACTED_KEY]'],
+  [/\bgh[pousr]_\w{20,}/g, '[REDACTED_KEY]'],
+  [/\bgithub_pat_\w{20,}/g, '[REDACTED_KEY]'],
+  [/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED_KEY]'],
+  [/\bxox[baprs]-[\w-]{10,}/g, '[REDACTED_KEY]'],
+  // Generic secret assignments: password=..., api_key: "...", ANON_TOKEN=...
+  // Allows prefixed key names (DB_PASSWORD, my-secret) via [\w-]*
+  [
+    /\b([\w-]*(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|access[_-]?key|private[_-]?key|appkey))(\s*[=:]\s*)(["']?)[^\s"']{6,}\3/gi,
+    '$1$2$3[REDACTED]$3',
+  ],
+  // Emails
+  [/\b[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}\b/g, '[REDACTED_EMAIL]'],
+  // Home directories — the username segment is PII
+  [/(?:\/Users|\/home)\/[\w.-]+/g, '~'],
+  [/\b[A-Za-z]:\\Users\\[\w.-]+/g, '~'],
+];
+
+const IPV4 = /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g;
+
+/** Loopback/private/link-local addresses carry no PII and real debug value. */
+function isPrivateOrLocal(a: number, b: number): boolean {
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254)
+  );
+}
+
+export function redactSensitive(text: string): string {
+  let out = text;
+  for (const [pattern, replacement] of REDACTIONS) {
+    out = out.replace(pattern, replacement);
+  }
+  out = out.replace(IPV4, (match, a: string, b: string, c: string, d: string) => {
+    const octets = [a, b, c, d].map(Number);
+    // Octets >255 mean it's a version string or similar, not an address
+    if (octets.some((o) => o > 255)) return match;
+    return isPrivateOrLocal(octets[0], octets[1]) ? match : '[REDACTED_IP]';
+  });
+  return out;
+}
+
+/**
+ * Cap text at roughly `max` chars keeping head and tail — error output tends
+ * to carry the signal at both ends (the command echo up top, the actual error
+ * at the bottom). The truncation marker is added on top of `max`.
+ */
+export function truncateMiddle(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const head = Math.ceil(max * 0.6);
+  const tail = max - head;
+  const omitted = text.length - max;
+  return `${text.slice(0, head)}\n…[${omitted} chars truncated]…\n${text.slice(text.length - tail)}`;
+}

--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -25,6 +25,11 @@ const REDACTIONS: Array<[RegExp, string]> = [
   [/\bgithub_pat_\w{20,}/g, '[REDACTED_KEY]'],
   [/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED_KEY]'],
   [/\bxox[baprs]-[\w-]{10,}/g, '[REDACTED_KEY]'],
+  // Google API keys, npm tokens, PostHog keys (phc_ is a public client key,
+  // but this module is conservative by design; phx_ personal keys are not)
+  [/\bAIza[\w-]{20,}/g, '[REDACTED_KEY]'],
+  [/\bnpm_[A-Za-z0-9]{20,}/g, '[REDACTED_KEY]'],
+  [/\bph[cx]_[\w-]{20,}/g, '[REDACTED_KEY]'],
   // Generic secret assignments: password=..., api_key: "...", ANON_TOKEN=...
   // Allows prefixed key names (DB_PASSWORD, my-secret) via [\w-]*
   [

--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -33,9 +33,11 @@ const REDACTIONS: Array<[RegExp, string]> = [
   ],
   // Emails
   [/\b[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}\b/g, '[REDACTED_EMAIL]'],
-  // Home directories — the username segment is PII
+  // Home directories — the username segment is PII. Windows (either slash
+  // direction) runs first so `C:/Users/x` collapses to `~` instead of the
+  // unix pattern matching its `/Users/x` suffix and leaving `C:~`.
+  [/\b[A-Za-z]:[\\/]Users[\\/][\w.-]+/g, '~'],
   [/(?:\/Users|\/home)\/[\w.-]+/g, '~'],
-  [/\b[A-Za-z]:\\Users\\[\w.-]+/g, '~'],
 ];
 
 const IPV4 = /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g;


### PR DESCRIPTION
## Summary

Adds `insforge feedback` — agents (and humans) report InsForge-side hurdles mid-task: bugs, missing capabilities, or DX friction, anywhere in the toolkit.

```bash
npx @insforge/cli feedback --json \
  --type bug --component sdk --language python --area storage \
  --title "upload() hangs for files over 5MB" \
  --detail "<what happened vs expected, minimal repro>" \
  --error "<verbatim output>" --workaround "<what worked instead>"
```

### Taxonomy (designed backwards from triage)

| Flag | Values | Question |
|---|---|---|
| `--type` (required) | `bug` \| `feature-request` \| `friction` \| `other` | What kind of hurdle? |
| `--component` (required) | `backend` \| `sdk` \| `cli` \| `skills` \| `docs` \| `other` | Which deliverable? |
| `--area` (optional) | `db`, `auth`, `storage`, … | Which product feature? |

Docs-vs-behavior discrepancies file as `bug` with `--doc`/`--expected`/`--workaround` carrying the evidence. `--language` is required with `--component sdk`.

### Privacy & anti-spam

- **Local PII redaction** (`src/lib/redact.ts`): emails, JWTs, bearer tokens, known key formats, secret assignments, connection-string credentials, public IPs, home-dir usernames. Redact-then-truncate ordering; per-field caps.
- **No login required** — OSS and logged-out users can report. Abuse is contained server-side in a dedicated InsForge feedback project (dogfooding): RLS-locked table with a validating edge function as the only write path, 20/hour per-IP rate limit (salted hash, raw IP never stored), 7-day duplicate folding. The backend is maintained in the feedback project itself, not in this repo — see DEVELOPMENT.md §6 for how to inspect/redeploy it.
- **PostHog** gets metadata only (type/component/severity/lengths) — never free text, per DEVELOPMENT.md §2.

The endpoint URL and anon key are hardcoded public client credentials (rationale in `src/lib/api/feedback.ts`), overridable via `INSFORGE_FEEDBACK_URL` / `INSFORGE_FEEDBACK_ANON_KEY`.

## Test plan

- 23 new tests (`src/lib/redact.test.ts`, `src/commands/feedback.test.ts`); full suite 627 passing, lint clean.
- Verified end-to-end against the live backend: new report → 201 + id; duplicate → folds into existing row (`duplicate_count` bumped); anon key denied direct table read/write; real built CLI submission confirmed.

## Cross-references & merge order

Companion skills PR: [InsForge/insforge-skills#119](https://github.com/InsForge/insforge-skills/pull/119) routes agents here from the `insforge-cli`, `insforge`, and `insforge-debug` skills. **Publish this to npm first, then merge the skills PR** — skills install from the repo's default branch at runtime, so merging skills first would document a command agents don't have yet.

Follow-ups tracked outside this PR: rotate the feedback project admin key, assign a triage owner for `status = 'new'` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `feedback` CLI command for reporting issues to InsForge
> - Adds a new `feedback` subcommand ([src/commands/feedback.ts](https://github.com/InsForge/CLI/pull/206/files#diff-48496a44b8103cdd7f5a9500af8dfcffe184e4f649a12c42ed403f12ca159ecd)) that collects structured reports (type, component, severity, area, etc.) and POSTs them to a hardcoded InsForge edge function endpoint via [`submitFeedback`](https://github.com/InsForge/CLI/pull/206/files#diff-2125049203abf10390a46767d8e4b2c75e6aac15f18fffc2baafb9ae7e50d7ff).
> - Supports interactive prompting for missing required fields in TTY mode, and JSON output mode for scripted use.
> - Free-text fields are sanitized via [`redactSensitive`](https://github.com/InsForge/CLI/pull/206/files#diff-cb4af16a85f20c9d2efc9d220be5a527429e2ce2e56c931c43f1b75a3fe4c0ca) (strips emails, JWTs, API keys, home dirs) and capped with `truncateMiddle` before submission.
> - Project context (project_id, org_id, region) is included in the payload unless running in OSS or unlinked mode. Analytics receive only enumerated values; free-text area/language maps to `'other'`.
> - Risk: the feedback endpoint and anon key are hardcoded with optional env overrides; rotating them requires a CLI release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6083b39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->