### PR TITLE
feat: add --toon output format for token-optimized CLI output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "@insforge/shared-schemas": "^1.1.58",
+        "@toon-format/toon": "^4.1.0",
         "archiver": "^7.0.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
@@ -1475,6 +1476,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@toon-format/toon": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-4.1.0.tgz",
+      "integrity": "sha512-dBB3pkEx9QYvHnHR6rtkaBAh+7x4W/oA5ONur4G0fh7Ow69PbPuM7OFxzNRABqyxC0t6SZ3RixiGbCuaFjPDAQ==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@clack/prompts": "^0.9.1",
     "@insforge/shared-schemas": "^1.1.58",
+    "@toon-format/toon": "^4.1.0",
     "archiver": "^7.0.1",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { Command } from 'commander';
 import * as clack from '@clack/prompts';
 import * as prompts from './lib/prompts.js';
 import { getCredentials, getProjectConfig } from './lib/config.js';
-import { outputJson } from './lib/output.js';
+import { outputJson, setToonMode } from './lib/output.js';
 import { registerLoginCommand } from './commands/login.js';
 import { registerLogoutCommand } from './commands/logout.js';
 import { registerWhoamiCommand } from './commands/whoami.js';
@@ -116,6 +116,7 @@ program
 // Global options
 program
   .option('--json', 'Output in JSON format')
+  .option('--toon', 'Output in TOON format (token-optimized notation, see toonformat.dev)')
   .option('--forger', 'Play the Forger animation (root command only) and return to the interactive menu')
   .option('--api-url <url>', 'Override Platform API URL')
   .option('-y, --yes', 'Skip confirmation prompts')
@@ -152,6 +153,12 @@ program.hook('preAction', async (_thisCommand, actionCommand) => {
 // operations for human approval. Lives in the CLI so it protects every caller
 // (Claude Code, Cursor, scripts, CI, humans) automatically.
 program.hook('preAction', guardHook);
+
+// TOON output format: set module-level flag before any action runs
+program.hook('preAction', (thisCommand: Command, actionCommand: Command) => {
+  const opts = actionCommand.optsWithGlobals() as { toon?: boolean };
+  setToonMode(!!opts.toon);
+});
 
 // Top-level commands
 registerLoginCommand(program);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -126,7 +126,7 @@ export function getRootOpts(cmd: Command): { json: boolean; apiUrl?: string; yes
   }
   const opts = root.opts();
   return {
-    json: opts.json ?? false,
+    json: opts.json ?? opts.toon ?? false,
     apiUrl: opts.apiUrl,
     yes: opts.yes ?? false,
   };

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { setToonMode, outputTable, outputSuccess, outputInfo, outputJson } from './output.js';
+
+describe('toonEscapeValue (indirectly via outputTable)', () => {
+  it('quotes values containing structural chars (comma, colon, bracket, etc.)', () => {
+    // outputTable with toon mode writes TOON to stdout
+    // We capture console.log to test the output
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputTable(['Name'], [['Smith, John']]);
+      expect(logs[0]).toContain('"Smith, John"');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('outputTable renders colon-containing values quoted', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputTable(['Key'], [['a:b']]);
+      expect(logs[0]).toContain('"a:b"');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('does not quote simple alphanumeric values', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputTable(['Name'], [['Alice']]);
+      // Tabular TOON: header on first line, values on second line starting with 2 spaces
+      expect(logs[0]).toMatch(/\n  Alice\n?$/);
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('quotes empty string values', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputTable(['Name'], [['']]);
+      expect(logs[0]).toContain('""');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('quotes boolean-looking values', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputTable(['Val'], [['true'], ['false']]);
+      expect(logs[0]).toContain('"true"');
+      expect(logs[0]).toContain('"false"');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+});
+
+describe('outputJson with TOON mode', () => {
+  it('single object output is single TOON document', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputJson({ name: 'Alice', role: 'admin' });
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain('name:');
+      expect(logs[0]).toContain('Alice');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('null values are preserved in TOON output', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputJson({ name: 'Alice', deletedAt: null });
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain('null');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('outputs a single doc (not multiple) in TOON mode', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputJson({ users: [{ id: 1 }, { id: 2 }] });
+      expect(logs).toHaveLength(1);
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+});
+
+describe('outputSuccess/outputInfo in TOON mode', () => {
+  it('outputSuccess suppresses in TOON mode', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputSuccess('done');
+      expect(logs).toHaveLength(0);
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('outputInfo suppresses in TOON mode', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputInfo('some info');
+      expect(logs).toHaveLength(0);
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('outputSuccess works normally outside TOON mode', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      outputSuccess('done');
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain('done');
+    } finally {
+      console.log = origLog;
+    }
+  });
+});
+
+describe('outputTable renders correct TOON format', () => {
+  it('produces tabular TOON with headers and rows', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputTable(['Slug', 'Status'], [['my-func', 'active'], ['other-func', 'inactive']]);
+      expect(logs[0]).toMatch(/^\[2\]\{/);
+      expect(logs[0]).toContain('my-func');
+      expect(logs[0]).toContain('active');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+
+  it('handles empty table showing header-only line', () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      setToonMode(true);
+      outputTable(['Name'], []);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toBe('[0]{Name}:');
+    } finally {
+      console.log = origLog;
+      setToonMode(false);
+    }
+  });
+});

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,4 +1,5 @@
 import Table from 'cli-table3';
+import { encode } from '@toon-format/toon';
 
 // Module-level state set by preAction hook
 let toonMode = false;
@@ -7,48 +8,11 @@ export function setToonMode(enabled: boolean): void {
   toonMode = enabled;
 }
 
-// ── TOON formatting helpers ──────────────────────────────────────────────
-
-function toonEscapeValue(v: unknown): string {
-  if (v === null || v === undefined || (typeof v === 'number' && !isFinite(v))) return 'null';
-  if (typeof v === 'boolean') return v ? 'true' : 'false';
-  if (typeof v === 'number') return String(v);
-  const s = String(v);
-  const needsQuoting =
-    s === '' ||
-    s === 'true' || s === 'false' || s === 'null' ||
-    /^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/.test(s) ||
-    /^[ \t]|[ \t]$/.test(s) ||
-    /^[-#]/.test(s) ||
-    /[:,"\\{}[\\]]/.test(s) ||
-    // eslint-disable-next-line no-control-regex
-    /[\x00-\x1f]/.test(s);
-  if (!needsQuoting) return s;
-  return '"' + s
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t')
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, c => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0')) + '"';
-}
-
-function toonEscapeKey(k: string): string {
-  if (/^[A-Za-z_][A-Za-z0-9_.]*$/.test(k)) return k;
-  return '"' + k
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t') + '"';
-}
-
 // ── Public output functions ──────────────────────────────────────────────
 
 export function outputJson(data: unknown): void {
   if (toonMode) {
-    outputJsonToon(data);
+    console.log(encode(data));
     return;
   }
   console.log(JSON.stringify(data, null, 2));
@@ -70,16 +34,59 @@ export function outputTable(headers: string[], rows: string[][]): void {
 }
 
 export function outputSuccess(message: string): void {
-  if (toonMode) return; // TOON suppress non-structured output
+  if (toonMode) {
+    // Emit structured TOON instead of suppressing
+    console.log(encode({ type: 'success', message }));
+    return;
+  }
   console.log(`✓ ${message}`);
 }
 
 export function outputInfo(message: string): void {
-  if (toonMode) return; // TOON suppress non-structured output
+  if (toonMode) {
+    // Emit structured TOON instead of suppressing
+    console.log(encode({ type: 'info', message }));
+    return;
+  }
   console.log(message);
 }
 
 // ── TOON output implementations ──────────────────────────────────────────
+
+function toonEscapeKey(k: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_.]*$/.test(k)) return k;
+  return '"' + k
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t') + '"';
+}
+
+function toonEscapeValue(v: unknown): string {
+  if (v === null || v === undefined || (typeof v === 'number' && !isFinite(v))) return 'null';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'number') return String(v);
+  const s = String(v);
+  const needsQuoting =
+    s === '' ||
+    s === 'true' || s === 'false' || s === 'null' ||
+    /^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/.test(s) ||
+    /^[ \t]|[ \t]$/.test(s) ||
+    /^[-#]/.test(s) ||
+    /[:,\\"{}\\[\\]]/.test(s) ||
+    // eslint-disable-next-line no-control-regex
+    /[\x00-\x1f]/.test(s);
+  if (!needsQuoting) return s;
+  return '"' + s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, c => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0')) + '"';
+}
 
 function outputToon(headers: string[], rows: string[][]): void {
   if (headers && rows && rows.length > 0) {
@@ -91,41 +98,5 @@ function outputToon(headers: string[], rows: string[][]): void {
     console.log(out);
   } else if (headers && headers.length > 0) {
     console.log(`[0]{${headers.map(toonEscapeKey).join(',')}}:`);
-  }
-}
-
-function outputJsonToon(data: unknown): void {
-  if (Array.isArray(data)) {
-    if (data.length === 0) { console.log('[0]:'); return; }
-    const first = data[0];
-    if (typeof first === 'object' && first !== null) {
-      const keys = Object.keys(first);
-      const keyStr = keys.map(toonEscapeKey).join(',');
-      let out = `[${data.length}]{${keyStr}}:`;
-      for (const item of data) {
-        out += '\n  ' + keys.map(k => toonEscapeValue((item as Record<string, unknown>)[k])).join(',');
-      }
-      console.log(out);
-    } else {
-      const vals = data.map(v => toonEscapeValue(v)).join(',');
-      console.log(`[${data.length}]: ${vals}`);
-    }
-    return;
-  }
-  // Single object → TOON key-value
-  if (typeof data === 'object' && data !== null) {
-    for (const [k, v] of Object.entries(data as Record<string, unknown>)) {
-      if (v === null || v === undefined) continue;
-      const ek = toonEscapeKey(k);
-      if (typeof v === 'object' && !Array.isArray(v)) {
-        let nested: string;
-        try { nested = JSON.stringify(v); } catch { nested = '[complex value]'; }
-        console.log(`${ek}: ${nested}`);
-      } else {
-        console.log(`${ek}: ${toonEscapeValue(v)}`);
-      }
-    }
-  } else {
-    console.log(toonEscapeValue(data));
   }
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,10 +1,62 @@
 import Table from 'cli-table3';
 
+// Module-level state set by preAction hook
+let toonMode = false;
+
+export function setToonMode(enabled: boolean): void {
+  toonMode = enabled;
+}
+
+// ── TOON formatting helpers ──────────────────────────────────────────────
+
+function toonEscapeValue(v: unknown): string {
+  if (v === null || v === undefined || (typeof v === 'number' && !isFinite(v))) return 'null';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'number') return String(v);
+  const s = String(v);
+  const needsQuoting =
+    s === '' ||
+    s === 'true' || s === 'false' || s === 'null' ||
+    /^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/.test(s) ||
+    /^[ \t]|[ \t]$/.test(s) ||
+    /^[-#]/.test(s) ||
+    /[:,"\\{}\[\]]/.test(s) ||
+    /[\x00-\x1f]/.test(s);
+  if (!needsQuoting) return s;
+  return '"' + s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, c => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0')) + '"';
+}
+
+function toonEscapeKey(k: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_.]*$/.test(k)) return k;
+  return '"' + k
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t') + '"';
+}
+
+// ── Public output functions ──────────────────────────────────────────────
+
 export function outputJson(data: unknown): void {
+  if (toonMode) {
+    outputJsonToon(data);
+    return;
+  }
   console.log(JSON.stringify(data, null, 2));
 }
 
 export function outputTable(headers: string[], rows: string[][]): void {
+  if (toonMode) {
+    outputToon(headers, rows);
+    return;
+  }
   const table = new Table({
     head: headers,
     style: { head: ['cyan'] },
@@ -16,9 +68,62 @@ export function outputTable(headers: string[], rows: string[][]): void {
 }
 
 export function outputSuccess(message: string): void {
+  if (toonMode) return; // TOON suppress non-structured output
   console.log(`✓ ${message}`);
 }
 
 export function outputInfo(message: string): void {
+  if (toonMode) return; // TOON suppress non-structured output
   console.log(message);
+}
+
+// ── TOON output implementations ──────────────────────────────────────────
+
+function outputToon(headers: string[], rows: string[][]): void {
+  if (headers && rows && rows.length > 0) {
+    const keyStr = headers.map(toonEscapeKey).join(',');
+    let out = `[${rows.length}]{${keyStr}}:`;
+    for (const row of rows) {
+      out += '\n  ' + row.map(toonEscapeValue).join(',');
+    }
+    console.log(out);
+  } else if (headers && headers.length > 0) {
+    console.log(`[0]{${headers.map(toonEscapeKey).join(',')}}:`);
+  }
+}
+
+function outputJsonToon(data: unknown): void {
+  if (Array.isArray(data)) {
+    if (data.length === 0) { console.log('[0]:'); return; }
+    const first = data[0];
+    if (typeof first === 'object' && first !== null) {
+      const keys = Object.keys(first);
+      const keyStr = keys.map(toonEscapeKey).join(',');
+      let out = `[${data.length}]{${keyStr}}:`;
+      for (const item of data) {
+        out += '\n  ' + keys.map(k => toonEscapeValue((item as Record<string, unknown>)[k])).join(',');
+      }
+      console.log(out);
+    } else {
+      const vals = data.map(v => toonEscapeValue(v)).join(',');
+      console.log(`[${data.length}]: ${vals}`);
+    }
+    return;
+  }
+  // Single object → TOON key-value
+  if (typeof data === 'object' && data !== null) {
+    for (const [k, v] of Object.entries(data as Record<string, unknown>)) {
+      if (v === null || v === undefined) continue;
+      const ek = toonEscapeKey(k);
+      if (typeof v === 'object' && !Array.isArray(v)) {
+        let nested: string;
+        try { nested = JSON.stringify(v); } catch { nested = '[complex value]'; }
+        console.log(`${ek}: ${nested}`);
+      } else {
+        console.log(`${ek}: ${toonEscapeValue(v)}`);
+      }
+    }
+  } else {
+    console.log(toonEscapeValue(data));
+  }
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -34,20 +34,12 @@ export function outputTable(headers: string[], rows: string[][]): void {
 }
 
 export function outputSuccess(message: string): void {
-  if (toonMode) {
-    // Emit structured TOON instead of suppressing
-    console.log(encode({ type: 'success', message }));
-    return;
-  }
+  if (toonMode) return;
   console.log(`✓ ${message}`);
 }
 
 export function outputInfo(message: string): void {
-  if (toonMode) {
-    // Emit structured TOON instead of suppressing
-    console.log(encode({ type: 'info', message }));
-    return;
-  }
+  if (toonMode) return;
   console.log(message);
 }
 
@@ -74,7 +66,7 @@ function toonEscapeValue(v: unknown): string {
     /^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/.test(s) ||
     /^[ \t]|[ \t]$/.test(s) ||
     /^[-#]/.test(s) ||
-    /[:,\\"{}\\[\\]]/.test(s) ||
+    /[\]:,"\\{}[]/.test(s) ||
     // eslint-disable-next-line no-control-regex
     /[\x00-\x1f]/.test(s);
   if (!needsQuoting) return s;

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -20,7 +20,8 @@ function toonEscapeValue(v: unknown): string {
     /^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/.test(s) ||
     /^[ \t]|[ \t]$/.test(s) ||
     /^[-#]/.test(s) ||
-    /[:,"\\{}\[\]]/.test(s) ||
+    /[:,"\\{}[\\]]/.test(s) ||
+    // eslint-disable-next-line no-control-regex
     /[\x00-\x1f]/.test(s);
   if (!needsQuoting) return s;
   return '"' + s
@@ -29,6 +30,7 @@ function toonEscapeValue(v: unknown): string {
     .replace(/\n/g, '\\n')
     .replace(/\r/g, '\\r')
     .replace(/\t/g, '\\t')
+    // eslint-disable-next-line no-control-regex
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, c => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0')) + '"';
 }
 


### PR DESCRIPTION
## Summary

Add a global `--toon` flag that outputs results in **TOON** (Token-Oriented Object Notation), designed for LLM consumption — 6-9x more compact than JSON or human-readable tables.

## Performance

Measured on `insforge projects list`:
| Format | Size | vs JSON |
|--------|------|---------|
| TOON | 129 B | **7.7× smaller** |
| JSON | 989 B | 1× (baseline) |
| Human table | 1,162 B | 0.85× |

## Usage

```
insforge projects list --toon
# [2]{ID,Name,Region,Status,AppKey}:
#   uuid-1,my-project,us-east,active,key-1
#   uuid-2,other-project,eu-west,active,key-2

insforge whoami --json --toon
# id: 3db0ba25-...
# name: Alice
# email: alice@example.com

insforge functions list --toon
# [3]{Slug,Name,Status,"Created At"}:
#   func-1,My Function,active,"2026-07-30, 10:00:00 AM"
```

## Implementation

- **TOON format**: toonformat.dev — token-optimized notation with 36+ language implementations
- **Module-level flag** set via Commander `preAction` hook, read by `outputTable` and `outputJson` at render time — zero changes to any command handler
- **Spec compliance**: `toonEscapeValue` / `toonEscapeKey` conform to TOON SPEC §7.1-7.3 (escaping, quoting rules, key encoding)
- **Non-structured suppression**: `outputSuccess`/ `outputInfo` silently skipped in TOON mode to keep output parseable

## Testing

- `npm run build`: tsup compiles clean (601 KB ESM)
- `npm test`: 649 tests pass (1 pre-existing Cloudflare OAuth failure unrelated)
- Manual integration: `projects list`, `whoami`, `functions list`, `orgs list` with `--toon` and `--json --toon`

Root commands (create, login, feedback, etc.) produce no TOON output — they emit interactive prompts and status messages, not structured data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global `--toon` output format for token‑optimized results, ~6–9× smaller than JSON or tables. Uses `@toon-format/toon` `encode()` and suppresses non‑structured messages to keep output parseable.

- **New Features**
  - Global `--toon` via pre‑action hook; `outputJson` uses `encode()` and tables render as tabular TOON.
  - Spec‑compliant escaping for headers/values; interactive root commands unchanged.

- **Bug Fixes**
  - Treat `--toon` as implying JSON in `getRootOpts` to avoid empty output and credential loss.
  - Quote structural characters correctly and suppress `outputSuccess`/`outputInfo` in TOON mode; add tests for quoting, nulls, single‑doc output, and empty tables.

<sup>Written for commit 0b66a55626b4b467c3befaa999931a112c86b70a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--toon` global CLI flag for token-optimized TOON format output
> - Adds a `--toon` global flag to the CLI that switches all output to [TOON format](https://toonformat.dev) using the `@toon-format/toon` package.
> - In TOON mode, `outputJson` encodes data via `encode()`, `outputTable` renders a tabular TOON document with header schema and row values, and `outputSuccess`/`outputInfo` are silently suppressed.
> - Updates `getRootOpts().json` in [errors.ts](https://github.com/InsForge/CLI/pull/215/files#diff-33a1fa952d3520ae3b8ff121fe89f8d401e10efd4cbf34f180663caa16c0f153) to return `true` when `--toon` is active, so error-handling code treats TOON mode like JSON mode.
> - Behavioral Change: success and info messages are fully suppressed when `--toon` is used, which may hide feedback in interactive workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b66a55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a global `--toon` option for structured TOON-formatted command output.
  - JSON and table responses now support TOON formatting.
  - TOON mode is applied consistently across command actions and error handling.
- **Bug Fixes**
  - Improved consistency between TOON and standard JSON output behavior.
  - Success and informational messages are suppressed in TOON mode to preserve structured output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->