### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps `@insforge/cli` from `0.2.1` to `0.2.2`.

`0.2.1` is already released (git tag, GitHub Release, and on npm), and 23 non-merge commits have landed on `main` since — most notably self-hosted Apify connect (#217), several deploy-polling fixes around transient 5xx/429/408, the legacy OSS sentinel project/org ID heal, and redacting the privileged api_key from `current --json`.

Also syncs `package-lock.json`, which was still reporting `0.2.0` — earlier bump commits touched only `package.json`, so the lock had drifted a version behind. Regenerated with `npm install --package-lock-only`; the diff is the two `version` fields and nothing else, no dependency churn.

Verified: `npm ci` installs from the updated lock, `npm run build` succeeds, `npm test` passes 677/13 skipped, and the built `dist/index.js` reports `0.2.2`.

Note this only prepares the version — per `67a6478`, publishing triggers on creating a GitHub Release, not on a tag push.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `@insforge/cli` to 0.2.2 and align `package-lock.json` (was 0.2.0) with `package.json`. No dependency changes; publishing happens when a GitHub Release is created.

<sup>Written for commit dc01d8bede7ae8829fa047cbbcc473890348f5cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to 0.2.2
> Updates the version field in [package.json](https://github.com/InsForge/CLI/pull/218/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.2.1` to `0.2.2` and regenerates the lockfile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc01d8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->