### PR TITLE
fix: stop reaching for db query --unrestricted outside operator triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,6 @@ Execute a raw SQL query.
 ```bash
 npx @insforge/cli db query "SELECT * FROM users LIMIT 10"
 npx @insforge/cli db query "SELECT count(*) FROM orders" --json
-npx @insforge/cli db query "SELECT * FROM pg_tables" --unrestricted
 ```
 
 #### `npx @insforge/cli db tables`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -704,7 +704,11 @@ export async function downloadGitHubTemplate(
       dbSpinner?.start('Running database migrations...');
       try {
         const sql = await fs.readFile(migrationPath, 'utf-8');
-        await runRawSql(sql, true);
+        // Applied as project_admin, the same privileges the retry hint below
+        // prints. Template init SQL is ordinary `public` schema setup and must
+        // not need the unrestricted (root) endpoint — that is reserved for
+        // operator triage, not for anything a template runs unattended.
+        await runRawSql(sql);
         dbSpinner?.stop('Database migrations applied');
       } catch (err) {
         dbSpinner?.stop('Database migration failed');

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -710,7 +710,7 @@ export async function downloadGitHubTemplate(
         dbSpinner?.stop('Database migration failed');
         if (!json) {
           clack.log.warn(`Migration failed: ${(err as Error).message}`);
-          clack.log.info('You can run the migration manually: npx @insforge/cli db query --unrestricted "$(cat migrations/db_init.sql)"');
+          clack.log.info('You can run the migration manually: npx @insforge/cli db query "$(cat migrations/db_init.sql)"');
         } else {
           throw err;
         }

--- a/src/commands/diagnose/db.ts
+++ b/src/commands/diagnose/db.ts
@@ -145,11 +145,29 @@ const DB_CHECKS: Record<string, DbCheck> = {
 
 const ALL_CHECKS = Object.keys(DB_CHECKS);
 
+/**
+ * Runs one health check on the unrestricted (root) SQL endpoint.
+ *
+ * `diagnose` is the operator triage path, which is the only sanctioned use of
+ * unrestricted execution — nothing else in the CLI should reach for it, and no
+ * command should suggest that users do. Root is required rather than merely
+ * convenient: as `project_admin`, `pg_stat_activity` masks the `query` text of
+ * backends owned by other roles as `<insufficient privilege>`, which would
+ * blank out the slow-query and lock checks.
+ *
+ * Every statement passed here is a fixed, read-only SELECT over Postgres
+ * statistics views declared in `DB_CHECKS` above. Do not widen this helper to
+ * accept caller-supplied or interpolated SQL.
+ */
+async function runDbCheckSql(sql: string): Promise<{ rows: Record<string, unknown>[] }> {
+  return runRawSql(sql, true);
+}
+
 export async function runDbChecks(): Promise<Record<string, Record<string, unknown>[]>> {
   const results: Record<string, Record<string, unknown>[]> = {};
   for (const key of ALL_CHECKS) {
     try {
-      const { rows } = await runRawSql(DB_CHECKS[key].sql, true);
+      const { rows } = await runDbCheckSql(DB_CHECKS[key].sql);
       results[key] = rows;
     } catch {
       results[key] = [];
@@ -185,7 +203,7 @@ export function registerDiagnoseDbCommand(diagnoseCmd: Command): void {
             continue;
           }
           try {
-            const { rows } = await runRawSql(check.sql, true);
+            const { rows } = await runDbCheckSql(check.sql);
             results[name] = rows;
           } catch (err) {
             results[name] = [];


### PR DESCRIPTION
`--unrestricted` routes `db query` to `/api/database/advance/rawsql/unrestricted`, which executes as **root** instead of `project_admin` (`src/lib/api/oss.ts:27-30`; server side, `withAdminContext` does `SET ROLE project_admin` for the restricted path). That privilege level is for InsForge operator triage only — it shouldn't be advertised to users, and nothing should reach for it unattended.

## Changes

**1. Stop suggesting the flag to users** (`e96a066`)
- `README.md` — dropped the `SELECT * FROM pg_tables ... --unrestricted` example from the `db query` snippet
- `src/commands/create.ts` — dropped the flag from the manual-retry hint printed when a template's `migrations/db_init.sql` fails

**2. Stop escalating silently in `create`** (`a7e11f2`)
- `src/commands/create.ts:707` called `runRawSql(sql, true)`, applying template init SQL as root with no user opt-in (the confirm prompt was removed in `1fb1c56`). Now `runRawSql(sql)` — `project_admin`, matching what the retry hint prints.

**3. Audit of remaining unrestricted call sites** (`a7e11f2`)
- Both are in `src/commands/diagnose/db.ts` — the triage command itself, i.e. the sanctioned use. Routed through one documented helper (`runDbCheckSql`) recording why root is genuinely required there (as `project_admin`, `pg_stat_activity` masks the `query` text of backends owned by other roles as `<insufficient privilege>`, blanking out the slow-query and lock checks) and that the SQL is a fixed read-only allowlist over Postgres statistics views, never caller-supplied.
- `src/lib/guard/inspect.ts:126` already uses the restricted path. The flag itself (`src/commands/db/query.ts`, `src/lib/api/oss.ts`) is untouched, so explicit `--unrestricted` use still works for triage.

**4. Version bump** (`b40e185`)
- `0.2.3` → `0.2.4` (patch), `package.json` + `package-lock.json`, per the repo's bump convention.

Left alone: the argv-passthrough comment in `src/lib/guard/index.ts` (internal note, not a usage suggestion) and `docs/specs/2026-03-27-diagnose-command-design.md` (dated design record).

## Why `project_admin` is sufficient for the templates

Checked all 11 templates in `InsForge/insforge-templates`; 9 ship a `migrations/db_init.sql`, and none needs root:

- `create extension if not exists pgcrypto` (7 templates) and `vector` (ai-pdf-chatbot) are no-ops — the backend pre-installs both in its own migrations `021` and `050`
- `citext` (landing) is a PG13+ *trusted* extension, installable by a non-superuser holding `CREATE ON DATABASE`
- `create schema if not exists better_auth` (ai-pdf-chatbot) needs that same `CREATE ON DATABASE`, granted to `project_admin` by backend migration `048` — whose stated purpose is "so dashboard/custom migration DDL can rely on the role's native permissions instead of root-owned backdoors"

Backend migration `046` puts it directly: "Raw SQL and custom migrations now execute as project_admin, so new public objects are naturally owned by that role. Existing public objects may have been created by the old root execution path" — and it backfills ownership of those. The `create` path was the last root back door still producing exactly the drift `046` cleans up.

Consequence worth knowing: template tables and functions are now owned by `project_admin`, so the `SECURITY DEFINER` RLS-recursion helpers in `crm` / `e-commerce` / `admin-dashboard` execute as `project_admin` rather than root. That's the posture `046` intends, and owner-exempt RLS still applies since `project_admin` owns the tables.

## Verification

- `vitest run` — 692 passed, 13 skipped, 0 failed
- `eslint src/commands/create.ts src/commands/diagnose/db.ts` — clean
- `tsc --noEmit` — output byte-identical to the same run on `main` (16 pre-existing errors in unrelated files; none in the changed files)
- Not run against a live project: the reasoning above is from the template SQL and the backend role migrations, not an observed `insforge create`. Worth one real run against `ai-pdf-chatbot` (the only template creating a schema) before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop suggesting and silently using unrestricted DB access: template `db_init.sql` now runs as `project_admin` (not root), and the README and the `create` retry hint no longer show `--unrestricted`.
Unrestricted queries remain for operator triage via `diagnose db` and for users who pass `--unrestricted` explicitly.

<sup>Written for commit a7e11f2e870dcf9b88fea0360cd4c5e45bf20469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the unrestricted database query example from the README.
  * Updated migration failure guidance to omit the unrestricted option from the manual command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `--unrestricted` flag from suggested `db query` commands in docs and CLI
> Removes the `--unrestricted` flag from the example `db query` command in [README.md](https://github.com/InsForge/CLI/pull/221/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and from the migration failure hint in [src/commands/create.ts](https://github.com/InsForge/CLI/pull/221/files#diff-b6d810b0306723c2b160e529addd463ae24be806303358ff1f6a2209bc13357d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e96a066.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
