### PR TITLE
feat: CLI Optimization Stage II — advisor, orgs leave/delete, self-hosted backups, ai overview

### DIFF
--- a/src/commands/advisor/index.test.ts
+++ b/src/commands/advisor/index.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { registerAdvisorCommands } from './index.js';
+
+vi.mock('../../lib/api/oss.js', () => ({
+  triggerAdvisorScan: vi.fn(async () => ({ scanId: 'scan-1', message: 'Scan started' })),
+  listAdvisorSuppressions: vi.fn(async () => [
+    {
+      id: 'sup-1',
+      ruleId: 'rls_disabled',
+      scope: 'instance',
+      affectedObject: 'public.todos',
+      reason: 'accepted_risk',
+      createdAt: '2026-08-01T00:00:00Z',
+    },
+  ]),
+  createAdvisorSuppression: vi.fn(async () => ({
+    id: 'sup-2',
+    ruleId: 'rls_disabled',
+    scope: 'rule',
+    reason: 'false_positive',
+    createdAt: '2026-08-01T00:00:00Z',
+  })),
+  deleteAdvisorSuppression: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/command-telemetry.js', () => ({
+  trackCommandUsage: vi.fn(async () => {}),
+}));
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>');
+  const advisorCmd = program.command('advisor');
+  registerAdvisorCommands(advisorCmd);
+  return program;
+}
+
+async function runWithCapturedLog(program: Command, argv: string[]): Promise<string[]> {
+  const logs: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return logs;
+}
+
+describe('advisor commands', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('scan --json emits the scan id', async () => {
+    const logs = await runWithCapturedLog(makeProgram(), ['advisor', 'scan', '--json']);
+    expect(JSON.parse(logs.join('\n'))).toEqual({ scanId: 'scan-1', message: 'Scan started' });
+  });
+
+  it('suppress with --object creates an instance-scoped suppression', async () => {
+    const { createAdvisorSuppression } = await import('../../lib/api/oss.js');
+    await runWithCapturedLog(makeProgram(), [
+      'advisor', 'suppress', 'rls_disabled',
+      '--object', 'public.todos',
+      '--reason', 'accepted_risk',
+      '--json',
+    ]);
+    expect(createAdvisorSuppression).toHaveBeenCalledWith({
+      ruleId: 'rls_disabled',
+      scope: 'instance',
+      affectedObject: 'public.todos',
+      reason: 'accepted_risk',
+    });
+  });
+
+  it('suppress without --object suppresses the whole rule', async () => {
+    const { createAdvisorSuppression } = await import('../../lib/api/oss.js');
+    await runWithCapturedLog(makeProgram(), [
+      'advisor', 'suppress', 'rls_disabled', '--reason', 'false_positive', '--json',
+    ]);
+    expect(createAdvisorSuppression).toHaveBeenCalledWith({
+      ruleId: 'rls_disabled',
+      scope: 'rule',
+      reason: 'false_positive',
+    });
+  });
+
+  it('suppress rejects an invalid --reason without calling the API', async () => {
+    const { createAdvisorSuppression } = await import('../../lib/api/oss.js');
+    await expect(
+      runWithCapturedLog(makeProgram(), [
+        'advisor', 'suppress', 'rls_disabled', '--reason', 'nope', '--json',
+      ]),
+    ).rejects.toThrow('process.exit');
+    expect(createAdvisorSuppression).not.toHaveBeenCalled();
+  });
+
+  it('suppress requires --note when --reason is "other"', async () => {
+    const { createAdvisorSuppression } = await import('../../lib/api/oss.js');
+    await expect(
+      runWithCapturedLog(makeProgram(), [
+        'advisor', 'suppress', 'rls_disabled', '--reason', 'other', '--json',
+      ]),
+    ).rejects.toThrow('process.exit');
+    expect(createAdvisorSuppression).not.toHaveBeenCalled();
+  });
+
+  it('suppressions --json lists suppressions', async () => {
+    const logs = await runWithCapturedLog(makeProgram(), ['advisor', 'suppressions', '--json']);
+    const data = JSON.parse(logs.join('\n')) as { id: string }[];
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe('sup-1');
+  });
+
+  it('unsuppress --json deletes by id', async () => {
+    const { deleteAdvisorSuppression } = await import('../../lib/api/oss.js');
+    const logs = await runWithCapturedLog(makeProgram(), ['advisor', 'unsuppress', 'sup-1', '--json']);
+    expect(deleteAdvisorSuppression).toHaveBeenCalledWith('sup-1');
+    expect(JSON.parse(logs.join('\n'))).toEqual({ deleted: true, suppression_id: 'sup-1' });
+  });
+
+  it('tracks telemetry on success', async () => {
+    const { trackCommandUsage } = await import('../../lib/command-telemetry.js');
+    await runWithCapturedLog(makeProgram(), ['advisor', 'scan', '--json']);
+    expect((trackCommandUsage as Mock).mock.calls[0].slice(0, 3)).toEqual(['advisor', 'scan', true]);
+  });
+});

--- a/src/commands/advisor/index.test.ts
+++ b/src/commands/advisor/index.test.ts
@@ -34,7 +34,9 @@ vi.mock('../../lib/credentials.js', () => ({
 
 function makeProgram() {
   const program = new Command().exitOverride();
-  program.option('--json').option('--api-url <url>');
+  // --reason mirrors the real root program's global guard flag — it shadows
+  // the suppress command's local --reason in Commander's parse.
+  program.option('--json').option('--api-url <url>').option('--reason <text>');
   const advisorCmd = program.command('advisor');
   registerAdvisorCommands(advisorCmd);
   return program;

--- a/src/commands/advisor/index.test.ts
+++ b/src/commands/advisor/index.test.ts
@@ -28,6 +28,10 @@ vi.mock('../../lib/command-telemetry.js', () => ({
   trackCommandUsage: vi.fn(async () => {}),
 }));
 
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok' })),
+}));
+
 function makeProgram() {
   const program = new Command().exitOverride();
   program.option('--json').option('--api-url <url>');
@@ -51,6 +55,7 @@ async function runWithCapturedLog(program: Command, argv: string[]): Promise<str
 
 describe('advisor commands', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errors: string[];
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -58,7 +63,10 @@ describe('advisor commands', () => {
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    errors = [];
+    errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    });
   });
 
   afterEach(() => {
@@ -101,12 +109,15 @@ describe('advisor commands', () => {
 
   it('suppress rejects an invalid --reason without calling the API', async () => {
     const { createAdvisorSuppression } = await import('../../lib/api/oss.js');
+    const { trackCommandUsage } = await import('../../lib/command-telemetry.js');
     await expect(
       runWithCapturedLog(makeProgram(), [
         'advisor', 'suppress', 'rls_disabled', '--reason', 'nope', '--json',
       ]),
     ).rejects.toThrow('process.exit');
     expect(createAdvisorSuppression).not.toHaveBeenCalled();
+    expect(errors.join('\n')).toContain('Invalid --reason');
+    expect((trackCommandUsage as Mock).mock.calls[0].slice(0, 3)).toEqual(['advisor', 'suppress', false]);
   });
 
   it('suppress requires --note when --reason is "other"', async () => {
@@ -117,6 +128,18 @@ describe('advisor commands', () => {
       ]),
     ).rejects.toThrow('process.exit');
     expect(createAdvisorSuppression).not.toHaveBeenCalled();
+    expect(errors.join('\n')).toContain('--note is required');
+  });
+
+  it('suppress rejects an explicitly empty --object instead of widening to rule scope', async () => {
+    const { createAdvisorSuppression } = await import('../../lib/api/oss.js');
+    await expect(
+      runWithCapturedLog(makeProgram(), [
+        'advisor', 'suppress', 'rls_disabled', '--object', '', '--reason', 'accepted_risk', '--json',
+      ]),
+    ).rejects.toThrow('process.exit');
+    expect(createAdvisorSuppression).not.toHaveBeenCalled();
+    expect(errors.join('\n')).toContain('--object cannot be empty');
   });
 
   it('suppressions --json lists suppressions', async () => {
@@ -124,6 +147,21 @@ describe('advisor commands', () => {
     const data = JSON.parse(logs.join('\n')) as { id: string }[];
     expect(data).toHaveLength(1);
     expect(data[0].id).toBe('sup-1');
+  });
+
+  it('suppressions renders a human-readable table', async () => {
+    const logs = await runWithCapturedLog(makeProgram(), ['advisor', 'suppressions']);
+    const out = logs.join('\n');
+    expect(out).toContain('rls_disabled');
+    expect(out).toContain('public.todos');
+    expect(out).toContain('accepted_risk');
+  });
+
+  it('suppressions reports the empty state', async () => {
+    const { listAdvisorSuppressions } = await import('../../lib/api/oss.js');
+    (listAdvisorSuppressions as Mock).mockResolvedValueOnce([]);
+    const logs = await runWithCapturedLog(makeProgram(), ['advisor', 'suppressions']);
+    expect(logs.join('\n')).toContain('No suppressions found.');
   });
 
   it('unsuppress --json deletes by id', async () => {

--- a/src/commands/advisor/index.ts
+++ b/src/commands/advisor/index.ts
@@ -5,27 +5,22 @@ import {
   createAdvisorSuppression,
   deleteAdvisorSuppression,
 } from '../../lib/api/oss.js';
+import { requireAuth } from '../../lib/credentials.js';
 import { CLIError, handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import { ADVISOR_SUPPRESSION_REASONS } from '../../types.js';
 import type { AdvisorSuppressionReason, AdvisorSuppressionScope } from '../../types.js';
-
-const SUPPRESSION_REASONS: AdvisorSuppressionReason[] = [
-  'false_positive',
-  'accepted_risk',
-  'wont_fix',
-  'other',
-];
 
 function assertReason(reason: string | undefined): AdvisorSuppressionReason {
   if (!reason) {
     throw new CLIError(
-      `Missing --reason. Valid reasons: ${SUPPRESSION_REASONS.join(', ')}.`,
+      `Missing --reason. Valid reasons: ${ADVISOR_SUPPRESSION_REASONS.join(', ')}.`,
     );
   }
-  if (!SUPPRESSION_REASONS.includes(reason as AdvisorSuppressionReason)) {
+  if (!(ADVISOR_SUPPRESSION_REASONS as readonly string[]).includes(reason)) {
     throw new CLIError(
-      `Invalid --reason "${reason}". Valid reasons: ${SUPPRESSION_REASONS.join(', ')}.`,
+      `Invalid --reason "${reason}". Valid reasons: ${ADVISOR_SUPPRESSION_REASONS.join(', ')}.`,
     );
   }
   return reason as AdvisorSuppressionReason;
@@ -36,8 +31,9 @@ export function registerAdvisorCommands(advisorCmd: Command): void {
     .command('scan')
     .description('Trigger an advisor scan now (instead of waiting for the schedule)')
     .action(async (_opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
+        await requireAuth(apiUrl);
         const result = await triggerAdvisorScan();
         await trackCommandUsage('advisor', 'scan', true);
         if (json) {
@@ -57,8 +53,9 @@ export function registerAdvisorCommands(advisorCmd: Command): void {
     .command('suppressions')
     .description('List suppressed advisor findings')
     .action(async (_opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
+        await requireAuth(apiUrl);
         const suppressions = await listAdvisorSuppressions();
         await trackCommandUsage('advisor', 'suppressions', true, {
           result_count: suppressions.length,
@@ -93,22 +90,29 @@ export function registerAdvisorCommands(advisorCmd: Command): void {
       '--object <affectedObject>',
       'Suppress only the finding for this affected object (default: the whole rule)',
     )
-    .option('--reason <reason>', `Why it is suppressed (${SUPPRESSION_REASONS.join(' | ')})`)
+    .option('--reason <reason>', `Why it is suppressed (${ADVISOR_SUPPRESSION_REASONS.join(' | ')})`)
     .option('--note <note>', 'Free-form note (required when --reason is "other")')
     .action(async (ruleId: string, opts: { object?: string; reason?: string; note?: string }, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
+        await requireAuth(apiUrl);
         const reason = assertReason(opts.reason);
-        if (reason === 'other' && !opts.note?.trim()) {
+        // The backend matches affectedObject verbatim against scan findings,
+        // so pass it through untrimmed — but a blank value is always a mistake.
+        if (opts.object !== undefined && opts.object.trim() === '') {
+          throw new CLIError('--object cannot be empty. Pass the finding\'s Affected Object exactly, or omit --object to suppress the whole rule.');
+        }
+        const note = opts.note?.trim();
+        if (reason === 'other' && !note) {
           throw new CLIError('--note is required when --reason is "other".');
         }
-        const scope: AdvisorSuppressionScope = opts.object ? 'instance' : 'rule';
+        const scope: AdvisorSuppressionScope = opts.object !== undefined ? 'instance' : 'rule';
         const suppression = await createAdvisorSuppression({
           ruleId,
           scope,
-          ...(opts.object ? { affectedObject: opts.object } : {}),
+          ...(opts.object !== undefined ? { affectedObject: opts.object } : {}),
           reason,
-          ...(opts.note ? { note: opts.note } : {}),
+          ...(note ? { note } : {}),
         });
         await trackCommandUsage('advisor', 'suppress', true, { scope, reason });
         if (json) {
@@ -129,8 +133,9 @@ export function registerAdvisorCommands(advisorCmd: Command): void {
     .command('unsuppress <suppressionId>')
     .description('Remove a suppression so the finding shows up again')
     .action(async (suppressionId: string, _opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
+        await requireAuth(apiUrl);
         await deleteAdvisorSuppression(suppressionId);
         await trackCommandUsage('advisor', 'unsuppress', true);
         if (json) {

--- a/src/commands/advisor/index.ts
+++ b/src/commands/advisor/index.ts
@@ -98,7 +98,9 @@ export function registerAdvisorCommands(advisorCmd: Command): void {
         await requireAuth(apiUrl);
         // The guard's global --reason on the root command wins Commander's
         // parse, so the local option never receives the value — read the
-        // merged view instead.
+        // merged view instead. If this command is ever added to the guard
+        // registry, the guard's intent text would share this flag; the enum
+        // check below rejects such free text loudly.
         const reason = assertReason(opts.reason ?? (cmd.optsWithGlobals().reason as string | undefined));
         // The backend matches affectedObject verbatim against scan findings,
         // so pass it through untrimmed — but a blank value is always a mistake.

--- a/src/commands/advisor/index.ts
+++ b/src/commands/advisor/index.ts
@@ -1,0 +1,146 @@
+import type { Command } from 'commander';
+import {
+  triggerAdvisorScan,
+  listAdvisorSuppressions,
+  createAdvisorSuppression,
+  deleteAdvisorSuppression,
+} from '../../lib/api/oss.js';
+import { CLIError, handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import type { AdvisorSuppressionReason, AdvisorSuppressionScope } from '../../types.js';
+
+const SUPPRESSION_REASONS: AdvisorSuppressionReason[] = [
+  'false_positive',
+  'accepted_risk',
+  'wont_fix',
+  'other',
+];
+
+function assertReason(reason: string | undefined): AdvisorSuppressionReason {
+  if (!reason) {
+    throw new CLIError(
+      `Missing --reason. Valid reasons: ${SUPPRESSION_REASONS.join(', ')}.`,
+    );
+  }
+  if (!SUPPRESSION_REASONS.includes(reason as AdvisorSuppressionReason)) {
+    throw new CLIError(
+      `Invalid --reason "${reason}". Valid reasons: ${SUPPRESSION_REASONS.join(', ')}.`,
+    );
+  }
+  return reason as AdvisorSuppressionReason;
+}
+
+export function registerAdvisorCommands(advisorCmd: Command): void {
+  advisorCmd
+    .command('scan')
+    .description('Trigger an advisor scan now (instead of waiting for the schedule)')
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const result = await triggerAdvisorScan();
+        await trackCommandUsage('advisor', 'scan', true);
+        if (json) {
+          outputJson(result);
+        } else {
+          outputSuccess(
+            `Advisor scan started (${result.scanId}). View results with \`insforge diagnose advisor\`.`,
+          );
+        }
+      } catch (err) {
+        await trackCommandUsage('advisor', 'scan', false, {}, err);
+        handleError(err, json);
+      }
+    });
+
+  advisorCmd
+    .command('suppressions')
+    .description('List suppressed advisor findings')
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const suppressions = await listAdvisorSuppressions();
+        await trackCommandUsage('advisor', 'suppressions', true, {
+          result_count: suppressions.length,
+        });
+        if (json) {
+          outputJson(suppressions);
+        } else if (!suppressions.length) {
+          outputInfo('No suppressions found.');
+        } else {
+          outputTable(
+            ['ID', 'Rule', 'Scope', 'Affected Object', 'Reason', 'Created'],
+            suppressions.map((s) => [
+              s.id,
+              s.ruleId,
+              s.scope,
+              s.affectedObject ?? '-',
+              s.reason,
+              new Date(s.createdAt).toLocaleDateString(),
+            ]),
+          );
+        }
+      } catch (err) {
+        await trackCommandUsage('advisor', 'suppressions', false, {}, err);
+        handleError(err, json);
+      }
+    });
+
+  advisorCmd
+    .command('suppress <ruleId>')
+    .description('Suppress an advisor finding (dismiss a false positive with a recorded reason)')
+    .option(
+      '--object <affectedObject>',
+      'Suppress only the finding for this affected object (default: the whole rule)',
+    )
+    .option('--reason <reason>', `Why it is suppressed (${SUPPRESSION_REASONS.join(' | ')})`)
+    .option('--note <note>', 'Free-form note (required when --reason is "other")')
+    .action(async (ruleId: string, opts: { object?: string; reason?: string; note?: string }, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const reason = assertReason(opts.reason);
+        if (reason === 'other' && !opts.note?.trim()) {
+          throw new CLIError('--note is required when --reason is "other".');
+        }
+        const scope: AdvisorSuppressionScope = opts.object ? 'instance' : 'rule';
+        const suppression = await createAdvisorSuppression({
+          ruleId,
+          scope,
+          ...(opts.object ? { affectedObject: opts.object } : {}),
+          reason,
+          ...(opts.note ? { note: opts.note } : {}),
+        });
+        await trackCommandUsage('advisor', 'suppress', true, { scope, reason });
+        if (json) {
+          outputJson(suppression);
+        } else {
+          const target = scope === 'instance' ? `"${ruleId}" on ${opts.object}` : `rule "${ruleId}"`;
+          outputSuccess(
+            `Suppressed ${target} (${suppression.id}). Undo with \`insforge advisor unsuppress ${suppression.id}\`.`,
+          );
+        }
+      } catch (err) {
+        await trackCommandUsage('advisor', 'suppress', false, {}, err);
+        handleError(err, json);
+      }
+    });
+
+  advisorCmd
+    .command('unsuppress <suppressionId>')
+    .description('Remove a suppression so the finding shows up again')
+    .action(async (suppressionId: string, _opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        await deleteAdvisorSuppression(suppressionId);
+        await trackCommandUsage('advisor', 'unsuppress', true);
+        if (json) {
+          outputJson({ deleted: true, suppression_id: suppressionId });
+        } else {
+          outputSuccess(`Suppression ${suppressionId} removed. The finding will reappear on the next scan.`);
+        }
+      } catch (err) {
+        await trackCommandUsage('advisor', 'unsuppress', false, {}, err);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/advisor/index.ts
+++ b/src/commands/advisor/index.ts
@@ -96,7 +96,10 @@ export function registerAdvisorCommands(advisorCmd: Command): void {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
         await requireAuth(apiUrl);
-        const reason = assertReason(opts.reason);
+        // The guard's global --reason on the root command wins Commander's
+        // parse, so the local option never receives the value — read the
+        // merged view instead.
+        const reason = assertReason(opts.reason ?? (cmd.optsWithGlobals().reason as string | undefined));
         // The backend matches affectedObject verbatim against scan findings,
         // so pass it through untrimmed — but a blank value is always a mistake.
         if (opts.object !== undefined && opts.object.trim() === '') {

--- a/src/commands/ai/index.ts
+++ b/src/commands/ai/index.ts
@@ -1,6 +1,8 @@
 import type { Command } from 'commander';
 import { registerAiSetupCommand } from './setup.js';
+import { registerAiOverviewCommand } from './overview.js';
 
 export function registerAiCommands(aiCmd: Command): void {
   registerAiSetupCommand(aiCmd);
+  registerAiOverviewCommand(aiCmd);
 }

--- a/src/commands/ai/overview.test.ts
+++ b/src/commands/ai/overview.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { registerAiOverviewCommand } from './overview.js';
+
+vi.mock('../../lib/api/ai.js', () => ({
+  getAiOverview: vi.fn(async () => ({
+    key: {
+      label: 'insforge-managed',
+      limit: 100,
+      limitRemaining: 87.66,
+      usage: 12.34,
+      usageDaily: 0.12,
+      usageWeekly: 1.23,
+      usageMonthly: 4.56,
+      observabilityAvailable: true,
+    },
+    charts: { spend: [], requests: [], tokens: [] },
+    modelUsage: [
+      {
+        model: 'anthropic/claude-sonnet-5',
+        providers: ['anthropic'],
+        requests: 42,
+        promptTokens: 1000,
+        completionTokens: 2000,
+        reasoningTokens: 0,
+        totalTokens: 3000,
+        spend: 1.5,
+        byokSpend: 0,
+      },
+    ],
+  })),
+}));
+
+vi.mock('../../lib/command-telemetry.js', () => ({
+  trackCommandUsage: vi.fn(async () => {}),
+}));
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>');
+  const aiCmd = program.command('ai');
+  registerAiOverviewCommand(aiCmd);
+  return program;
+}
+
+async function runWithCapturedLog(program: Command, argv: string[]): Promise<string[]> {
+  const logs: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return logs;
+}
+
+describe('ai overview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('--json emits the full overview payload', async () => {
+    const logs = await runWithCapturedLog(makeProgram(), ['ai', 'overview', '--json']);
+    const data = JSON.parse(logs.join('\n')) as { key: { usage: number } };
+    expect(data.key.usage).toBe(12.34);
+  });
+
+  it('human output shows total usage, limit, and remaining', async () => {
+    const logs = await runWithCapturedLog(makeProgram(), ['ai', 'overview']);
+    const out = logs.join('\n');
+    expect(out).toContain('Usage (total):    $12.34');
+    expect(out).toContain('Limit:            $100.00');
+    expect(out).toContain('Remaining:        $87.66');
+    expect(out).toContain('anthropic/claude-sonnet-5');
+  });
+
+  it('renders an unlimited key without a numeric limit', async () => {
+    const { getAiOverview } = await import('../../lib/api/ai.js');
+    (getAiOverview as Mock).mockResolvedValueOnce({
+      key: {
+        limit: null,
+        limitRemaining: null,
+        usage: 5,
+        usageDaily: 0,
+        usageWeekly: 0,
+        usageMonthly: 5,
+        observabilityAvailable: false,
+        observabilityError: 'management key required',
+      },
+      charts: { spend: [], requests: [], tokens: [] },
+    });
+    const logs = await runWithCapturedLog(makeProgram(), ['ai', 'overview']);
+    const out = logs.join('\n');
+    expect(out).toContain('Limit:            unlimited');
+    expect(out).toContain('management key required');
+  });
+});

--- a/src/commands/ai/overview.test.ts
+++ b/src/commands/ai/overview.test.ts
@@ -35,6 +35,10 @@ vi.mock('../../lib/command-telemetry.js', () => ({
   trackCommandUsage: vi.fn(async () => {}),
 }));
 
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok' })),
+}));
+
 function makeProgram() {
   const program = new Command().exitOverride();
   program.option('--json').option('--api-url <url>');

--- a/src/commands/ai/overview.test.ts
+++ b/src/commands/ai/overview.test.ts
@@ -100,4 +100,17 @@ describe('ai overview', () => {
     expect(out).toContain('Limit:            unlimited');
     expect(out).toContain('management key required');
   });
+
+  it('renders missing fields as unknown, not unlimited', async () => {
+    const { getAiOverview } = await import('../../lib/api/ai.js');
+    (getAiOverview as Mock).mockResolvedValueOnce({
+      key: { usage: 5, observabilityAvailable: true },
+      charts: { spend: [], requests: [], tokens: [] },
+    });
+    const logs = await runWithCapturedLog(makeProgram(), ['ai', 'overview']);
+    const out = logs.join('\n');
+    expect(out).toContain('Limit:            unknown');
+    expect(out).toContain('Usage today:      unknown');
+    expect(out).not.toContain('Usage today:      unlimited');
+  });
 });

--- a/src/commands/ai/overview.ts
+++ b/src/commands/ai/overview.ts
@@ -1,0 +1,58 @@
+import type { Command } from 'commander';
+import { getAiOverview } from '../../lib/api/ai.js';
+import { handleError, getRootOpts } from '../../lib/errors.js';
+import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
+
+/** OpenRouter usage/limit figures are USD credit amounts. */
+function usd(n: number | null): string {
+  if (n === null) return 'unlimited';
+  return `$${n.toFixed(2)}`;
+}
+
+export function registerAiOverviewCommand(aiCmd: Command): void {
+  aiCmd
+    .command('overview')
+    .description('Show Model Gateway key usage: total spend, limit, and remaining credit')
+    .action(async (_opts, cmd) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        const overview = await getAiOverview();
+        await trackCommandUsage('ai', 'overview', true);
+
+        if (json) {
+          outputJson(overview);
+          return;
+        }
+
+        const k = overview.key;
+        if (k.label) outputInfo(`Key:              ${k.label}`);
+        outputInfo(`Usage (total):    ${usd(k.usage)}`);
+        outputInfo(`Limit:            ${usd(k.limit)}`);
+        outputInfo(`Remaining:        ${usd(k.limitRemaining)}`);
+        if (k.limitReset) outputInfo(`Limit resets:     ${k.limitReset}`);
+        outputInfo(`Usage today:      ${usd(k.usageDaily)}`);
+        outputInfo(`Usage this week:  ${usd(k.usageWeekly)}`);
+        outputInfo(`Usage this month: ${usd(k.usageMonthly)}`);
+        if (k.isFreeTier) outputInfo('Tier:             free');
+
+        if (overview.modelUsage && overview.modelUsage.length > 0) {
+          outputInfo('');
+          outputTable(
+            ['Model', 'Requests', 'Tokens', 'Spend'],
+            overview.modelUsage.map((m) => [
+              m.model,
+              String(m.requests),
+              String(m.totalTokens),
+              usd(m.spend),
+            ]),
+          );
+        } else if (!k.observabilityAvailable && k.observabilityError) {
+          outputInfo(`\nPer-model activity unavailable: ${k.observabilityError}`);
+        }
+      } catch (err) {
+        await trackCommandUsage('ai', 'overview', false, {}, err);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/ai/overview.ts
+++ b/src/commands/ai/overview.ts
@@ -49,6 +49,8 @@ export function registerAiOverviewCommand(aiCmd: Command): void {
           );
         } else if (!k.observabilityAvailable && k.observabilityError) {
           outputInfo(`\nPer-model activity unavailable: ${k.observabilityError}`);
+        } else if (k.observabilityAvailable) {
+          outputInfo('\nNo per-model activity yet.');
         }
       } catch (err) {
         await trackCommandUsage('ai', 'overview', false, {}, err);

--- a/src/commands/ai/overview.ts
+++ b/src/commands/ai/overview.ts
@@ -1,12 +1,13 @@
 import type { Command } from 'commander';
 import { getAiOverview } from '../../lib/api/ai.js';
+import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
-/** OpenRouter usage/limit figures are USD credit amounts. */
-function usd(n: number | null): string {
-  if (n === null) return 'unlimited';
+/** OpenRouter usage/limit figures are USD credit amounts; null means no limit. */
+function usd(n: number | null | undefined): string {
+  if (n === null || n === undefined) return 'unlimited';
   return `$${n.toFixed(2)}`;
 }
 
@@ -15,8 +16,9 @@ export function registerAiOverviewCommand(aiCmd: Command): void {
     .command('overview')
     .description('Show Model Gateway key usage: total spend, limit, and remaining credit')
     .action(async (_opts, cmd) => {
-      const { json } = getRootOpts(cmd);
+      const { json, apiUrl } = getRootOpts(cmd);
       try {
+        await requireAuth(apiUrl);
         const overview = await getAiOverview();
         await trackCommandUsage('ai', 'overview', true);
 
@@ -27,13 +29,14 @@ export function registerAiOverviewCommand(aiCmd: Command): void {
 
         const k = overview.key;
         if (k.label) outputInfo(`Key:              ${k.label}`);
-        outputInfo(`Usage (total):    ${usd(k.usage)}`);
+        // Usage fields are unvalidated backend JSON — a missing figure is 0 spend, not "unlimited".
+        outputInfo(`Usage (total):    ${usd(k.usage ?? 0)}`);
         outputInfo(`Limit:            ${usd(k.limit)}`);
         outputInfo(`Remaining:        ${usd(k.limitRemaining)}`);
         if (k.limitReset) outputInfo(`Limit resets:     ${k.limitReset}`);
-        outputInfo(`Usage today:      ${usd(k.usageDaily)}`);
-        outputInfo(`Usage this week:  ${usd(k.usageWeekly)}`);
-        outputInfo(`Usage this month: ${usd(k.usageMonthly)}`);
+        outputInfo(`Usage today:      ${usd(k.usageDaily ?? 0)}`);
+        outputInfo(`Usage this week:  ${usd(k.usageWeekly ?? 0)}`);
+        outputInfo(`Usage this month: ${usd(k.usageMonthly ?? 0)}`);
         if (k.isFreeTier) outputInfo('Tier:             free');
 
         if (overview.modelUsage && overview.modelUsage.length > 0) {

--- a/src/commands/ai/overview.ts
+++ b/src/commands/ai/overview.ts
@@ -5,9 +5,10 @@ import { handleError, getRootOpts } from '../../lib/errors.js';
 import { outputJson, outputTable, outputInfo } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
 
-/** OpenRouter usage/limit figures are USD credit amounts; null means no limit. */
+/** OpenRouter USD credit figures: null is the API's "no limit" sentinel; a missing field is unknown. */
 function usd(n: number | null | undefined): string {
-  if (n === null || n === undefined) return 'unlimited';
+  if (n === null) return 'unlimited';
+  if (n === undefined) return 'unknown';
   return `$${n.toFixed(2)}`;
 }
 
@@ -29,14 +30,13 @@ export function registerAiOverviewCommand(aiCmd: Command): void {
 
         const k = overview.key;
         if (k.label) outputInfo(`Key:              ${k.label}`);
-        // Usage fields are unvalidated backend JSON — a missing figure is 0 spend, not "unlimited".
-        outputInfo(`Usage (total):    ${usd(k.usage ?? 0)}`);
+        outputInfo(`Usage (total):    ${usd(k.usage)}`);
         outputInfo(`Limit:            ${usd(k.limit)}`);
         outputInfo(`Remaining:        ${usd(k.limitRemaining)}`);
         if (k.limitReset) outputInfo(`Limit resets:     ${k.limitReset}`);
-        outputInfo(`Usage today:      ${usd(k.usageDaily ?? 0)}`);
-        outputInfo(`Usage this week:  ${usd(k.usageWeekly ?? 0)}`);
-        outputInfo(`Usage this month: ${usd(k.usageMonthly ?? 0)}`);
+        outputInfo(`Usage today:      ${usd(k.usageDaily)}`);
+        outputInfo(`Usage this week:  ${usd(k.usageWeekly)}`);
+        outputInfo(`Usage this month: ${usd(k.usageMonthly)}`);
         if (k.isFreeTier) outputInfo('Tier:             free');
 
         if (overview.modelUsage && overview.modelUsage.length > 0) {

--- a/src/commands/backups/index.test.ts
+++ b/src/commands/backups/index.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { registerBackupsCommands } from './index.js';
+
+const FAKE_PROJECT_ID = 'fa4e0000-1234-5678-90ab-cd1234567890';
+
+const ossBackup = {
+  id: 'oss-b1',
+  name: 'nightly',
+  triggerSource: 'manual' as const,
+  status: 'completed' as const,
+  sizeBytes: 2048,
+  errorMessage: null,
+  createdAt: '2026-08-01T00:00:00Z',
+  completedAt: '2026-08-01T00:01:00Z',
+  createdBy: null,
+  expiresAt: null,
+};
+
+vi.mock('../../lib/api/platform.js', () => ({
+  listBackups: vi.fn(async () => []),
+  getLatestBackup: vi.fn(async () => null),
+  createBackup: vi.fn(async () => ({ message: 'Backup started', project: { id: 'p1', name: 'x', status: 'active' } })),
+  renameBackup: vi.fn(async () => ({ id: 'b1', name: 'new' })),
+  deleteBackup: vi.fn(async () => {}),
+  restoreBackup: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/api/oss.js', () => ({
+  listOssBackups: vi.fn(async () => [ossBackup]),
+  createOssBackup: vi.fn(async () => ({ ...ossBackup, id: 'oss-b2', status: 'running', sizeBytes: null, completedAt: null })),
+  renameOssBackup: vi.fn(async () => ({ ...ossBackup, name: 'renamed' })),
+  deleteOssBackup: vi.fn(async () => {}),
+  restoreOssBackup: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok' })),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  FAKE_PROJECT_ID: 'fa4e0000-1234-5678-90ab-cd1234567890',
+  getProjectId: vi.fn(),
+}));
+
+vi.mock('../../lib/analytics.js', () => ({
+  captureEvent: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>').option('-y, --yes');
+  const backupsCmd = program.command('backups');
+  registerBackupsCommands(backupsCmd);
+  return program;
+}
+
+async function runWithCapturedLog(program: Command, argv: string[]): Promise<string[]> {
+  const logs: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return logs;
+}
+
+async function setProjectId(id: string) {
+  const { getProjectId } = await import('../../lib/config.js');
+  (getProjectId as Mock).mockImplementation((override?: string) => override ?? id);
+}
+
+describe('backups — OSS (self-hosted) mode', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await setProjectId(FAKE_PROJECT_ID);
+  });
+
+  it('list uses the OSS route, not the Platform API', async () => {
+    const { listOssBackups } = await import('../../lib/api/oss.js');
+    const { listBackups } = await import('../../lib/api/platform.js');
+    const logs = await runWithCapturedLog(makeProgram(), ['backups', 'list', '--json']);
+    expect(listOssBackups).toHaveBeenCalled();
+    expect(listBackups).not.toHaveBeenCalled();
+    const data = JSON.parse(logs.join('\n')) as { id: string }[];
+    expect(data[0].id).toBe('oss-b1');
+  });
+
+  it('latest derives the newest backup from the list', async () => {
+    const { listOssBackups } = await import('../../lib/api/oss.js');
+    (listOssBackups as Mock).mockResolvedValueOnce([
+      { ...ossBackup, id: 'old', createdAt: '2026-07-01T00:00:00Z' },
+      { ...ossBackup, id: 'new', createdAt: '2026-08-02T00:00:00Z' },
+    ]);
+    const logs = await runWithCapturedLog(makeProgram(), ['backups', 'latest', '--json']);
+    expect((JSON.parse(logs.join('\n')) as { id: string }).id).toBe('new');
+  });
+
+  it('create --wait polls until the backup settles', async () => {
+    const { listOssBackups, createOssBackup } = await import('../../lib/api/oss.js');
+    (listOssBackups as Mock).mockResolvedValueOnce([{ ...ossBackup, id: 'oss-b2' }]);
+    const logs = await runWithCapturedLog(makeProgram(), ['backups', 'create', '--wait', '--json']);
+    expect(createOssBackup).toHaveBeenCalled();
+    expect((JSON.parse(logs.join('\n')) as { status: string }).status).toBe('completed');
+  });
+
+  it('restore --yes hits the OSS restore route', async () => {
+    const { restoreOssBackup } = await import('../../lib/api/oss.js');
+    const { restoreBackup } = await import('../../lib/api/platform.js');
+    const logs = await runWithCapturedLog(makeProgram(), ['backups', 'restore', 'oss-b1', '--yes', '--json']);
+    expect(restoreOssBackup).toHaveBeenCalledWith('oss-b1');
+    expect(restoreBackup).not.toHaveBeenCalled();
+    expect(JSON.parse(logs.join('\n'))).toEqual({ restored: true, backup_id: 'oss-b1' });
+  });
+
+  it('delete --yes hits the OSS delete route', async () => {
+    const { deleteOssBackup } = await import('../../lib/api/oss.js');
+    await runWithCapturedLog(makeProgram(), ['backups', 'delete', 'oss-b1', '--yes', '--json']);
+    expect(deleteOssBackup).toHaveBeenCalledWith('oss-b1');
+  });
+
+  it('rename hits the OSS rename route', async () => {
+    const { renameOssBackup } = await import('../../lib/api/oss.js');
+    const logs = await runWithCapturedLog(makeProgram(), ['backups', 'rename', 'oss-b1', 'renamed', '--json']);
+    expect(renameOssBackup).toHaveBeenCalledWith('oss-b1', 'renamed');
+    expect((JSON.parse(logs.join('\n')) as { name: string }).name).toBe('renamed');
+  });
+});
+
+describe('backups — cloud mode', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await setProjectId('11111111-2222-3333-4444-555555555555');
+  });
+
+  it('list keeps using the Platform API', async () => {
+    const { listBackups } = await import('../../lib/api/platform.js');
+    const { listOssBackups } = await import('../../lib/api/oss.js');
+    await runWithCapturedLog(makeProgram(), ['backups', 'list', '--json']);
+    expect(listBackups).toHaveBeenCalled();
+    expect(listOssBackups).not.toHaveBeenCalled();
+  });
+
+  it('an explicit --project targets the cloud project even when linked OSS', async () => {
+    await setProjectId(FAKE_PROJECT_ID);
+    const { listBackups } = await import('../../lib/api/platform.js');
+    await runWithCapturedLog(makeProgram(), [
+      'backups', 'list', '--project', '11111111-2222-3333-4444-555555555555', '--json',
+    ]);
+    expect(listBackups).toHaveBeenCalledWith('11111111-2222-3333-4444-555555555555', undefined);
+  });
+});

--- a/src/commands/backups/index.test.ts
+++ b/src/commands/backups/index.test.ts
@@ -108,6 +108,28 @@ describe('backups — OSS (self-hosted) mode', () => {
     expect((JSON.parse(logs.join('\n')) as { status: string }).status).toBe('completed');
   });
 
+  it('create surfaces an immediately failed backup even without --wait', async () => {
+    const { createOssBackup } = await import('../../lib/api/oss.js');
+    (createOssBackup as Mock).mockResolvedValueOnce({
+      ...ossBackup,
+      id: 'oss-b3',
+      status: 'failed',
+      errorMessage: 'pg_dump exploded',
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(
+        runWithCapturedLog(makeProgram(), ['backups', 'create', '--json']),
+      ).rejects.toThrow('process.exit');
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
   it('restore --yes hits the OSS restore route', async () => {
     const { restoreOssBackup } = await import('../../lib/api/oss.js');
     const { restoreBackup } = await import('../../lib/api/platform.js');

--- a/src/commands/backups/index.ts
+++ b/src/commands/backups/index.ts
@@ -8,12 +8,19 @@ import {
   deleteBackup,
   restoreBackup,
 } from '../../lib/api/platform.js';
+import {
+  listOssBackups,
+  createOssBackup,
+  renameOssBackup,
+  deleteOssBackup,
+  restoreOssBackup,
+} from '../../lib/api/oss.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
-import { getProjectId } from '../../lib/config.js';
+import { getProjectId, FAKE_PROJECT_ID } from '../../lib/config.js';
 import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
 import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
-import type { Backup } from '../../types.js';
+import type { Backup, OssBackup } from '../../types.js';
 
 function resolveProjectId(opts: { project?: string }): string {
   const id = getProjectId(opts.project);
@@ -21,6 +28,16 @@ function resolveProjectId(opts: { project?: string }): string {
     throw new CLIError('No project specified. Pass --project <id> or run `insforge link` first.');
   }
   return id;
+}
+
+/**
+ * Self-hosted projects (`link --api-key`) carry the FAKE_PROJECT_ID sentinel —
+ * they have no Cloud Platform record, so their backups live on the project's
+ * own OSS backend (`/api/database/backups`). Cloud projects keep using the
+ * Platform API.
+ */
+function isOssProject(projectId: string): boolean {
+  return projectId === FAKE_PROJECT_ID;
 }
 
 function formatBytes(n: number | null): string {
@@ -42,7 +59,50 @@ function backupRow(b: Backup): string[] {
   ];
 }
 
+function ossBackupRow(b: OssBackup): string[] {
+  return [
+    b.id,
+    b.name ?? '-',
+    b.status,
+    b.triggerSource,
+    formatBytes(b.sizeBytes),
+    new Date(b.createdAt).toLocaleString(),
+  ];
+}
+
 const BACKUP_HEADERS = ['ID', 'Name', 'Status', 'Source', 'Size', 'Created'];
+
+/** Newest-first pick; the OSS list endpoint does not guarantee order. */
+function newestOssBackup(backups: OssBackup[]): OssBackup | null {
+  if (!backups.length) return null;
+  return [...backups].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )[0];
+}
+
+const OSS_WAIT_INTERVAL_MS = 2_000;
+const OSS_WAIT_MAX_ATTEMPTS = 300; // 10 minutes
+
+/**
+ * The OSS create endpoint returns immediately with a `running` backup and
+ * dumps in the background, so `--wait` polls the list until it settles.
+ */
+async function waitForOssBackup(backupId: string): Promise<OssBackup> {
+  for (let attempt = 0; attempt < OSS_WAIT_MAX_ATTEMPTS; attempt++) {
+    const backups = await listOssBackups();
+    const backup = backups.find((b) => b.id === backupId);
+    if (!backup) {
+      throw new CLIError(`Backup ${backupId} disappeared while waiting for it to finish.`);
+    }
+    if (backup.status !== 'running') {
+      return backup;
+    }
+    await new Promise((r) => setTimeout(r, OSS_WAIT_INTERVAL_MS));
+  }
+  throw new CLIError(
+    `Timed out waiting for backup ${backupId} to finish. Check it with \`insforge backups list\`.`,
+  );
+}
 
 export function registerBackupsCommands(backupsCmd: Command): void {
   backupsCmd
@@ -54,6 +114,17 @@ export function registerBackupsCommands(backupsCmd: Command): void {
       try {
         await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        if (isOssProject(projectId)) {
+          const backups = await listOssBackups();
+          if (json) {
+            outputJson(backups);
+          } else if (!backups.length) {
+            outputInfo('No backups found.');
+          } else {
+            outputTable(BACKUP_HEADERS, backups.map(ossBackupRow));
+          }
+          return;
+        }
         const backups = await listBackups(projectId, apiUrl);
         if (json) {
           outputJson(backups);
@@ -76,6 +147,23 @@ export function registerBackupsCommands(backupsCmd: Command): void {
       try {
         await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        if (isOssProject(projectId)) {
+          // The OSS backend has no /latest route — derive it from the list.
+          const latest = newestOssBackup(await listOssBackups());
+          if (json) {
+            outputJson(latest);
+          } else if (!latest) {
+            outputInfo('No backups found.');
+          } else {
+            outputInfo(`ID:       ${latest.id}`);
+            outputInfo(`Name:     ${latest.name ?? '-'}`);
+            outputInfo(`Status:   ${latest.status}`);
+            outputInfo(`Size:     ${formatBytes(latest.sizeBytes)}`);
+            outputInfo(`Created:  ${new Date(latest.createdAt).toLocaleString()}`);
+            if (latest.errorMessage) outputInfo(`Error:    ${latest.errorMessage}`);
+          }
+          return;
+        }
         const latest = await getLatestBackup(projectId, apiUrl);
         if (json) {
           outputJson(latest);
@@ -102,6 +190,24 @@ export function registerBackupsCommands(backupsCmd: Command): void {
       try {
         await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        if (isOssProject(projectId)) {
+          let backup = await createOssBackup(opts.name);
+          if (opts.wait) {
+            backup = await waitForOssBackup(backup.id);
+            if (backup.status === 'failed') {
+              throw new CLIError(`Backup ${backup.id} failed: ${backup.errorMessage ?? 'unknown error'}`);
+            }
+          }
+          captureEvent(projectId, 'cli_backup_create', { named: !!opts.name, oss: true });
+          if (json) {
+            outputJson(backup);
+          } else if (backup.status === 'completed') {
+            outputSuccess(`Backup ${backup.id} completed (${formatBytes(backup.sizeBytes)}).`);
+          } else {
+            outputSuccess(`Backup ${backup.id} started. Check progress with \`insforge backups list\`.`);
+          }
+          return;
+        }
         const result = await createBackup(projectId, opts.name, !!opts.wait, apiUrl);
         captureEvent(projectId, 'cli_backup_create', { named: !!opts.name });
         if (json) {
@@ -125,7 +231,10 @@ export function registerBackupsCommands(backupsCmd: Command): void {
       try {
         await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
-        const result = await renameBackup(projectId, backupId, name === '' ? null : name, apiUrl);
+        const newName = name === '' ? null : name;
+        const result = isOssProject(projectId)
+          ? await renameOssBackup(backupId, newName)
+          : await renameBackup(projectId, backupId, newName, apiUrl);
         if (json) {
           outputJson(result);
         } else {
@@ -158,7 +267,11 @@ export function registerBackupsCommands(backupsCmd: Command): void {
           }
         }
 
-        await deleteBackup(projectId, backupId, apiUrl);
+        if (isOssProject(projectId)) {
+          await deleteOssBackup(backupId);
+        } else {
+          await deleteBackup(projectId, backupId, apiUrl);
+        }
         captureEvent(projectId, 'cli_backup_delete', {});
         if (json) {
           outputJson({ deleted: true, backup_id: backupId });
@@ -190,6 +303,19 @@ export function registerBackupsCommands(backupsCmd: Command): void {
             outputInfo('Cancelled.');
             return;
           }
+        }
+
+        if (isOssProject(projectId)) {
+          // The OSS restore endpoint is synchronous — when it returns, the
+          // database has been restored.
+          await restoreOssBackup(backupId);
+          captureEvent(projectId, 'cli_backup_restore', { oss: true });
+          if (json) {
+            outputJson({ restored: true, backup_id: backupId });
+          } else {
+            outputSuccess(`Database restored from backup ${backupId}.`);
+          }
+          return;
         }
 
         await restoreBackup(projectId, backupId, apiUrl);

--- a/src/commands/backups/index.ts
+++ b/src/commands/backups/index.ts
@@ -23,7 +23,8 @@ import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 import type { Backup, OssBackup } from '../../types.js';
 
 function resolveProjectId(opts: { project?: string }): string {
-  const id = getProjectId(opts.project);
+  // An explicit --project must beat INSFORGE_PROJECT_ID — it also picks the backend route.
+  const id = opts.project ?? getProjectId();
   if (!id) {
     throw new CLIError('No project specified. Pass --project <id> or run `insforge link` first.');
   }
@@ -104,8 +105,10 @@ export function registerBackupsCommands(backupsCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        // OSS bypass only when the OSS route is actually the target — an
+        // explicit cloud --project from a self-hosted link needs a real login.
+        await requireAuth(apiUrl, isOssProject(projectId));
         if (isOssProject(projectId)) {
           const backups = await listOssBackups();
           if (json) {
@@ -137,8 +140,8 @@ export function registerBackupsCommands(backupsCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        await requireAuth(apiUrl, isOssProject(projectId));
         if (isOssProject(projectId)) {
           // The OSS backend has no /latest route — derive it from the list.
           const latest = newestOssBackup(await listOssBackups());
@@ -180,15 +183,15 @@ export function registerBackupsCommands(backupsCmd: Command): void {
     .action(async (opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        await requireAuth(apiUrl, isOssProject(projectId));
         if (isOssProject(projectId)) {
           let backup = await createOssBackup(opts.name);
           if (opts.wait) {
             backup = await waitForOssBackup(backup.id);
-            if (backup.status === 'failed') {
-              throw new CLIError(`Backup ${backup.id} failed: ${backup.errorMessage ?? 'unknown error'}`);
-            }
+          }
+          if (backup.status === 'failed') {
+            throw new CLIError(`Backup ${backup.id} failed: ${backup.errorMessage ?? 'unknown error'}`);
           }
           captureEvent(projectId, 'cli_backup_create', { named: !!opts.name, oss: true });
           if (json) {
@@ -221,8 +224,8 @@ export function registerBackupsCommands(backupsCmd: Command): void {
     .action(async (backupId: string, name: string, opts, cmd) => {
       const { json, apiUrl } = getRootOpts(cmd);
       try {
-        await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        await requireAuth(apiUrl, isOssProject(projectId));
         const newName = name === '' ? null : name;
         const result = isOssProject(projectId)
           ? await renameOssBackup(backupId, newName)
@@ -248,8 +251,9 @@ export function registerBackupsCommands(backupsCmd: Command): void {
     .action(async (backupId: string, opts, cmd) => {
       const { json, apiUrl, yes } = getRootOpts(cmd);
       try {
-        await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        const oss = isOssProject(projectId);
+        await requireAuth(apiUrl, oss);
 
         if (!yes && !json) {
           const confirmed = await clack.confirm({ message: `Delete backup ${backupId}?` });
@@ -259,12 +263,12 @@ export function registerBackupsCommands(backupsCmd: Command): void {
           }
         }
 
-        if (isOssProject(projectId)) {
+        if (oss) {
           await deleteOssBackup(backupId);
         } else {
           await deleteBackup(projectId, backupId, apiUrl);
         }
-        captureEvent(projectId, 'cli_backup_delete', {});
+        captureEvent(projectId, 'cli_backup_delete', oss ? { oss: true } : {});
         if (json) {
           outputJson({ deleted: true, backup_id: backupId });
         } else {
@@ -284,12 +288,17 @@ export function registerBackupsCommands(backupsCmd: Command): void {
     .action(async (backupId: string, opts, cmd) => {
       const { json, apiUrl, yes } = getRootOpts(cmd);
       try {
-        await requireAuth(apiUrl);
         const projectId = resolveProjectId(opts);
+        const oss = isOssProject(projectId);
+        await requireAuth(apiUrl, oss);
 
         if (!yes && !json) {
+          // OSS backups are database dumps; only cloud restores also cover storage.
+          const blastRadius = oss
+            ? "This OVERWRITES the project's current database."
+            : "This OVERWRITES the project's current database and storage.";
           const confirmed = await clack.confirm({
-            message: `Restore from backup ${backupId}? This OVERWRITES the project's current database and storage.`,
+            message: `Restore from backup ${backupId}? ${blastRadius}`,
           });
           if (clack.isCancel(confirmed) || !confirmed) {
             outputInfo('Cancelled.');
@@ -297,7 +306,7 @@ export function registerBackupsCommands(backupsCmd: Command): void {
           }
         }
 
-        if (isOssProject(projectId)) {
+        if (oss) {
           // The OSS restore endpoint is synchronous.
           await restoreOssBackup(backupId);
           captureEvent(projectId, 'cli_backup_restore', { oss: true });

--- a/src/commands/backups/index.ts
+++ b/src/commands/backups/index.ts
@@ -30,12 +30,7 @@ function resolveProjectId(opts: { project?: string }): string {
   return id;
 }
 
-/**
- * Self-hosted projects (`link --api-key`) carry the FAKE_PROJECT_ID sentinel —
- * they have no Cloud Platform record, so their backups live on the project's
- * own OSS backend (`/api/database/backups`). Cloud projects keep using the
- * Platform API.
- */
+/** Self-hosted projects carry the FAKE_PROJECT_ID sentinel and use the OSS backup routes. */
 function isOssProject(projectId: string): boolean {
   return projectId === FAKE_PROJECT_ID;
 }
@@ -83,10 +78,7 @@ function newestOssBackup(backups: OssBackup[]): OssBackup | null {
 const OSS_WAIT_INTERVAL_MS = 2_000;
 const OSS_WAIT_MAX_ATTEMPTS = 300; // 10 minutes
 
-/**
- * The OSS create endpoint returns immediately with a `running` backup and
- * dumps in the background, so `--wait` polls the list until it settles.
- */
+/** OSS create returns a `running` backup immediately, so --wait polls until it settles. */
 async function waitForOssBackup(backupId: string): Promise<OssBackup> {
   for (let attempt = 0; attempt < OSS_WAIT_MAX_ATTEMPTS; attempt++) {
     const backups = await listOssBackups();
@@ -306,8 +298,7 @@ export function registerBackupsCommands(backupsCmd: Command): void {
         }
 
         if (isOssProject(projectId)) {
-          // The OSS restore endpoint is synchronous — when it returns, the
-          // database has been restored.
+          // The OSS restore endpoint is synchronous.
           await restoreOssBackup(backupId);
           captureEvent(projectId, 'cli_backup_restore', { oss: true });
           if (json) {

--- a/src/commands/diagnose/advisor.ts
+++ b/src/commands/diagnose/advisor.ts
@@ -177,10 +177,13 @@ export function registerDiagnoseAdvisorCommand(diagnoseCmd: Command): void {
             return;
           }
 
-          const headers = ['Severity', 'Category', 'Affected Object', 'Title'];
+          // Rule ID is what `insforge advisor suppress <ruleId>` takes, so it
+          // must be visible here — this table is where users find findings.
+          const headers = ['Severity', 'Category', 'Rule', 'Affected Object', 'Title'];
           const rows = issuesData.issues.map((issue) => [
             issue.severity,
             issue.category,
+            issue.ruleId,
             issue.affectedObject,
             issue.title,
           ]);

--- a/src/commands/diagnose/advisor.ts
+++ b/src/commands/diagnose/advisor.ts
@@ -177,8 +177,7 @@ export function registerDiagnoseAdvisorCommand(diagnoseCmd: Command): void {
             return;
           }
 
-          // Rule ID is what `insforge advisor suppress <ruleId>` takes, so it
-          // must be visible here — this table is where users find findings.
+          // Rule is the id `advisor suppress` takes, so it must be visible here.
           const headers = ['Severity', 'Category', 'Rule', 'Affected Object', 'Title'];
           const rows = issuesData.issues.map((issue) => [
             issue.severity,

--- a/src/commands/orgs/lifecycle.test.ts
+++ b/src/commands/orgs/lifecycle.test.ts
@@ -37,6 +37,11 @@ vi.mock('../../lib/command-telemetry.js', () => ({
   trackCommandUsage: vi.fn(async () => {}),
 }));
 
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn(async () => false),
+  isCancel: vi.fn(() => false),
+}));
+
 function makeProgram() {
   const program = new Command().exitOverride();
   program.option('--json').option('--api-url <url>').option('-y, --yes');
@@ -116,13 +121,42 @@ describe('orgs leave / delete', () => {
     expect(deleteOrganization).not.toHaveBeenCalled();
   });
 
-  it('delete --org-id --json deletes the org', async () => {
+  it('delete --org-id --json deletes the org and reports the linked-project fact', async () => {
     const { deleteOrganization } = await import('../../lib/api/platform.js');
     const logs = await runWithCapturedLog(makeProgram(), [
       'orgs', 'delete', '--org-id', 'org-1', '--json',
     ]);
     expect(deleteOrganization).toHaveBeenCalledWith('org-1', undefined);
-    expect(JSON.parse(logs.join('\n'))).toEqual({ deleted: true, org_id: 'org-1' });
+    expect(JSON.parse(logs.join('\n'))).toEqual({
+      deleted: true,
+      org_id: 'org-1',
+      linked_project_deleted: false,
+    });
+  });
+
+  it('interactive delete lists the projects that will be destroyed and honors a declined confirm', async () => {
+    const { deleteOrganization, listProjects } = await import('../../lib/api/platform.js');
+    const clack = await import('@clack/prompts');
+    (listProjects as Mock).mockResolvedValueOnce([
+      { id: 'p1', name: 'app-one' },
+      { id: 'p2', name: 'app-two' },
+    ]);
+    const logs = await runWithCapturedLog(makeProgram(), ['orgs', 'delete', '--org-id', 'org-1']);
+    expect(clack.confirm).toHaveBeenCalled();
+    expect(deleteOrganization).not.toHaveBeenCalled();
+    const out = logs.join('\n');
+    expect(out).toContain('app-one');
+    expect(out).toContain('PERMANENTLY deleted');
+    expect(out).toContain('Cancelled.');
+  });
+
+  it('interactive delete aborts when the project inventory cannot be fetched', async () => {
+    const { deleteOrganization, listProjects } = await import('../../lib/api/platform.js');
+    (listProjects as Mock).mockRejectedValueOnce(new CLIError('network down'));
+    await expect(
+      runWithCapturedLog(makeProgram(), ['orgs', 'delete', '--org-id', 'org-1']),
+    ).rejects.toThrow('process.exit');
+    expect(deleteOrganization).not.toHaveBeenCalled();
   });
 
   it('delete with --yes warns about the linked project after deleting its org', async () => {

--- a/src/commands/orgs/lifecycle.test.ts
+++ b/src/commands/orgs/lifecycle.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { registerOrgsManageCommands } from './manage.js';
+import { CLIError } from '../../lib/errors.js';
+
+vi.mock('../../lib/api/platform.js', () => ({
+  createOrganization: vi.fn(),
+  updateOrganization: vi.fn(),
+  listMembers: vi.fn(),
+  inviteMember: vi.fn(),
+  removeMember: vi.fn(),
+  updateMemberRole: vi.fn(),
+  leaveOrganization: vi.fn(async () => ({ message: 'Successfully left the organization' })),
+  deleteOrganization: vi.fn(async () => ({
+    message: 'Organization deleted successfully',
+    organizationId: 'org-1',
+  })),
+  listOrganizations: vi.fn(async () => [
+    { id: 'org-1', name: 'Acme', type: 'team', created_at: '', updated_at: '' },
+  ]),
+  listProjects: vi.fn(async () => []),
+}));
+
+vi.mock('../../lib/credentials.js', () => ({
+  requireAuth: vi.fn(async () => ({ accessToken: 'tok' })),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  getProjectConfig: vi.fn(),
+}));
+
+vi.mock('../../lib/resolve-org.js', () => ({
+  resolveOrgId: vi.fn(async () => 'org-1'),
+}));
+
+vi.mock('../../lib/command-telemetry.js', () => ({
+  trackCommandUsage: vi.fn(async () => {}),
+}));
+
+function makeProgram() {
+  const program = new Command().exitOverride();
+  program.option('--json').option('--api-url <url>').option('-y, --yes');
+  const orgsCmd = program.command('orgs');
+  registerOrgsManageCommands(orgsCmd);
+  return program;
+}
+
+async function runWithCapturedLog(program: Command, argv: string[]): Promise<string[]> {
+  const logs: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+  return logs;
+}
+
+describe('orgs leave / delete', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errors: string[];
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    errors = [];
+    errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    });
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('leave refuses to run without an explicit --org-id', async () => {
+    const { leaveOrganization } = await import('../../lib/api/platform.js');
+    await expect(
+      runWithCapturedLog(makeProgram(), ['orgs', 'leave', '--json']),
+    ).rejects.toThrow('process.exit');
+    expect(leaveOrganization).not.toHaveBeenCalled();
+    expect(errors.join('\n')).toContain('--org-id');
+  });
+
+  it('leave --org-id --json leaves the org', async () => {
+    const { leaveOrganization } = await import('../../lib/api/platform.js');
+    const logs = await runWithCapturedLog(makeProgram(), [
+      'orgs', 'leave', '--org-id', 'org-1', '--json',
+    ]);
+    expect(leaveOrganization).toHaveBeenCalledWith('org-1', undefined);
+    expect(JSON.parse(logs.join('\n'))).toEqual({ left: true, org_id: 'org-1' });
+  });
+
+  it('leave surfaces the backend last-administrator error', async () => {
+    const { leaveOrganization } = await import('../../lib/api/platform.js');
+    (leaveOrganization as Mock).mockRejectedValueOnce(
+      new CLIError('Cannot leave organization as the last administrator. Please transfer admin role to another member first'),
+    );
+    await expect(
+      runWithCapturedLog(makeProgram(), ['orgs', 'leave', '--org-id', 'org-1', '--json']),
+    ).rejects.toThrow('process.exit');
+    expect(errors.join('\n')).toContain('last administrator');
+  });
+
+  it('delete refuses to run without an explicit --org-id', async () => {
+    const { deleteOrganization } = await import('../../lib/api/platform.js');
+    await expect(
+      runWithCapturedLog(makeProgram(), ['orgs', 'delete', '--json']),
+    ).rejects.toThrow('process.exit');
+    expect(deleteOrganization).not.toHaveBeenCalled();
+  });
+
+  it('delete --org-id --json deletes the org', async () => {
+    const { deleteOrganization } = await import('../../lib/api/platform.js');
+    const logs = await runWithCapturedLog(makeProgram(), [
+      'orgs', 'delete', '--org-id', 'org-1', '--json',
+    ]);
+    expect(deleteOrganization).toHaveBeenCalledWith('org-1', undefined);
+    expect(JSON.parse(logs.join('\n'))).toEqual({ deleted: true, org_id: 'org-1' });
+  });
+
+  it('delete with --yes warns about the linked project after deleting its org', async () => {
+    const { getProjectConfig } = await import('../../lib/config.js');
+    (getProjectConfig as Mock).mockReturnValue({
+      project_id: 'p1',
+      project_name: 'my-app',
+      org_id: 'org-1',
+      appkey: 'k',
+      region: 'us-east',
+      api_key: 'key',
+      oss_host: 'https://k.us-east.insforge.app',
+    });
+    const logs = await runWithCapturedLog(makeProgram(), [
+      'orgs', 'delete', '--org-id', 'org-1', '--yes',
+    ]);
+    expect(logs.join('\n')).toContain('insforge link');
+  });
+});

--- a/src/commands/orgs/manage.ts
+++ b/src/commands/orgs/manage.ts
@@ -172,7 +172,7 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
           }
           if (linkedInOrg) {
             outputInfo(
-              `⚠ The project this directory is linked to (${linkedConfig?.project_name}) belongs to this organization and will be deleted too.`,
+              `The linked project "${linkedConfig?.project_name}" belongs to this organization and will be deleted with it.`,
             );
           }
           const confirmed = await clack.confirm({

--- a/src/commands/orgs/manage.ts
+++ b/src/commands/orgs/manage.ts
@@ -30,12 +30,7 @@ function assertRole(role: string): MemberRole {
   return role as MemberRole;
 }
 
-/**
- * Destructive org ops (leave/delete) never resolve the org implicitly — a
- * stray linked project, INSFORGE_ORG_ID, or default org must not be able to
- * silently point them at the wrong organization. Mirrors how
- * `projects delete` requires an explicit --project.
- */
+/** Destructive org ops never fall back to an ambient org — --org-id must be explicit. */
 function requireExplicitOrgId(opts: { orgId?: string }, verb: string): string {
   if (!opts.orgId) {
     throw new CLIError(
@@ -158,9 +153,7 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         await requireAuth(apiUrl);
         const orgId = requireExplicitOrgId(opts, 'delete');
 
-        // Deleting an org cascades: the backend cancels its subscription and
-        // permanently deletes every project in it. Surface that blast radius
-        // (and whether the currently linked project is in it) before asking.
+        // Org deletion cascades to every project in it, so surface that before asking.
         const linkedConfig = getProjectConfig();
         const linkedInOrg = linkedConfig?.org_id === orgId;
 

--- a/src/commands/orgs/manage.ts
+++ b/src/commands/orgs/manage.ts
@@ -159,8 +159,9 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
 
         if (!yes && !json) {
           const label = await orgLabel(orgId, apiUrl);
-          const projects = await listProjects(orgId, apiUrl).catch(() => null);
-          if (projects && projects.length > 0) {
+          // Fail closed: without the project inventory the user can't judge the blast radius.
+          const projects = await listProjects(orgId, apiUrl);
+          if (projects.length > 0) {
             outputInfo(`This organization has ${projects.length} project(s) that will be PERMANENTLY deleted with it:`);
             for (const p of projects.slice(0, 10)) {
               outputInfo(`  - ${p.name} (${p.id})`);
@@ -186,7 +187,7 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         const result = await deleteOrganization(orgId, apiUrl);
         await trackCommandUsage('orgs', 'delete', true);
         if (json) {
-          outputJson({ deleted: true, org_id: orgId });
+          outputJson({ deleted: true, org_id: orgId, linked_project_deleted: linkedInOrg });
         } else {
           outputSuccess(result.message || `Organization ${orgId} deleted.`);
           if (linkedInOrg) {

--- a/src/commands/orgs/manage.ts
+++ b/src/commands/orgs/manage.ts
@@ -7,10 +7,15 @@ import {
   inviteMember,
   removeMember,
   updateMemberRole,
+  leaveOrganization,
+  deleteOrganization,
+  listOrganizations,
+  listProjects,
 } from '../../lib/api/platform.js';
 import { requireAuth } from '../../lib/credentials.js';
 import { handleError, getRootOpts, CLIError } from '../../lib/errors.js';
 import { resolveOrgId } from '../../lib/resolve-org.js';
+import { getProjectConfig } from '../../lib/config.js';
 import { outputJson, outputTable, outputSuccess, outputInfo } from '../../lib/output.js';
 import type { MemberRole } from '../../types.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
@@ -23,6 +28,28 @@ function assertRole(role: string): MemberRole {
     throw new CLIError(`Invalid role "${role}". Valid roles: ${MEMBER_ROLES.join(', ')}.`);
   }
   return role as MemberRole;
+}
+
+/**
+ * Destructive org ops (leave/delete) never resolve the org implicitly — a
+ * stray linked project, INSFORGE_ORG_ID, or default org must not be able to
+ * silently point them at the wrong organization. Mirrors how
+ * `projects delete` requires an explicit --project.
+ */
+function requireExplicitOrgId(opts: { orgId?: string }, verb: string): string {
+  if (!opts.orgId) {
+    throw new CLIError(
+      `Refusing to ${verb} an organization implicitly. Pass --org-id <id> to target an organization explicitly.`,
+    );
+  }
+  return opts.orgId;
+}
+
+/** Best-effort org label for confirmation prompts: `"name" (id)` or the bare id. */
+async function orgLabel(orgId: string, apiUrl?: string): Promise<string> {
+  const orgs = await listOrganizations(apiUrl).catch(() => null);
+  const org = orgs?.find((o) => o.id === orgId);
+  return org ? `"${org.name}" (${orgId})` : orgId;
 }
 
 export function registerOrgsManageCommands(orgsCmd: Command): void {
@@ -83,6 +110,98 @@ export function registerOrgsManageCommands(orgsCmd: Command): void {
         }
       } catch (err) {
         await trackCommandUsage('orgs', 'update', false, {}, err);
+        handleError(err, json);
+      }
+    });
+
+  orgsCmd
+    .command('leave')
+    .description('Leave an organization (you must be re-invited to return)')
+    .option('--org-id <id>', 'Organization ID (required — will not default to the linked org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = requireExplicitOrgId(opts, 'leave');
+
+        if (!yes && !json) {
+          const label = await orgLabel(orgId, apiUrl);
+          const confirmed = await clack.confirm({
+            message: `Leave organization ${label}? You lose access to all of its projects and must be re-invited to return.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        const result = await leaveOrganization(orgId, apiUrl);
+        await trackCommandUsage('orgs', 'leave', true);
+        if (json) {
+          outputJson({ left: true, org_id: orgId });
+        } else {
+          outputSuccess(result.message || `Left organization ${orgId}.`);
+        }
+      } catch (err) {
+        await trackCommandUsage('orgs', 'leave', false, {}, err);
+        handleError(err, json);
+      }
+    });
+
+  orgsCmd
+    .command('delete')
+    .description('Permanently delete an organization and ALL of its projects')
+    .option('--org-id <id>', 'Organization ID (required — will not default to the linked org)')
+    .action(async (opts, cmd) => {
+      const { json, apiUrl, yes } = getRootOpts(cmd);
+      try {
+        await requireAuth(apiUrl);
+        const orgId = requireExplicitOrgId(opts, 'delete');
+
+        // Deleting an org cascades: the backend cancels its subscription and
+        // permanently deletes every project in it. Surface that blast radius
+        // (and whether the currently linked project is in it) before asking.
+        const linkedConfig = getProjectConfig();
+        const linkedInOrg = linkedConfig?.org_id === orgId;
+
+        if (!yes && !json) {
+          const label = await orgLabel(orgId, apiUrl);
+          const projects = await listProjects(orgId, apiUrl).catch(() => null);
+          if (projects && projects.length > 0) {
+            outputInfo(`This organization has ${projects.length} project(s) that will be PERMANENTLY deleted with it:`);
+            for (const p of projects.slice(0, 10)) {
+              outputInfo(`  - ${p.name} (${p.id})`);
+            }
+            if (projects.length > 10) {
+              outputInfo(`  … and ${projects.length - 10} more`);
+            }
+          }
+          if (linkedInOrg) {
+            outputInfo(
+              `⚠ The project this directory is linked to (${linkedConfig?.project_name}) belongs to this organization and will be deleted too.`,
+            );
+          }
+          const confirmed = await clack.confirm({
+            message: `Permanently delete organization ${label}? This destroys every project in it (databases, storage, all resources) and cancels its subscription.`,
+          });
+          if (clack.isCancel(confirmed) || !confirmed) {
+            outputInfo('Cancelled.');
+            return;
+          }
+        }
+
+        const result = await deleteOrganization(orgId, apiUrl);
+        await trackCommandUsage('orgs', 'delete', true);
+        if (json) {
+          outputJson({ deleted: true, org_id: orgId });
+        } else {
+          outputSuccess(result.message || `Organization ${orgId} deleted.`);
+          if (linkedInOrg) {
+            outputInfo('The linked project was deleted with the organization. Run `insforge link` to link a different project.');
+          }
+        }
+      } catch (err) {
+        await trackCommandUsage('orgs', 'delete', false, {}, err);
         handleError(err, json);
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ import { registerComputeDeployCommand } from './commands/compute/deploy.js';
 import { registerLogsCommand } from './commands/logs.js';
 import { registerMetadataCommand } from './commands/metadata.js';
 import { registerDiagnoseCommands } from './commands/diagnose/index.js';
+import { registerAdvisorCommands } from './commands/advisor/index.js';
 import { registerPaymentsCommands } from './commands/payments/index.js';
 import { registerPosthogSetupCommand } from './commands/posthog/setup.js';
 import { registerWebscraperCommands } from './commands/webscraper/index.js';
@@ -244,6 +245,10 @@ registerMetadataCommand(program);
 // Diagnose commands
 const diagnoseCmd = program.command('diagnose');
 registerDiagnoseCommands(diagnoseCmd);
+
+// Advisor commands (scan + suppressions; read results with `diagnose advisor`)
+const advisorCmd = program.command('advisor').description('Run advisor scans and manage suppressed findings');
+registerAdvisorCommands(advisorCmd);
 
 // Payments commands
 const paymentsCmd = program.command('payments').description('Manage payments');

--- a/src/lib/api/ai.ts
+++ b/src/lib/api/ai.ts
@@ -6,11 +6,7 @@ export interface OpenRouterKeyResponse {
   maskedKey?: string;
 }
 
-/**
- * Key-level Model Gateway observability (`GET /api/ai/overview`). Usage and
- * limit figures are USD credits on the OpenRouter key. `charts`/`modelUsage`
- * are only populated when the backend has a management key (observability).
- */
+/** Model Gateway key observability; usage/limit figures are USD credits. */
 export interface AiOverview {
   key: {
     label?: string;

--- a/src/lib/api/ai.ts
+++ b/src/lib/api/ai.ts
@@ -6,6 +6,48 @@ export interface OpenRouterKeyResponse {
   maskedKey?: string;
 }
 
+/**
+ * Key-level Model Gateway observability (`GET /api/ai/overview`). Usage and
+ * limit figures are USD credits on the OpenRouter key. `charts`/`modelUsage`
+ * are only populated when the backend has a management key (observability).
+ */
+export interface AiOverview {
+  key: {
+    label?: string;
+    limit: number | null;
+    limitRemaining: number | null;
+    limitReset?: string | null;
+    usage: number;
+    usageDaily: number;
+    usageWeekly: number;
+    usageMonthly: number;
+    isFreeTier?: boolean;
+    observabilityAvailable: boolean;
+    observabilityError?: string;
+  };
+  charts: {
+    spend: { label: string; value: number }[];
+    requests: { label: string; value: number }[];
+    tokens: { label: string; value: number }[];
+  };
+  modelUsage?: {
+    model: string;
+    providers: string[];
+    requests: number;
+    promptTokens: number;
+    completionTokens: number;
+    reasoningTokens: number;
+    totalTokens: number;
+    spend: number;
+    byokSpend: number;
+  }[];
+}
+
+export async function getAiOverview(): Promise<AiOverview> {
+  const res = await ossFetch('/api/ai/overview');
+  return await res.json() as AiOverview;
+}
+
 export async function getOpenRouterApiKey(): Promise<OpenRouterKeyResponse> {
   const res = await ossFetch('/api/ai/openrouter/api-key');
   const data = await res.json() as Partial<OpenRouterKeyResponse>;

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -1,6 +1,10 @@
 import { getProjectConfig } from '../config.js';
 import { CLIError, formatFetchError, ProjectNotLinkedError } from '../errors.js';
 import type {
+  AdvisorSuppression,
+  AdvisorSuppressionReason,
+  AdvisorSuppressionScope,
+  OssBackup,
   ProjectConfig,
   RotateKeyResponse,
   S3AccessKey,
@@ -157,6 +161,76 @@ export async function deleteS3AccessKey(id: string): Promise<void> {
   await ossFetch(`/api/storage/s3/access-keys/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
+// --- Advisor ---
+
+export async function triggerAdvisorScan(): Promise<{ scanId: string; message: string }> {
+  const res = await ossFetch('/api/advisor/scan', { method: 'POST' });
+  return await res.json() as { scanId: string; message: string };
+}
+
+export async function listAdvisorSuppressions(): Promise<AdvisorSuppression[]> {
+  const res = await ossFetch('/api/advisor/suppressions');
+  const data = await res.json() as { suppressions?: AdvisorSuppression[] };
+  return data.suppressions ?? [];
+}
+
+export interface CreateAdvisorSuppressionBody {
+  ruleId: string;
+  scope: AdvisorSuppressionScope;
+  /** Required for `instance` scope — the finding's affected object, verbatim. */
+  affectedObject?: string;
+  reason: AdvisorSuppressionReason;
+  note?: string;
+}
+
+export async function createAdvisorSuppression(
+  body: CreateAdvisorSuppressionBody,
+): Promise<AdvisorSuppression> {
+  const res = await ossFetch('/api/advisor/suppressions', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return await res.json() as AdvisorSuppression;
+}
+
+export async function deleteAdvisorSuppression(id: string): Promise<void> {
+  await ossFetch(`/api/advisor/suppressions/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}
+
+// --- Database backups (self-hosted / OSS route) ---
+
+export async function listOssBackups(): Promise<OssBackup[]> {
+  const res = await ossFetch('/api/database/backups');
+  const data = await res.json() as { backups?: OssBackup[] };
+  return data.backups ?? [];
+}
+
+export async function createOssBackup(name?: string): Promise<OssBackup> {
+  const res = await ossFetch('/api/database/backups', {
+    method: 'POST',
+    body: JSON.stringify(name ? { name } : {}),
+  });
+  return await res.json() as OssBackup;
+}
+
+export async function renameOssBackup(backupId: string, name: string | null): Promise<OssBackup> {
+  const res = await ossFetch(`/api/database/backups/${encodeURIComponent(backupId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ name }),
+  });
+  return await res.json() as OssBackup;
+}
+
+export async function deleteOssBackup(backupId: string): Promise<void> {
+  await ossFetch(`/api/database/backups/${encodeURIComponent(backupId)}`, { method: 'DELETE' });
+}
+
+export async function restoreOssBackup(backupId: string): Promise<void> {
+  await ossFetch(`/api/database/backups/${encodeURIComponent(backupId)}/restore`, {
+    method: 'POST',
+  });
+}
+
 export async function ossFetch(
   path: string,
   options: RequestInit = {},
@@ -199,6 +273,10 @@ export async function ossFetch(
 
     if (res.status === 404 && isRouteLevel404 && path === '/api/database/migrations') {
       message = 'Database migrations are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin about database migration support.';
+    }
+
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/database/backups')) {
+      message = 'Database backups are not available on this backend.\nSelf-hosted: upgrade your InsForge instance to a version with the backups feature.';
     }
 
     if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/ai')) {

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -275,7 +275,8 @@ export async function ossFetch(
       message = 'Database migrations are not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: contact your InsForge admin about database migration support.';
     }
 
-    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/database/backups')) {
+    // Exact match only: per-id backup routes 404 for a missing backup id.
+    if (res.status === 404 && isRouteLevel404 && path === '/api/database/backups') {
       message = 'Database backups are not available on this backend.\nSelf-hosted: upgrade your InsForge instance to a version with the backups feature.';
     }
 
@@ -291,12 +292,9 @@ export async function ossFetch(
       message = 'The web scraper is not available on this backend.\nUpgrade your InsForge instance to a version with web scraper support, then run `insforge webscraper apify connect --token <token>` to connect your Apify account.';
     }
 
-    // Safe to treat any 404 on /api/advisor/* as a route-level miss: the OSS
-    // advisor endpoints return 200 with a null/empty body when no scan exists
-    // (a resource-level "no data" state), so they never emit a 404 for a
-    // present-but-empty resource. A 404 here therefore means the route itself
-    // is absent (backend older than the advisor feature).
-    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/advisor')) {
+    // Excludes per-id suppression routes: deleting a missing suppression 404s
+    // with the code NOT_FOUND, which must keep its real message.
+    if (res.status === 404 && isRouteLevel404 && path.startsWith('/api/advisor') && !path.startsWith('/api/advisor/suppressions/')) {
       message = 'Backend Advisor is not available on this backend.\nSelf-hosted: upgrade your InsForge instance. Cloud: update the project to a newer version.';
     }
 

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -554,6 +554,26 @@ export async function updateMemberRole(
   return data.member ?? (data as unknown as Member);
 }
 
+export async function leaveOrganization(
+  orgId: string,
+  apiUrl?: string,
+): Promise<{ message: string }> {
+  const res = await platformFetch(`/organizations/v1/${orgId}/leave`, {
+    method: 'POST',
+  }, apiUrl);
+  return await res.json() as { message: string };
+}
+
+export async function deleteOrganization(
+  orgId: string,
+  apiUrl?: string,
+): Promise<{ message: string; organizationId: string }> {
+  const res = await platformFetch(`/organizations/v1/${orgId}`, {
+    method: 'DELETE',
+  }, apiUrl);
+  return await res.json() as { message: string; organizationId: string };
+}
+
 // --- Backups ---
 
 export async function listBackups(projectId: string, apiUrl?: string): Promise<Backup[]> {

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -558,7 +558,7 @@ export async function leaveOrganization(
   orgId: string,
   apiUrl?: string,
 ): Promise<{ message: string }> {
-  const res = await platformFetch(`/organizations/v1/${orgId}/leave`, {
+  const res = await platformFetch(`/organizations/v1/${encodeURIComponent(orgId)}/leave`, {
     method: 'POST',
   }, apiUrl);
   return await res.json() as { message: string };
@@ -568,7 +568,7 @@ export async function deleteOrganization(
   orgId: string,
   apiUrl?: string,
 ): Promise<{ message: string; organizationId: string }> {
-  const res = await platformFetch(`/organizations/v1/${orgId}`, {
+  const res = await platformFetch(`/organizations/v1/${encodeURIComponent(orgId)}`, {
     method: 'DELETE',
   }, apiUrl);
   return await res.json() as { message: string; organizationId: string };

--- a/src/lib/guard/risk-registry.test.ts
+++ b/src/lib/guard/risk-registry.test.ts
@@ -141,6 +141,18 @@ describe('assess — command-path classification', () => {
     expect(risk.whatHappens).toContain('live');
   });
 
+  it('flags org lifecycle commands (leave high, delete critical)', () => {
+    const leave = assess({ path: 'orgs leave', args: [], opts: { orgId: 'org-1' } });
+    expect(leave.severity).toBe('high');
+    expect(leave.kind).toBe('org.leave');
+    expect(leave.whatHappens).toContain('org-1');
+
+    const del = assess({ path: 'orgs delete', args: [], opts: { orgId: 'org-1' } });
+    expect(del.severity).toBe('critical');
+    expect(del.kind).toBe('org.delete');
+    expect(del.whatHappens).toContain('org-1');
+  });
+
   it('catches unregistered destructive verbs (defense in depth)', () => {
     const r = assess(cmd('widgets destroy', ['x']));
     expect(r.severity).toBe('high');

--- a/src/lib/guard/risk-registry.ts
+++ b/src/lib/guard/risk-registry.ts
@@ -309,6 +309,24 @@ const REGISTRY: Record<string, (ctx: OperationContext) => RiskAssessment> = {
     risk: 'They must be re-invited to regain access.',
   }),
 
+  'orgs leave': (ctx) => ({
+    severity: 'high',
+    kind: 'org.leave',
+    title: 'Leave an organization',
+    whatHappens: `Removes you from organization "${(ctx.opts.orgId as string) ?? '?'}".`,
+    blastRadius: 'You lose access to every project in the organization.',
+    risk: 'You must be re-invited by an administrator to regain access.',
+  }),
+
+  'orgs delete': (ctx) => ({
+    severity: 'critical',
+    kind: 'org.delete',
+    title: 'Delete an organization',
+    whatHappens: `Permanently deletes organization "${(ctx.opts.orgId as string) ?? '?'}" and every project in it.`,
+    blastRadius: 'All of the org\'s projects (databases, storage, functions), members, and its subscription are destroyed.',
+    risk: 'Irreversible. Every app pointing at any project in this organization breaks immediately.',
+  }),
+
   'secrets rotate': (ctx) => ({
     severity: 'high',
     kind: 'secrets.rotate',

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,3 +404,45 @@ export interface S3AccessKeyWithSecret extends S3AccessKey {
   /** Plaintext secret — returned only at creation, never again. */
   secretAccessKey: string;
 }
+
+// --- Advisor suppressions (OSS backend) ---
+
+export type AdvisorSuppressionScope = 'instance' | 'rule';
+export type AdvisorSuppressionReason = 'false_positive' | 'accepted_risk' | 'wont_fix' | 'other';
+
+export interface AdvisorSuppression {
+  id: string;
+  ruleId: string;
+  /** Set for `instance` scope only — the exact finding this suppresses. */
+  affectedObject?: string;
+  scope: AdvisorSuppressionScope;
+  reason: AdvisorSuppressionReason;
+  note?: string;
+  createdBy?: string;
+  createdAt: string;
+  // Enriched from the latest completed scan when a matching finding exists.
+  title?: string;
+  severity?: 'critical' | 'warning' | 'info';
+  category?: 'security' | 'performance' | 'health';
+}
+
+// --- Database backups (OSS backend) ---
+
+/**
+ * A backup record from the OSS backend (`/api/database/backups`). Distinct
+ * from the Cloud Platform `Backup` shape: camelCase fields and no
+ * project/org/plan metadata.
+ */
+export interface OssBackup {
+  id: string;
+  name: string | null;
+  triggerSource: 'manual' | 'scheduled';
+  status: 'running' | 'completed' | 'failed';
+  sizeBytes: number | null;
+  errorMessage: string | null;
+  createdAt: string;
+  completedAt: string | null;
+  createdBy: string | null;
+  /** When retention will delete this backup; scheduled backups only. */
+  expiresAt: string | null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,11 +428,7 @@ export interface AdvisorSuppression {
 
 // --- Database backups (OSS backend) ---
 
-/**
- * A backup record from the OSS backend (`/api/database/backups`). Distinct
- * from the Cloud Platform `Backup` shape: camelCase fields and no
- * project/org/plan metadata.
- */
+/** Backup record from the OSS backend — distinct shape from the Cloud `Backup`. */
 export interface OssBackup {
   id: string;
   name: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,7 +408,14 @@ export interface S3AccessKeyWithSecret extends S3AccessKey {
 // --- Advisor suppressions (OSS backend) ---
 
 export type AdvisorSuppressionScope = 'instance' | 'rule';
-export type AdvisorSuppressionReason = 'false_positive' | 'accepted_risk' | 'wont_fix' | 'other';
+
+export const ADVISOR_SUPPRESSION_REASONS = [
+  'false_positive',
+  'accepted_risk',
+  'wont_fix',
+  'other',
+] as const;
+export type AdvisorSuppressionReason = (typeof ADVISOR_SUPPRESSION_REASONS)[number];
 
 export interface AdvisorSuppression {
   id: string;


### PR DESCRIPTION
## Summary

Implements the non-struck commands from the **CLI Optimization Stage II** PRD (Notion: `CLI-Optimization-Stage-II`).

| Command | Endpoint | Notes |
|---|---|---|
| `advisor scan` | OSS `POST /api/advisor/scan` | Trigger a re-scan immediately after a fix instead of waiting for the schedule |
| `advisor suppress <ruleId> [--object] --reason [--note]` | OSS `POST /api/advisor/suppressions` | Dismiss false positives with a recorded reason; `--object` → instance scope, otherwise whole rule; `--note` required for reason `other` |
| `advisor suppressions` / `advisor unsuppress <id>` | OSS `GET` / `DELETE /api/advisor/suppressions/:id` | List / restore suppressed findings |
| `orgs leave --org-id <id>` | `POST /organizations/v1/:id/leave` | Guarded; surfaces backend errors (e.g. last-administrator rule) verbatim |
| `orgs delete --org-id <id>` | `DELETE /organizations/v1/:id` | Modeled on `projects delete`; see below |
| `backups *` (all subcommands) | OSS `GET/POST /api/database/backups`, `PATCH/DELETE /:id`, `POST /:id/restore` | Self-hosted projects now work; cloud Platform behavior unchanged |
| `ai overview` | OSS `GET /api/ai/overview` | Total usage, limit, remaining credit, daily/weekly/monthly spend, per-model activity |

## Design notes

- **`orgs leave` / `orgs delete` never resolve the org implicitly** — `--org-id` is required (mirrors `projects delete`'s explicit `--project` rule), so a stray linked project / `INSFORGE_ORG_ID` / default org can't point a destructive op at the wrong organization.
- **`orgs delete` surfaces the cascade**: the cloud backend cancels the org's Stripe subscriptions (`stripe.subscriptions.cancel`, abort-on-failure before any DB write) and permanently deletes every project in the org. The CLI lists the projects that will be destroyed and warns when the currently linked project belongs to the org (and suggests re-`link` after).
- **Guard registry**: new `orgs leave` (high) and `orgs delete` (critical) entries; advisor/backups reuse existing entries.
- **Backups OSS mode**: routed via the `FAKE_PROJECT_ID` sentinel; an explicit `--project` still targets a cloud project. OSS `create` is async, so `--wait` polls the list until the backup settles; OSS has no `/latest` route, so `latest` derives the newest record from the list. Route-level 404 gets a friendly "upgrade your instance" message.
- **`diagnose advisor` table now shows the Rule column** — it's the id `advisor suppress` takes.
- `advisor` and `ai overview` are OSS-route commands (work for both cloud-linked and `--api-key`-linked projects).

## Testing

- 718 unit tests pass (21 new across `advisor`, `orgs lifecycle`, `backups` dual-mode, `ai overview`, guard registry), eslint clean, tsup build + `--help` smoke-tested.

## Cross-reference

- Agent-skills update (same change set): InsForge/insforge-skills branch `feat/cli-stage2-commands` — documents all new commands in the `insforge-cli` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Stage II CLI commands: advisor scan/suppressions, orgs leave/delete with safeguards, self-hosted backups, and `ai overview`. Tightens safety, routing, auth, and error handling, and makes `ai overview` show missing fields as “unknown” while keeping “unlimited” semantics.

- **New Features**
  - Advisor: `scan`; `suppress <ruleId> [--object] --reason [--note]`; `suppressions`; `unsuppress <id>`; stricter input validation; requires auth; `diagnose advisor` shows the Rule ID.
  - Orgs: `leave --org-id <id>` and `delete --org-id <id>` with confirmations, explicit org targeting, risk registry entries (leave=high, delete=critical), cascade listing, linked-project warnings, and `--json` includes `linked_project_deleted`.
  - Backups (self-hosted): all `backups` subcommands use OSS endpoints when linked to the sentinel; `create --wait` polls until done; `latest` derives from list; friendly 404 guidance; explicit `--project` always targets cloud.
  - AI: `ai overview` shows total usage, limit, remaining credit, daily/weekly/monthly spend, and per-model activity when available; shows “No per-model activity yet” when observability is empty.

- **Bug Fixes**
  - Advisor: `suppress` reads `--reason` correctly when provided via a global flag; per-id suppression 404s no longer get masked by “advisor not available”; `--object` cannot be empty; reasons use a single source-of-truth.
  - Backups: target resolution happens before auth with OSS bypass only when the OSS route is the target; explicit `--project` beats ambient config; immediate failed OSS create now errors; restore confirm clarifies “database only”; delete analytics tag `oss: true`; backups feature-missing 404 scoped to the collection route.
  - Orgs: delete confirmation fail-closes if project inventory can’t be fetched.
  - AI: `ai overview` now requires auth; missing fields render as “unknown” (null still means “unlimited”); USD formatting hardened against partial payloads.

<sup>Written for commit 1dbd4f93ac84482d13e60b86b617a747f2cf489f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add advisor, orgs leave/delete, self-hosted backups, and ai overview CLI commands
> - Adds an `advisor` command group with `scan`, `suppressions`, `suppress`, and `unsuppress` subcommands, including reason validation, optional instance scoping, and JSON/human output.
> - Adds `orgs leave` and `orgs delete` subcommands requiring explicit `--org-id`, with interactive confirmation, cascade project warnings, and risk registry entries (high/critical severity).
> - Extends backup commands to transparently route to self-hosted (OSS) endpoints when the linked project matches the `FAKE_PROJECT_ID` sentinel, including `--wait` polling on create and synchronous restore; cloud projects continue using the Platform API.
> - Registers `ai overview` under the `ai` command group, rendering Model Gateway key usage, limits, and optional per-model spend table.
> - Adds `Rule` column to the `diagnose advisor` table to show the `ruleId` used with `advisor suppress`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #223 opened
>
> - Added authentication bypass logic for self-hosted (OSS) projects across all backup commands [2485f4a]
> - Enhanced advisor suppress command validation and consolidated suppression reason constants [2485f4a]
> - Modified organization delete command to always fetch and display project inventory before confirmation [2485f4a]
> - Added authentication requirement to all advisor commands [2485f4a]
> - Fixed URL encoding for organization IDs in leave and delete API functions [2485f4a]
> - Added friendly message to ai overview command when no model usage data exists [2485f4a]
> - Changed backup project resolution to prefer explicit --project flag over environment configuration [2485f4a]
> - Added authentication requirement to `ai overview` command [a527e90]
> - Updated `usd` utility function and overview output formatting to handle missing values [a527e90]
> - Added credential mocking to `ai overview` test suite [a527e90]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f81f9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added advisor commands to scan projects and manage rule- or object-scoped suppressions.
  - Added `ai overview` to display AI usage, limits, remaining capacity, and model details.
  - Added backup management for self-hosted projects, including listing, creation, renaming, restoration, and deletion.
  - Added organization leave and delete commands with confirmations, cancellation, warnings, and JSON output.
- **Enhancements**
  - Advisor issue results now display rule IDs.
  - Added risk warnings for organization lifecycle operations.
- **Tests**
  - Expanded coverage across advisor, AI overview, backups, and organization lifecycle commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->