### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Minor bump for the CLI Optimization Stage II feature set merged in #223 (new `advisor` command group, `orgs leave`/`orgs delete`, self-hosted `backups` support, `ai overview`).

After merge, publish with:
```bash
git checkout main && git pull
gh release create v0.3.0 --title v0.3.0 --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@insforge/cli` v0.3.0. This version ships CLI Optimization Stage II: `advisor` command group, `orgs leave`/`orgs delete`, self-hosted `backups`, and `ai overview`.

- **Migration**
  - Create GitHub release `v0.3.0` after merge.

<sup>Written for commit 6321dfde56d0f259a0951dced7b8f373c6b15fb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump package version to 0.3.0
> Updates the version field in [package.json](https://github.com/InsForge/CLI/pull/224/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.2.4` to `0.3.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6321dfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->