### PR TITLE
feat(local): `insforge local start` — a local backend running InsForge's own stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ npx @insforge/cli local start --json
 | --- | --- |
 | `--storage <backend>` | `local` (filesystem, default), `minio`, or `rustfs`. The bundled stores stay on the internal Docker network and enable the S3-compatible gateway at `/storage/v1/s3`. |
 | `--pull` | Re-pull images even when present locally. |
-| `--port-app`, `--port-auth`, `--port-deno`, `--port-postgres`, `--port-postgrest` | Host port overrides. Defaults are 7130 / 7131 / 7133 / 5432 / 5430. |
+| `--port-app`, `--port-auth`, `--port-deno`, `--port-postgres`, `--port-postgrest` | Host port overrides. Defaults are 7130 / 7131 / 7133 / 5432 / 5430. A port set here is never relocated. |
 
 Afterwards every other command targets the local backend — no login, because the
 directory is linked with the instance's own API key:
@@ -152,8 +152,14 @@ missing while volumes still exist, `local start` refuses rather than generating
 new ones — Postgres reads its password only when the cluster is created, so fresh
 secrets would leave the database unreachable.
 
-**Ports.** Everything binds to `127.0.0.1`. A development backend has no business
-being reachable from the rest of the network.
+**Ports.** The first instance on a machine gets 7130 / 7131 / 7133 / 5432 / 5430.
+When those are taken the whole block shifts by ten — a second instance lands on
+7140, a third on 7150 — and `start` prints what moved. Ports a directory has
+already used stay put across restarts, so `.env.local` keeps pointing at the
+right place.
+
+Everything binds to `127.0.0.1`. A development backend has no business being
+reachable from the rest of the network.
 
 #### `npx @insforge/cli local stop`
 

--- a/README.md
+++ b/README.md
@@ -153,10 +153,13 @@ Later starts do not pull: an image moving under an instance that has data is how
 the backend ends up running migrations its volume did not expect. `--pull` asks
 for it deliberately.
 
-`.insforge/checkout/.env` holds the only copy of the instance's secrets. If it is
-missing while volumes still exist, `local start` refuses rather than generating
-new ones — Postgres reads its password only when the cluster is created, so fresh
-secrets would leave the database unreachable.
+`.insforge/checkout/.env` is where the instance's secrets are generated, and the
+only copy of most of them — the Postgres password, JWT secret, encryption key,
+and admin password appear nowhere else. (The API key is also in
+`.insforge/project.json`, the anon key in `.env.local`.) If the file is missing
+while volumes still exist, `local start` refuses rather than generating new ones:
+Postgres reads its password only when the cluster is created, so fresh secrets
+would leave the database unreachable.
 
 **Ports.** The first instance on a machine gets 7130 / 7131 / 7133 / 5432 / 5430.
 When those are taken the whole block shifts by ten — a second instance lands on
@@ -164,8 +167,9 @@ When those are taken the whole block shifts by ten — a second instance lands o
 already used stay put across restarts, so `.env.local` keeps pointing at the
 right place.
 
-Everything binds to `127.0.0.1`. A development backend has no business being
-reachable from the rest of the network.
+Every published port binds to `127.0.0.1` — a development backend has no business
+being reachable from the rest of the network. Services reach each other over the
+project's internal Docker network, which is not published at all.
 
 #### `npx @insforge/cli local stop`
 
@@ -1216,7 +1220,7 @@ npx @insforge/cli config apply --auto-approve   # skip confirmation prompt
 
 Running `npx @insforge/cli link` creates a `.insforge/` directory in your project:
 
-```
+```text
 .insforge/
 └── project.json    # project_id, org_id, appkey, region, api_key, oss_host
 ```
@@ -1226,7 +1230,7 @@ Add `.insforge/` to your `.gitignore` — it contains your project API key.
 `local start` adds the following and writes a `.insforge/.gitignore` covering
 them, so the generated secrets cannot be committed even by `git add -A`:
 
-```
+```text
 .insforge/
 ├── local.json           # ports, storage backend, compose project name
 ├── setup.sh             # the script fetched from the InsForge repository
@@ -1237,9 +1241,9 @@ them, so the generated secrets cannot be committed even by `git add -A`:
 ```
 
 `checkout/.env` is written once and re-read on every later start. Deleting it
-loses the secrets for the running instance: the API key your `.env.local` holds,
-and the Postgres password, which the database only ever read at cluster
-creation. `local start` refuses rather than regenerating them.
+loses the secrets that live nowhere else — among them the Postgres password,
+which the database only ever read at cluster creation. `local start` refuses
+rather than regenerating them.
 
 ### Declarative project config — `insforge.toml`
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ Requires Node.js >= 18. We recommend running via `npx` so you always get the lat
 ## Quick Start
 
 ```bash
-# Run InsForge on your own machine — no account, no clone (Docker required)
-npx -y @insforge/cli@latest local start
-
 # Login via browser (OAuth)
 npx @insforge/cli login
 
@@ -31,6 +28,10 @@ npx @insforge/cli link
 npx @insforge/cli db tables
 npx @insforge/cli db query "SELECT * FROM users LIMIT 10"
 ```
+
+A hosted project is the default and what these commands assume. If you
+specifically want a backend running in Docker on your own machine — offline work,
+a throwaway database, no account — see [Local Instances](#local-instances).
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Requires Node.js >= 18. We recommend running via `npx` so you always get the lat
 ## Quick Start
 
 ```bash
+# Run InsForge on your own machine — no account, no clone (Docker required)
+npx -y @insforge/cli@latest local start
+
 # Login via browser (OAuth)
 npx @insforge/cli login
 
@@ -97,6 +100,92 @@ when you want to link a directory directly to a known project.
 > (`hidden: true` in `src/index.ts`) and are intentionally excluded from this
 > reference. Use `npx @insforge/cli list` instead of `orgs`/`projects`; `records`
 > is internal and not supported for direct use.
+
+### Local Instances
+
+Run a full InsForge backend on your own machine in Docker: Postgres, PostgREST,
+the backend, and the edge-functions runtime. No account, no repository clone.
+
+**One instance per directory.** The compose project name includes a hash of the
+directory path, so every app folder gets its own containers, volumes, and
+database — including two folders that share a name.
+
+#### `npx @insforge/cli local start`
+
+Starts the stack, waits for it to become healthy, links the directory, and seeds
+`.env.local`.
+
+```bash
+npx @insforge/cli local start
+npx @insforge/cli local start --storage minio   # bundled S3-compatible store
+npx @insforge/cli local start --pull            # re-pull images
+npx @insforge/cli local start --port-app 8130   # relocate a port
+npx @insforge/cli local start --json
+```
+
+| Option | Description |
+| --- | --- |
+| `--storage <backend>` | `local` (filesystem, default), `minio`, or `rustfs`. The bundled stores stay on the internal Docker network and enable the S3-compatible gateway at `/storage/v1/s3`. |
+| `--pull` | Re-pull images even when present locally. |
+| `--port-app`, `--port-auth`, `--port-deno`, `--port-postgres`, `--port-postgrest` | Host port overrides. Defaults are 7130 / 7131 / 7133 / 5432 / 5430. |
+
+Afterwards every other command targets the local backend — no login, because the
+directory is linked with the instance's own API key:
+
+```bash
+npx @insforge/cli db query "select 1"
+npx @insforge/cli storage create-bucket avatars
+npx @insforge/cli functions deploy
+```
+
+**Where the stack comes from.** The first start fetches
+[`deploy/setup.sh`](https://github.com/InsForge/InsForge/blob/main/deploy/setup.sh)
+from the InsForge repository and runs it into `.insforge/checkout/`. That script
+is what self-hosting uses, so a local instance runs the same compose file, init
+SQL, and images as a deployed one — the CLI adds one overlay, which sets the
+telemetry stamp and binds the published ports to loopback. Every start re-runs it,
+picking up upstream changes; the generated `.env` is left alone. Images track
+`:latest`; `--pull` refreshes them.
+
+`.insforge/checkout/.env` holds the only copy of the instance's secrets. If it is
+missing while volumes still exist, `local start` refuses rather than generating
+new ones — Postgres reads its password only when the cluster is created, so fresh
+secrets would leave the database unreachable.
+
+**Ports.** Everything binds to `127.0.0.1`. A development backend has no business
+being reachable from the rest of the network.
+
+#### `npx @insforge/cli local stop`
+
+```bash
+npx @insforge/cli local stop                # stop; data is kept
+npx @insforge/cli local stop --delete-data  # also destroy the volumes
+npx @insforge/cli local stop --unlink       # restore the previous cloud link
+```
+
+`--delete-data` is irreversible and classified `critical` by the human-in-the-loop
+guard, so with the guard enabled it requires approval. A plain `stop` never prompts.
+
+If the directory was linked to a cloud project, `local start` saves that link to
+`.insforge/project.cloud.json` rather than overwriting it, and `local stop
+--unlink` puts it back.
+
+#### `npx @insforge/cli local status`
+
+```bash
+npx @insforge/cli local status
+npx @insforge/cli local status --show-keys   # print keys in full
+npx @insforge/cli local status --json
+```
+
+Shows health, ports, the backend version, the compose project name, and
+per-container state. Keys are masked by default, and `--json` omits them unless
+`--show-keys` is passed — so its output is safe to paste into an issue.
+
+**Requirements.** Docker with Compose 2.24.4 or newer, and roughly 1.5 GB
+available to the daemon. Any Docker-compatible runtime works (Docker Desktop,
+OrbStack, Colima, Rancher Desktop). Without Docker, `insforge create` gives you a
+hosted project instead.
 
 ### Top-Level
 
@@ -1121,6 +1210,21 @@ Running `npx @insforge/cli link` creates a `.insforge/` directory in your projec
 ```
 
 Add `.insforge/` to your `.gitignore` — it contains your project API key.
+
+`local start` adds two more files and writes a `.insforge/.gitignore` covering
+them, so the generated keys cannot be committed even by `git add -A`:
+
+```
+.insforge/
+├── local.json           # ports, resolved version, compose project name
+├── local.env            # generated secrets, mode 0600 — fed to docker compose
+├── local-db-init.sql    # cluster-init SQL, mounted into Postgres read-only
+└── project.cloud.json   # only when a cloud link was displaced
+```
+
+`local.env` is written once and re-read on every later start. Deleting it loses
+the keys for the running instance; regenerating them would rotate the API key
+away from the `.env.local` your app already holds.
 
 ### Declarative project config — `insforge.toml`
 

--- a/README.md
+++ b/README.md
@@ -1223,20 +1223,23 @@ Running `npx @insforge/cli link` creates a `.insforge/` directory in your projec
 
 Add `.insforge/` to your `.gitignore` — it contains your project API key.
 
-`local start` adds two more files and writes a `.insforge/.gitignore` covering
-them, so the generated keys cannot be committed even by `git add -A`:
+`local start` adds the following and writes a `.insforge/.gitignore` covering
+them, so the generated secrets cannot be committed even by `git add -A`:
 
 ```
 .insforge/
-├── local.json           # ports, resolved version, compose project name
-├── local.env            # generated secrets, mode 0600 — fed to docker compose
-├── local-db-init.sql    # cluster-init SQL, mounted into Postgres read-only
+├── local.json           # ports, storage backend, compose project name
+├── setup.sh             # the script fetched from the InsForge repository
+├── checkout/            # the stack that script wrote
+│   ├── .env             # generated secrets, mode 0600
+│   └── deploy/…         # the compose file and what it mounts
 └── project.cloud.json   # only when a cloud link was displaced
 ```
 
-`local.env` is written once and re-read on every later start. Deleting it loses
-the keys for the running instance; regenerating them would rotate the API key
-away from the `.env.local` your app already holds.
+`checkout/.env` is written once and re-read on every later start. Deleting it
+loses the secrets for the running instance: the API key your `.env.local` holds,
+and the Postgres password, which the database only ever read at cluster
+creation. `local start` refuses rather than regenerating them.
 
 ### Declarative project config — `insforge.toml`
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,14 @@ from the InsForge repository and runs it into `.insforge/checkout/`. That script
 is what self-hosting uses, so a local instance runs the same compose file, init
 SQL, and images as a deployed one — the CLI adds one overlay, which sets the
 telemetry stamp and binds the published ports to loopback. Every start re-runs it,
-picking up upstream changes; the generated `.env` is left alone. Images track
-`:latest`; `--pull` refreshes them.
+picking up upstream changes; the generated `.env` is left alone.
+
+Images track `:latest`. A directory's first start pulls, because Docker will not
+re-fetch a tag it already has — without it a machine that pulled months ago runs
+that image and reports its version, with nothing to suggest a newer one exists.
+Later starts do not pull: an image moving under an instance that has data is how
+the backend ends up running migrations its volume did not expect. `--pull` asks
+for it deliberately.
 
 `.insforge/checkout/.env` holds the only copy of the instance's secrets. If it is
 missing while volumes still exist, `local start` refuses rather than generating

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/cli",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "files": [
     "dist/index.js",
     "dist/index.d.ts",
-    "dist/assets/forger.json"
+    "dist/assets/forger.json",
+    "dist/assets/local/cli-overlay.yml"
   ],
   "dependencies": {
     "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "InsForge CLI - Command line tool for InsForge platform",
   "type": "module",
   "bin": {

--- a/src/assets/local/cli-overlay.yml
+++ b/src/assets/local/cli-overlay.yml
@@ -1,0 +1,23 @@
+# What the CLI changes about the upstream compose file. Everything else is
+# upstream's, unmodified.
+services:
+  insforge:
+    # Telemetry reads this as an artifact stamp: each way of shipping the stack
+    # says what it is, so `local start` can be told apart from a self-hosted
+    # docker compose. The upstream file does not reference the variable, and
+    # Compose only passes variables a file names — so an env file cannot carry
+    # it, and an overlay is the way to add it.
+    environment:
+      INSFORGE_DEPLOYMENT_METHOD: cli-local
+
+    # Upstream publishes the API and dashboard on every interface, which is what
+    # a self-hosted install wants. A development backend on a laptop that joins
+    # untrusted networks does not: bind it to loopback like the rest of the stack
+    # already is.
+    #
+    # !override, because Compose merges port lists by appending — without it the
+    # 0.0.0.0 entry survives alongside the loopback one and still listens.
+    # Requires Compose 2.24.4+, which is what ensureDocker checks for.
+    ports: !override
+      - "127.0.0.1:${APP_PORT:-7130}:7130"
+      - "127.0.0.1:${AUTH_PORT:-7131}:7131"

--- a/src/commands/local/index.ts
+++ b/src/commands/local/index.ts
@@ -1,0 +1,14 @@
+import type { Command } from 'commander';
+import { registerLocalStartCommand } from './start.js';
+import { registerLocalStopCommand } from './stop.js';
+import { registerLocalStatusCommand } from './status.js';
+
+export function registerLocalCommands(program: Command): void {
+  const localCmd = program
+    .command('local')
+    .description('Run InsForge on your own machine in Docker (one instance per directory)');
+
+  registerLocalStartCommand(localCmd);
+  registerLocalStopCommand(localCmd);
+  registerLocalStatusCommand(localCmd);
+}

--- a/src/commands/local/start.ts
+++ b/src/commands/local/start.ts
@@ -105,6 +105,11 @@ function backupCloudLink(): string | null {
   return existing.project_name;
 }
 
+/** Quote an argument so a path with spaces survives being pasted into a shell. */
+function shellQuote(arg: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(arg) ? arg : `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
 async function waitForHealth(
   baseUrl: string,
   ctx: ComposeContext,
@@ -119,7 +124,7 @@ async function waitForHealth(
       throw new CLIError(
         `The backend did not become healthy within ${Math.round(HEALTH_TIMEOUT_MS / 1000)}s.\n` +
           `Inspect the containers with:\n` +
-          `  docker ${composeArgs(ctx, ['logs', 'insforge']).join(' ')}`,
+          `  docker ${composeArgs(ctx, ['logs', 'insforge']).map(shellQuote).join(' ')}`,
       );
     }
     onTick(Date.now() - started);
@@ -172,7 +177,7 @@ export function registerLocalStartCommand(localCmd: Command): void {
         // .env alone, so nothing rotates under a running instance.
         const fetchSpinner = json ? null : clack.spinner();
         fetchSpinner?.start('Fetching the InsForge stack...');
-        await ensureCheckout(undefined, () => projectVolumes(projectName));
+        await ensureCheckout(undefined, () => projectVolumes(projectName), storage);
         fetchSpinner?.stop('Stack ready');
 
         // On a restart our own containers already hold these ports, which is not

--- a/src/commands/local/start.ts
+++ b/src/commands/local/start.ts
@@ -1,0 +1,307 @@
+import type { Command } from 'commander';
+import { existsSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as clack from '@clack/prompts';
+import pc from 'picocolors';
+import {
+  FAKE_ORG_ID,
+  FAKE_PROJECT_ID,
+  getProjectConfig,
+  getProjectConfigFile,
+  saveProjectConfig,
+} from '../../lib/config.js';
+import { probeBackendHealth } from '../../lib/api/oss.js';
+import { dockerMemoryMb, ensureDockerReady } from '../../lib/docker.js';
+import { upsertEnvFile } from '../../lib/env-writer.js';
+import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import {
+  composePs,
+  composeRunInherit,
+  type ComposeContext,
+  projectVolumes,
+} from '../../lib/local/compose.js';
+import { ensurePortsAvailable, resolvePorts } from '../../lib/local/ports.js';
+import { ensureCheckout } from '../../lib/local/checkout.js';
+import { readSecrets, writeEnvDeltas } from '../../lib/local/secrets.js';
+import {
+  composeProjectName,
+  readLocalState,
+  writeLocalState,
+  type LocalPorts,
+  type LocalState,
+  type StorageBackend,
+} from '../../lib/local/state.js';
+import type { ProjectConfig } from '../../types.js';
+
+const STORAGE_BACKENDS: StorageBackend[] = ['local', 'minio', 'rustfs'];
+
+/** Enough for a cold pull plus first-boot migrations on a slow machine. */
+const HEALTH_TIMEOUT_MS = 240_000;
+const HEALTH_INTERVAL_MS = 2_000;
+
+/** Four containers need roughly this much before Postgres starts getting OOM-killed. */
+const MIN_DOCKER_MEMORY_MB = 1_500;
+
+interface StartOptions {
+  storage?: string;
+  pull?: boolean;
+  portApp?: string;
+  portAuth?: string;
+  portDeno?: string;
+  portPostgres?: string;
+  portPostgrest?: string;
+}
+
+function parsePort(value: string | undefined, flag: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new CLIError(`Invalid ${flag}: "${value}" is not a port number between 1 and 65535.`);
+  }
+  return n;
+}
+
+function portOverrides(opts: StartOptions): Partial<LocalPorts> {
+  const out: Partial<LocalPorts> = {};
+  const app = parsePort(opts.portApp, '--port-app');
+  const auth = parsePort(opts.portAuth, '--port-auth');
+  const deno = parsePort(opts.portDeno, '--port-deno');
+  const postgres = parsePort(opts.portPostgres, '--port-postgres');
+  const postgrest = parsePort(opts.portPostgrest, '--port-postgrest');
+  if (app !== undefined) out.app = app;
+  if (auth !== undefined) out.auth = auth;
+  if (deno !== undefined) out.deno = deno;
+  if (postgres !== undefined) out.postgres = postgres;
+  if (postgrest !== undefined) out.postgrest = postgrest;
+  return out;
+}
+
+function resolveStorage(opts: StartOptions, previous: StorageBackend | undefined): StorageBackend {
+  if (opts.storage === undefined) return previous ?? 'local';
+  const value = opts.storage as StorageBackend;
+  if (!STORAGE_BACKENDS.includes(value)) {
+    throw new CLIError(
+      `Invalid --storage "${opts.storage}". Valid: ${STORAGE_BACKENDS.join(', ')}.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Move an existing cloud link aside instead of clobbering it. Mirrors what
+ * `branch switch` does with project.parent.json, so `local stop` can put the
+ * cloud project back.
+ */
+function backupCloudLink(): string | null {
+  const existing = getProjectConfig();
+  if (!existing || existing.project_id === FAKE_PROJECT_ID) return null;
+  const target = join(process.cwd(), '.insforge', 'project.cloud.json');
+  if (!existsSync(target)) {
+    copyFileSync(getProjectConfigFile(), target);
+  }
+  return existing.project_name;
+}
+
+async function waitForHealth(
+  baseUrl: string,
+  onTick: (elapsedMs: number) => void,
+): Promise<{ version?: string }> {
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+  const started = Date.now();
+  for (;;) {
+    const probe = await probeBackendHealth(baseUrl, 5_000);
+    if (probe.reachable) return probe;
+    if (Date.now() >= deadline) {
+      throw new CLIError(
+        `The backend did not become healthy within ${Math.round(HEALTH_TIMEOUT_MS / 1000)}s.\n` +
+          `Inspect the containers with:\n` +
+          `  docker compose -p ${composeProjectName()} logs insforge`,
+      );
+    }
+    onTick(Date.now() - started);
+    await new Promise((r) => setTimeout(r, HEALTH_INTERVAL_MS));
+  }
+}
+
+export function registerLocalStartCommand(localCmd: Command): void {
+  localCmd
+    .command('start')
+    .description('Start a local InsForge backend in Docker and link this directory')
+    .option('--storage <backend>', `Object storage backend: ${STORAGE_BACKENDS.join(', ')}`)
+    .option('--pull', 'Re-pull images even when they are already present locally')
+    .option('--port-app <n>', 'Host port for the API and dashboard (default 7130)')
+    .option('--port-auth <n>', 'Host port for the auth service (default 7131)')
+    .option('--port-deno <n>', 'Host port for the functions runtime (default 7133)')
+    .option('--port-postgres <n>', 'Host port for Postgres (default 5432)')
+    .option('--port-postgrest <n>', 'Host port for PostgREST (default 5430)')
+    .action(async (opts: StartOptions, cmd: Command) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        ensureDockerReady();
+
+        const memory = dockerMemoryMb();
+        if (memory !== null && memory < MIN_DOCKER_MEMORY_MB && !json) {
+          clack.log.warn(
+            `Docker has ${memory} MB available. InsForge needs about ${MIN_DOCKER_MEMORY_MB} MB for four ` +
+              'containers — raise it in Docker Desktop → Settings → Resources if startup fails.',
+          );
+        }
+
+        const previous = readLocalState();
+        const storage = resolveStorage(opts, previous?.storage);
+        const ports = resolvePorts({ ...previous?.ports, ...portOverrides(opts) });
+        const projectName = previous?.projectName ?? composeProjectName();
+        const ctx: ComposeContext = { projectName, storage };
+
+        // The stack is defined in InsForge's repository, not here: this fetches
+        // its setup.sh and runs it, which lands the compose file, the files it
+        // mounts, and an .env holding the secrets it generates. Re-run on every
+        // start so a release that adds a file is picked up; it leaves an existing
+        // .env alone, so nothing rotates under a running instance.
+        const fetchSpinner = json ? null : clack.spinner();
+        fetchSpinner?.start('Fetching the InsForge stack...');
+        await ensureCheckout(undefined, () => projectVolumes(projectName));
+        fetchSpinner?.stop('Stack ready');
+
+        // On a restart our own containers already hold these ports, which is not
+        // a conflict. Only check when nothing of ours is running; if there is a
+        // genuine clash after that, `docker compose up` reports it.
+        const alreadyRunning = composePs(ctx).some((s) => s.state === 'running');
+        if (!alreadyRunning) {
+          await ensurePortsAvailable(ports);
+        }
+
+        writeEnvDeltas({ ports, storage });
+
+        const secrets = readSecrets();
+        if (!secrets) {
+          throw new CLIError(
+            "The stack's env file is missing the keys setup.sh generates.\n" +
+              'Delete .insforge/checkout/.env and start again — note that this loses\n' +
+              'the credentials of any instance already running in this directory.',
+          );
+        }
+
+        const state: LocalState = {
+          version: 1,
+          projectName,
+          storage,
+          ports,
+          createdAt: previous?.createdAt ?? new Date().toISOString(),
+        };
+        // Before `up`, deliberately. A failed `up` can still leave containers or
+        // volumes behind, and `local stop` needs the recorded project name to
+        // reach them — writing this afterwards would strand whatever it made.
+        writeLocalState(state);
+
+        // The recorded version reaches compose through INSFORGE_STACK_TAG in the
+        // generated env file — the same variable a hand-run compose uses.
+        if (opts.pull && composeRunInherit(ctx, ['pull']) !== 0) {
+          throw new CLIError('docker compose pull failed. See the output above.');
+        }
+        if (!json) clack.log.step('Starting containers...');
+        if (composeRunInherit(ctx, ['up', '-d']) !== 0) {
+          throw new CLIError('docker compose up failed. See the output above.');
+        }
+
+        const baseUrl = `http://localhost:${ports.app}`;
+        const spinner = json ? null : clack.spinner();
+        spinner?.start('Waiting for the backend (first boot runs migrations)...');
+        const health = await waitForHealth(baseUrl, (elapsed) => {
+          spinner?.message(
+            `Waiting for the backend (first boot runs migrations)... ${Math.round(elapsed / 1000)}s`,
+          );
+        });
+        spinner?.stop('Backend is healthy');
+
+        const displacedCloudProject = backupCloudLink();
+        const projectConfig: ProjectConfig = {
+          project_id: FAKE_PROJECT_ID,
+          project_name: 'local',
+          org_id: FAKE_ORG_ID,
+          appkey: 'local',
+          region: 'local',
+          api_key: secrets.apiKey,
+          oss_host: baseUrl,
+        };
+        saveProjectConfig(projectConfig);
+
+        // NEXT_PUBLIC_* matches what `insforge create` seeds; VITE_* is added
+        // because a Vite app cannot read NEXT_PUBLIC_ variables and local
+        // development is overwhelmingly Vite. upsertEnvFile never overwrites an
+        // existing value, so a user's own pins survive.
+        const envResult = upsertEnvFile(join(process.cwd(), '.env.local'), {
+          NEXT_PUBLIC_INSFORGE_URL: baseUrl,
+          NEXT_PUBLIC_INSFORGE_ANON_KEY: secrets.anonKey,
+          VITE_INSFORGE_URL: baseUrl,
+          VITE_INSFORGE_ANON_KEY: secrets.anonKey,
+        });
+
+        await trackCommandUsage('local', 'start', true, { storage });
+
+        if (json) {
+          outputJson({
+            success: true,
+            apiUrl: baseUrl,
+            dashboardUrl: baseUrl,
+            databaseUrl: `postgresql://postgres:postgres@localhost:${ports.postgres}/insforge`,
+            apiKey: secrets.apiKey,
+            anonKey: secrets.anonKey,
+            admin: { username: secrets.adminUsername, password: secrets.adminPassword },
+            ports,
+            storage,
+            composeProject: projectName,
+            // Keys only: `mismatched` carries the values already in the user's
+            // .env.local, which are theirs and would end up in a CI log.
+            envLocal: {
+              added: envResult.added,
+              skipped: envResult.skipped,
+              mismatched: envResult.mismatched.map((m) => m.key),
+            },
+          });
+          return;
+        }
+
+        clack.note(
+          [
+            `${pc.dim('API URL     ')} ${pc.cyan(baseUrl)}`,
+            `${pc.dim('Dashboard   ')} ${pc.cyan(baseUrl)}`,
+            `${pc.dim('DB URL      ')} postgresql://postgres:postgres@localhost:${ports.postgres}/insforge`,
+            `${pc.dim('API key     ')} ${secrets.apiKey} ${pc.dim('(superadmin — server-side only)')}`,
+            `${pc.dim('anon key    ')} ${secrets.anonKey} ${pc.dim('(safe for browsers)')}`,
+            `${pc.dim('Admin login ')} ${secrets.adminUsername} / ${secrets.adminPassword}`,
+            `${pc.dim('Storage     ')} ${storage === 'local' ? 'local filesystem' : `${storage} (S3 gateway enabled)`}`,
+            `${pc.dim('Version     ')} ${health.version ?? 'latest published'}`,
+          ].join('\n'),
+          'Local InsForge is running',
+        );
+
+        if (displacedCloudProject) {
+          clack.log.warn(
+            `This directory was linked to cloud project "${displacedCloudProject}". ` +
+              'Saved to .insforge/project.cloud.json — `insforge local stop --unlink` restores it.',
+          );
+        }
+        if (envResult.mismatched.length > 0) {
+          clack.log.warn(
+            `.env.local already sets ${envResult.mismatched.map((m) => m.key).join(', ')} to different ` +
+              'values — left untouched. Update them by hand to point at the local backend.',
+          );
+        }
+
+        clack.log.info(
+          `Linked this directory. Every other command now targets the local backend:\n` +
+            `  insforge db query "select 1"     insforge functions deploy\n` +
+            `  insforge local status            insforge local stop`,
+        );
+      } catch (err) {
+        await trackCommandUsage('local', 'start', false, {}, err);
+        handleError(err, json);
+      }
+    });
+}
+
+/** Exported for tests. */
+export const __testing = { parsePort, portOverrides, resolveStorage };

--- a/src/commands/local/start.ts
+++ b/src/commands/local/start.ts
@@ -22,9 +22,9 @@ import {
   type ComposeContext,
   projectVolumes,
 } from '../../lib/local/compose.js';
-import { ensurePortsAvailable, resolvePorts } from '../../lib/local/ports.js';
+import { allocatePorts, resolvePorts } from '../../lib/local/ports.js';
 import { ensureCheckout } from '../../lib/local/checkout.js';
-import { readSecrets, writeEnvDeltas } from '../../lib/local/secrets.js';
+import { databaseUrl, readSecrets, writeEnvDeltas } from '../../lib/local/secrets.js';
 import {
   composeProjectName,
   readLocalState,
@@ -151,7 +151,15 @@ export function registerLocalStartCommand(localCmd: Command): void {
 
         const previous = readLocalState();
         const storage = resolveStorage(opts, previous?.storage);
-        const ports = resolvePorts({ ...previous?.ports, ...portOverrides(opts) });
+        const overrides = portOverrides(opts);
+        const desiredPorts = resolvePorts({ ...previous?.ports, ...overrides });
+        // Ports with an answer behind them, which allocation must not move: the
+        // ones passed as flags, and the ones a previous start already recorded
+        // and wrote into this directory's .env.local.
+        const fixedPorts = new Set<keyof LocalPorts>([
+          ...((previous?.ports ? Object.keys(previous.ports) : []) as (keyof LocalPorts)[]),
+          ...(Object.keys(overrides) as (keyof LocalPorts)[]),
+        ]);
         const projectName = previous?.projectName ?? composeProjectName();
         const ctx: ComposeContext = { projectName, storage };
 
@@ -166,11 +174,19 @@ export function registerLocalStartCommand(localCmd: Command): void {
         fetchSpinner?.stop('Stack ready');
 
         // On a restart our own containers already hold these ports, which is not
-        // a conflict. Only check when nothing of ours is running; if there is a
-        // genuine clash after that, `docker compose up` reports it.
+        // a conflict. Only allocate when nothing of ours is running; if there is
+        // a genuine clash after that, `docker compose up` reports it.
+        let ports = desiredPorts;
         const alreadyRunning = composePs(ctx).some((s) => s.state === 'running');
         if (!alreadyRunning) {
-          await ensurePortsAvailable(ports);
+          const allocation = await allocatePorts(desiredPorts, fixedPorts);
+          ports = allocation.ports;
+          if (allocation.moved.length > 0 && !json) {
+            clack.log.info(
+              `Default ports are in use, so this instance took the next block:\n` +
+                allocation.moved.map((m) => `  ${m.from} → ${m.to}`).join('\n'),
+            );
+          }
         }
 
         writeEnvDeltas({ ports, storage });
@@ -246,7 +262,7 @@ export function registerLocalStartCommand(localCmd: Command): void {
             success: true,
             apiUrl: baseUrl,
             dashboardUrl: baseUrl,
-            databaseUrl: `postgresql://postgres:postgres@localhost:${ports.postgres}/insforge`,
+            databaseUrl: databaseUrl(secrets.postgresPassword, ports.postgres),
             apiKey: secrets.apiKey,
             anonKey: secrets.anonKey,
             admin: { username: secrets.adminUsername, password: secrets.adminPassword },
@@ -268,7 +284,7 @@ export function registerLocalStartCommand(localCmd: Command): void {
           [
             `${pc.dim('API URL     ')} ${pc.cyan(baseUrl)}`,
             `${pc.dim('Dashboard   ')} ${pc.cyan(baseUrl)}`,
-            `${pc.dim('DB URL      ')} postgresql://postgres:postgres@localhost:${ports.postgres}/insforge`,
+            `${pc.dim('DB URL      ')} ${databaseUrl(secrets.postgresPassword, ports.postgres)}`,
             `${pc.dim('API key     ')} ${secrets.apiKey} ${pc.dim('(superadmin — server-side only)')}`,
             `${pc.dim('anon key    ')} ${secrets.anonKey} ${pc.dim('(safe for browsers)')}`,
             `${pc.dim('Admin login ')} ${secrets.adminUsername} / ${secrets.adminPassword}`,

--- a/src/commands/local/start.ts
+++ b/src/commands/local/start.ts
@@ -17,6 +17,7 @@ import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
 import { outputJson } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
 import {
+  composeArgs,
   composePs,
   composeRunInherit,
   type ComposeContext,
@@ -106,6 +107,7 @@ function backupCloudLink(): string | null {
 
 async function waitForHealth(
   baseUrl: string,
+  ctx: ComposeContext,
   onTick: (elapsedMs: number) => void,
 ): Promise<{ version?: string }> {
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
@@ -117,7 +119,7 @@ async function waitForHealth(
       throw new CLIError(
         `The backend did not become healthy within ${Math.round(HEALTH_TIMEOUT_MS / 1000)}s.\n` +
           `Inspect the containers with:\n` +
-          `  docker compose -p ${composeProjectName()} logs insforge`,
+          `  docker ${composeArgs(ctx, ['logs', 'insforge']).join(' ')}`,
       );
     }
     onTick(Date.now() - started);
@@ -224,14 +226,17 @@ export function registerLocalStartCommand(localCmd: Command): void {
           throw new CLIError('docker compose pull failed. See the output above.');
         }
         if (!json) clack.log.step('Starting containers...');
-        if (composeRunInherit(ctx, ['up', '-d']) !== 0) {
+        // --remove-orphans: switching --storage drops the previous backend's
+        // service from the compose files in play. Without this its container
+        // keeps running, invisible to every later status and stop.
+        if (composeRunInherit(ctx, ['up', '-d', '--remove-orphans']) !== 0) {
           throw new CLIError('docker compose up failed. See the output above.');
         }
 
         const baseUrl = `http://localhost:${ports.app}`;
         const spinner = json ? null : clack.spinner();
         spinner?.start('Waiting for the backend (first boot runs migrations)...');
-        const health = await waitForHealth(baseUrl, (elapsed) => {
+        const health = await waitForHealth(baseUrl, ctx, (elapsed) => {
           spinner?.message(
             `Waiting for the backend (first boot runs migrations)... ${Math.round(elapsed / 1000)}s`,
           );

--- a/src/commands/local/start.ts
+++ b/src/commands/local/start.ts
@@ -212,9 +212,15 @@ export function registerLocalStartCommand(localCmd: Command): void {
         // reach them — writing this afterwards would strand whatever it made.
         writeLocalState(state);
 
-        // The recorded version reaches compose through INSFORGE_STACK_TAG in the
-        // generated env file — the same variable a hand-run compose uses.
-        if (opts.pull && composeRunInherit(ctx, ['pull']) !== 0) {
+        // The stack tracks :latest, and Docker will not re-fetch a tag it already
+        // has — a machine that pulled months ago runs that image and reports its
+        // version, with nothing to suggest a newer one exists. So a directory
+        // that has never started pulls first, and gets what :latest means today.
+        //
+        // Later starts do not. An image moving under an instance that has data is
+        // how you get the backend running migrations the volume behind it did not
+        // expect; --pull is the way to ask for it deliberately.
+        if ((opts.pull || previous === null) && composeRunInherit(ctx, ['pull']) !== 0) {
           throw new CLIError('docker compose pull failed. See the output above.');
         }
         if (!json) clack.log.step('Starting containers...');

--- a/src/commands/local/status.ts
+++ b/src/commands/local/status.ts
@@ -1,0 +1,110 @@
+import type { Command } from 'commander';
+import pc from 'picocolors';
+import { probeBackendHealth } from '../../lib/api/oss.js';
+import { ensureDockerReady } from '../../lib/docker.js';
+import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
+import { outputInfo, outputJson, outputTable } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import { composePs, type ComposeContext } from '../../lib/local/compose.js';
+import { readSecrets } from '../../lib/local/secrets.js';
+import { readLocalState } from '../../lib/local/state.js';
+
+export function registerLocalStatusCommand(localCmd: Command): void {
+  localCmd
+    .command('status')
+    .description('Show the local InsForge instance for this directory: ports, keys, container health')
+    .option('--show-keys', 'Print the API key and admin password in full')
+    .action(async (opts: { showKeys?: boolean }, cmd: Command) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        ensureDockerReady();
+
+        const state = readLocalState();
+        if (!state) {
+          throw new CLIError(
+            'No local instance is recorded for this directory.\nRun `insforge local start` to create one.',
+          );
+        }
+
+        // Re-render if the file is gone (deleted by hand, or by a previous
+        // --delete-data). Every compose call needs it, and without this the only
+        // way to stop the containers would be raw `docker`.
+
+        const ctx: ComposeContext = { projectName: state.projectName, storage: state.storage };
+        const services = composePs(ctx);
+        const baseUrl = `http://localhost:${state.ports.app}`;
+        const health = await probeBackendHealth(baseUrl, 3_000);
+        const secrets = readSecrets();
+
+        await trackCommandUsage('local', 'status', true, { healthy: health.reachable });
+
+        if (json) {
+          outputJson({
+            running: services.some((s) => s.state === 'running'),
+            healthy: health.reachable,
+            apiUrl: baseUrl,
+            databaseUrl: `postgresql://postgres:postgres@localhost:${state.ports.postgres}/insforge`,
+            ports: state.ports,
+            storage: state.storage,
+              version: health.version ?? null,
+            composeProject: state.projectName,
+            createdAt: state.createdAt,
+            services,
+            // Keys are secrets: only in the payload when explicitly asked for,
+            // so `local status --json` is safe to paste into an issue.
+            ...(opts.showKeys && secrets
+              ? {
+                  apiKey: secrets.apiKey,
+                  anonKey: secrets.anonKey,
+                  admin: { username: secrets.adminUsername, password: secrets.adminPassword },
+                }
+              : {}),
+          });
+          return;
+        }
+
+        const mask = (v: string): string =>
+          opts.showKeys ? v : `${v.slice(0, Math.min(8, v.length))}${'•'.repeat(8)}`;
+
+        outputInfo('');
+        outputInfo(
+          `  ${health.reachable ? pc.green('● healthy') : pc.yellow('○ not responding')}  ` +
+            `${pc.dim('InsForge')} ${health.version ?? 'latest published'}`,
+        );
+        outputInfo('');
+        outputInfo(`  ${pc.dim('API URL   ')} ${pc.cyan(baseUrl)}`);
+        outputInfo(
+          `  ${pc.dim('DB URL    ')} postgresql://postgres:postgres@localhost:${state.ports.postgres}/insforge`,
+        );
+        if (secrets) {
+          outputInfo(`  ${pc.dim('API key   ')} ${mask(secrets.apiKey)}`);
+          outputInfo(`  ${pc.dim('anon key  ')} ${mask(secrets.anonKey)}`);
+          outputInfo(
+            `  ${pc.dim('Admin     ')} ${secrets.adminUsername} / ${mask(secrets.adminPassword)}`,
+          );
+        }
+        outputInfo(
+          `  ${pc.dim('Storage   ')} ${state.storage === 'local' ? 'local filesystem' : state.storage}`,
+        );
+        outputInfo(`  ${pc.dim('Compose   ')} ${state.projectName}`);
+        outputInfo('');
+
+        if (services.length === 0) {
+          outputInfo('  No containers. Run `insforge local start` to bring the instance up.');
+        } else {
+          outputTable(
+            ['SERVICE', 'STATE', 'STATUS'],
+            services.map((s) => [s.service, s.state, s.health || s.status]),
+          );
+        }
+
+        if (!opts.showKeys && secrets) {
+          outputInfo('');
+          outputInfo(pc.dim('  Keys are masked. Re-run with --show-keys to print them in full.'));
+        }
+      } catch (err) {
+        await trackCommandUsage('local', 'status', false, {}, err);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/local/status.ts
+++ b/src/commands/local/status.ts
@@ -6,7 +6,7 @@ import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
 import { outputInfo, outputJson, outputTable } from '../../lib/output.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
 import { composePs, type ComposeContext } from '../../lib/local/compose.js';
-import { readSecrets } from '../../lib/local/secrets.js';
+import { databaseUrl, readSecrets } from '../../lib/local/secrets.js';
 import { readLocalState } from '../../lib/local/state.js';
 
 export function registerLocalStatusCommand(localCmd: Command): void {
@@ -43,7 +43,6 @@ export function registerLocalStatusCommand(localCmd: Command): void {
             running: services.some((s) => s.state === 'running'),
             healthy: health.reachable,
             apiUrl: baseUrl,
-            databaseUrl: `postgresql://postgres:postgres@localhost:${state.ports.postgres}/insforge`,
             ports: state.ports,
             storage: state.storage,
               version: health.version ?? null,
@@ -57,6 +56,11 @@ export function registerLocalStatusCommand(localCmd: Command): void {
                   apiKey: secrets.apiKey,
                   anonKey: secrets.anonKey,
                   admin: { username: secrets.adminUsername, password: secrets.adminPassword },
+                  // Carries the Postgres password, so it belongs with the keys
+                  // rather than in the always-present fields. `ports.postgres`
+                  // is there unconditionally for anything that just needs to
+                  // know where the database is.
+                  databaseUrl: databaseUrl(secrets.postgresPassword, state.ports.postgres),
                 }
               : {}),
           });
@@ -73,10 +77,10 @@ export function registerLocalStatusCommand(localCmd: Command): void {
         );
         outputInfo('');
         outputInfo(`  ${pc.dim('API URL   ')} ${pc.cyan(baseUrl)}`);
-        outputInfo(
-          `  ${pc.dim('DB URL    ')} postgresql://postgres:postgres@localhost:${state.ports.postgres}/insforge`,
-        );
         if (secrets) {
+          outputInfo(
+            `  ${pc.dim('DB URL    ')} ${databaseUrl(mask(secrets.postgresPassword), state.ports.postgres)}`,
+          );
           outputInfo(`  ${pc.dim('API key   ')} ${mask(secrets.apiKey)}`);
           outputInfo(`  ${pc.dim('anon key  ')} ${mask(secrets.anonKey)}`);
           outputInfo(

--- a/src/commands/local/status.ts
+++ b/src/commands/local/status.ts
@@ -26,10 +26,6 @@ export function registerLocalStatusCommand(localCmd: Command): void {
           );
         }
 
-        // Re-render if the file is gone (deleted by hand, or by a previous
-        // --delete-data). Every compose call needs it, and without this the only
-        // way to stop the containers would be raw `docker`.
-
         const ctx: ComposeContext = { projectName: state.projectName, storage: state.storage };
         const services = composePs(ctx);
         const baseUrl = `http://localhost:${state.ports.app}`;
@@ -67,8 +63,11 @@ export function registerLocalStatusCommand(localCmd: Command): void {
           return;
         }
 
+        // A prefix helps identify which key you are looking at. A password has
+        // no such use, and the prefix is just less password.
         const mask = (v: string): string =>
           opts.showKeys ? v : `${v.slice(0, Math.min(8, v.length))}${'•'.repeat(8)}`;
+        const hide = (v: string): string => (opts.showKeys ? v : '•'.repeat(16));
 
         outputInfo('');
         outputInfo(
@@ -79,12 +78,12 @@ export function registerLocalStatusCommand(localCmd: Command): void {
         outputInfo(`  ${pc.dim('API URL   ')} ${pc.cyan(baseUrl)}`);
         if (secrets) {
           outputInfo(
-            `  ${pc.dim('DB URL    ')} ${databaseUrl(mask(secrets.postgresPassword), state.ports.postgres)}`,
+            `  ${pc.dim('DB URL    ')} ${databaseUrl(hide(secrets.postgresPassword), state.ports.postgres)}`,
           );
           outputInfo(`  ${pc.dim('API key   ')} ${mask(secrets.apiKey)}`);
           outputInfo(`  ${pc.dim('anon key  ')} ${mask(secrets.anonKey)}`);
           outputInfo(
-            `  ${pc.dim('Admin     ')} ${secrets.adminUsername} / ${mask(secrets.adminPassword)}`,
+            `  ${pc.dim('Admin     ')} ${secrets.adminUsername} / ${hide(secrets.adminPassword)}`,
           );
         }
         outputInfo(

--- a/src/commands/local/stop.ts
+++ b/src/commands/local/stop.ts
@@ -6,9 +6,11 @@ import { FAKE_PROJECT_ID, getProjectConfig, getProjectConfigFile } from '../../l
 import { ensureDockerReady } from '../../lib/docker.js';
 import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
 import { outputJson, outputSuccess } from '../../lib/output.js';
+import { checkoutEnvFile } from '../../lib/local/checkout.js';
 import { trackCommandUsage } from '../../lib/command-telemetry.js';
 import {
   composeRunInherit,
+  forceRemoveProject,
   removeProjectVolumes,
   type ComposeContext,
 } from '../../lib/local/compose.js';
@@ -47,23 +49,44 @@ export function registerLocalStopCommand(localCmd: Command): void {
           );
         }
 
-        // Re-render if the file is gone (deleted by hand, or by a previous
-        // --delete-data). Every compose call needs it, and without this the only
-        // way to stop the containers would be raw `docker`.
-
         const ctx: ComposeContext = { projectName: state.projectName, storage: state.storage };
-        const args = opts.deleteData ? ['down', '-v'] : ['down'];
-        if (composeRunInherit(ctx, args) !== 0) {
-          throw new CLIError('docker compose down failed. See the output above.');
+        // Without the env file compose refuses to load at all, so fall back to
+        // labels. The volume sweep below runs either way and is what actually
+        // removes the data.
+        if (existsSync(checkoutEnvFile())) {
+          const args = opts.deleteData ? ['down', '-v'] : ['down'];
+          if (composeRunInherit(ctx, args) !== 0) {
+            throw new CLIError('docker compose down failed. See the output above.');
+          }
+        } else {
+          if (!opts.deleteData) {
+            throw new CLIError(
+              `${checkoutEnvFile()} is missing, so the stack cannot be stopped cleanly.\n\n` +
+                'Restore it from a backup, or run `insforge local stop --delete-data`\n' +
+                'to remove the containers and their data outright.',
+            );
+          }
+          clack.log.warn(
+            `${checkoutEnvFile()} is gone — removing the containers by label instead.`,
+          );
+          forceRemoveProject(state.projectName);
         }
 
         // Sweep whatever `down -v` did not name. A --storage switch leaves the
         // previous backend's volume outside the compose files in play, so it
         // survived a delete that reported having removed everything.
         let sweptVolumes: string[] = [];
+        let remainingVolumes: string[] = [];
+        let sweepError: string | undefined;
         if (opts.deleteData) {
-          sweptVolumes = removeProjectVolumes(state.projectName);
-          clearLocalState();
+          const sweep = removeProjectVolumes(state.projectName);
+          sweptVolumes = sweep.removed;
+          remainingVolumes = sweep.remaining;
+          sweepError = sweep.error;
+          // The state file is the only record of which project the surviving
+          // volumes belong to. Clearing it after a partial delete would leave
+          // data on disk with nothing pointing at it.
+          if (remainingVolumes.length === 0) clearLocalState();
         }
 
         let restored: string | null = null;
@@ -81,12 +104,24 @@ export function registerLocalStopCommand(localCmd: Command): void {
 
         if (json) {
           outputJson({
-            success: true,
+            success: remainingVolumes.length === 0,
             deletedData: !!opts.deleteData,
             sweptVolumes,
+            remainingVolumes,
             restoredCloudProject: restored,
           });
           return;
+        }
+
+        if (remainingVolumes.length > 0) {
+          throw new CLIError(
+            `The containers are stopped, but ${remainingVolumes.length} volume` +
+              `${remainingVolumes.length === 1 ? '' : 's'} could not be removed:\n` +
+              remainingVolumes.map((v) => `  • ${v}`).join('\n') +
+              (sweepError ? `\n\n${sweepError}` : '') +
+              '\n\nThis directory still points at them, so `insforge local stop --delete-data`\n' +
+              'will try again once whatever is holding them is gone.',
+          );
         }
 
         outputSuccess(
@@ -94,7 +129,7 @@ export function registerLocalStopCommand(localCmd: Command): void {
             ? 'Local InsForge stopped and all data removed.' +
                 (sweptVolumes.length > 0
                   ? `
-  Also removed ${sweptVolumes.length} volume${sweptVolumes.length === 1 ? '' : 's'} left by a previous storage backend.`
+  Also swept ${sweptVolumes.length} volume${sweptVolumes.length === 1 ? '' : 's'} that \`compose down -v\` did not remove.`
                   : '')
             : 'Local InsForge stopped. Data is kept — `insforge local start` resumes it.',
         );

--- a/src/commands/local/stop.ts
+++ b/src/commands/local/stop.ts
@@ -1,0 +1,111 @@
+import type { Command } from 'commander';
+import { existsSync, copyFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import * as clack from '@clack/prompts';
+import { FAKE_PROJECT_ID, getProjectConfig, getProjectConfigFile } from '../../lib/config.js';
+import { ensureDockerReady } from '../../lib/docker.js';
+import { CLIError, getRootOpts, handleError } from '../../lib/errors.js';
+import { outputJson, outputSuccess } from '../../lib/output.js';
+import { trackCommandUsage } from '../../lib/command-telemetry.js';
+import {
+  composeRunInherit,
+  removeProjectVolumes,
+  type ComposeContext,
+} from '../../lib/local/compose.js';
+import { clearLocalState, readLocalState } from '../../lib/local/state.js';
+
+interface StopOptions {
+  deleteData?: boolean;
+  unlink?: boolean;
+}
+
+/** Put a cloud link that `local start` displaced back in place. */
+function restoreCloudLink(): string | null {
+  const backup = join(process.cwd(), '.insforge', 'project.cloud.json');
+  if (!existsSync(backup)) return null;
+  copyFileSync(backup, getProjectConfigFile());
+  unlinkSync(backup);
+  return getProjectConfig()?.project_name ?? null;
+}
+
+export function registerLocalStopCommand(localCmd: Command): void {
+  localCmd
+    .command('stop')
+    .description('Stop the local InsForge backend for this directory (data is kept)')
+    .option('--delete-data', 'Also remove the volumes — database, storage, and logs are destroyed')
+    .option('--unlink', 'Restore the cloud project link this directory had before `local start`')
+    .action(async (opts: StopOptions, cmd: Command) => {
+      const { json } = getRootOpts(cmd);
+      try {
+        ensureDockerReady();
+
+        const state = readLocalState();
+        if (!state) {
+          throw new CLIError(
+            'No local instance is recorded for this directory.\n' +
+              'Run `insforge local start` here first, or `docker ps` to find instances started elsewhere.',
+          );
+        }
+
+        // Re-render if the file is gone (deleted by hand, or by a previous
+        // --delete-data). Every compose call needs it, and without this the only
+        // way to stop the containers would be raw `docker`.
+
+        const ctx: ComposeContext = { projectName: state.projectName, storage: state.storage };
+        const args = opts.deleteData ? ['down', '-v'] : ['down'];
+        if (composeRunInherit(ctx, args) !== 0) {
+          throw new CLIError('docker compose down failed. See the output above.');
+        }
+
+        // Sweep whatever `down -v` did not name. A --storage switch leaves the
+        // previous backend's volume outside the compose files in play, so it
+        // survived a delete that reported having removed everything.
+        let sweptVolumes: string[] = [];
+        if (opts.deleteData) {
+          sweptVolumes = removeProjectVolumes(state.projectName);
+          clearLocalState();
+        }
+
+        let restored: string | null = null;
+        if (opts.unlink) {
+          restored = restoreCloudLink();
+          if (!restored) {
+            const current = getProjectConfig();
+            if (current?.project_id === FAKE_PROJECT_ID && existsSync(getProjectConfigFile())) {
+              unlinkSync(getProjectConfigFile());
+            }
+          }
+        }
+
+        await trackCommandUsage('local', 'stop', true, { delete_data: !!opts.deleteData });
+
+        if (json) {
+          outputJson({
+            success: true,
+            deletedData: !!opts.deleteData,
+            sweptVolumes,
+            restoredCloudProject: restored,
+          });
+          return;
+        }
+
+        outputSuccess(
+          opts.deleteData
+            ? 'Local InsForge stopped and all data removed.' +
+                (sweptVolumes.length > 0
+                  ? `
+  Also removed ${sweptVolumes.length} volume${sweptVolumes.length === 1 ? '' : 's'} left by a previous storage backend.`
+                  : '')
+            : 'Local InsForge stopped. Data is kept — `insforge local start` resumes it.',
+        );
+        if (restored) {
+          clack.log.info(`Restored the cloud link to "${restored}".`);
+        } else if (opts.unlink) {
+          clack.log.info('Removed the local link. No cloud project link was saved for this directory.');
+        }
+      } catch (err) {
+        await trackCommandUsage('local', 'stop', false, {}, err);
+        handleError(err, json);
+      }
+    });
+}

--- a/src/commands/local/stop.ts
+++ b/src/commands/local/stop.ts
@@ -54,7 +54,12 @@ export function registerLocalStopCommand(localCmd: Command): void {
         // labels. The volume sweep below runs either way and is what actually
         // removes the data.
         if (existsSync(checkoutEnvFile())) {
-          const args = opts.deleteData ? ['down', '-v'] : ['down'];
+          // --remove-orphans for the same reason `up` has it: a --storage switch
+          // that persisted the new backend and then failed leaves the old one's
+          // container outside the compose files this call loads.
+          const args = opts.deleteData
+            ? ['down', '-v', '--remove-orphans']
+            : ['down', '--remove-orphans'];
           if (composeRunInherit(ctx, args) !== 0) {
             throw new CLIError('docker compose down failed. See the output above.');
           }
@@ -100,19 +105,10 @@ export function registerLocalStopCommand(localCmd: Command): void {
           }
         }
 
-        await trackCommandUsage('local', 'stop', true, { delete_data: !!opts.deleteData });
-
-        if (json) {
-          outputJson({
-            success: remainingVolumes.length === 0,
-            deletedData: !!opts.deleteData,
-            sweptVolumes,
-            remainingVolumes,
-            restoredCloudProject: restored,
-          });
-          return;
-        }
-
+        // Before the success event, and before the --json early return. Both
+        // used to run first, so a partial delete was recorded as a success and
+        // exited 0 — and the catch below could not correct it, since telemetry
+        // only reports once per process.
         if (remainingVolumes.length > 0) {
           throw new CLIError(
             `The containers are stopped, but ${remainingVolumes.length} volume` +
@@ -122,6 +118,18 @@ export function registerLocalStopCommand(localCmd: Command): void {
               '\n\nThis directory still points at them, so `insforge local stop --delete-data`\n' +
               'will try again once whatever is holding them is gone.',
           );
+        }
+
+        await trackCommandUsage('local', 'stop', true, { delete_data: !!opts.deleteData });
+
+        if (json) {
+          outputJson({
+            success: true,
+            deletedData: !!opts.deleteData,
+            sweptVolumes,
+            restoredCloudProject: restored,
+          });
+          return;
         }
 
         outputSuccess(

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ import { registerConfigCommand } from './commands/config/index.js';
 import { registerAiCommands } from './commands/ai/index.js';
 import { registerDomainsCommands } from './commands/domains/index.js';
 import { registerMemoryCommands } from './commands/memory/index.js';
+import { registerLocalCommands } from './commands/local/index.js';
 import { guardHook } from './lib/guard/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -302,6 +303,9 @@ registerSchedulesCreateCommand(schedulesCmd);
 registerSchedulesUpdateCommand(schedulesCmd);
 registerSchedulesDeleteCommand(schedulesCmd);
 registerSchedulesLogsCommand(schedulesCmd);
+
+// Local instance commands (Docker on this machine)
+registerLocalCommands(program);
 
 // Config commands
 registerConfigCommand(program);

--- a/src/lib/api/oss.ts
+++ b/src/lib/api/oss.ts
@@ -317,11 +317,22 @@ export async function ossFetch(
 export async function probeBackendHealth(
   baseUrl: string,
   timeoutMs = 10_000,
-): Promise<{ reachable: boolean; status: number | null; detail?: string }> {
+): Promise<{ reachable: boolean; status: number | null; detail?: string; version?: string }> {
   const url = `${baseUrl.replace(/\/$/, '')}/api/health`;
   try {
     const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
-    return { reachable: res.ok, status: res.status };
+    // The version comes from the instance rather than from anything the CLI
+    // recorded, so it stays true after an image is pulled underneath it.
+    let version: string | undefined;
+    if (res.ok) {
+      try {
+        version = ((await res.clone().json()) as { version?: string }).version;
+      } catch {
+        // A healthy backend that answers something other than the expected JSON
+        // is still healthy; the version is just unavailable.
+      }
+    }
+    return { reachable: res.ok, status: res.status, version };
   } catch (err) {
     return { reachable: false, status: null, detail: formatFetchError(err, url) };
   }

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -20,6 +20,97 @@ export function ensureDockerAvailable(): void {
   }
 }
 
+// A local instance needs a container runtime, so getting one comes first — the
+// user asked for local. The other two paths are offered, not chosen for them:
+// nothing here falls back on its own.
+const INSTALL_HINT = [
+  '  • Docker Desktop: https://docs.docker.com/get-docker/',
+  '  • Or OrbStack / Colima / Rancher Desktop — any Docker-compatible daemon works.',
+  '',
+  '  Would rather not run one?',
+  '  • `insforge create` — a hosted project, ready in about 30 seconds.',
+  '  • `insforge link --api-base-url <url> --api-key <key>` — point this directory',
+  '    at a backend you already have. Neither needs Docker.',
+].join('\n');
+
+/**
+ * Preflight for local instances. Distinguishes the four ways this fails, since
+ * "Docker is required" tells someone whose daemon is merely asleep nothing
+ * actionable. Called only by `local *` — the rest of the CLI stays Docker-free.
+ */
+export function ensureDockerReady(): void {
+  const cli = spawnSync('docker', ['--version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (cli.error || cli.status !== 0) {
+    throw new CLIError(`Docker is not installed, or not on your PATH.\n${INSTALL_HINT}`);
+  }
+
+  const daemon = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (daemon.error || daemon.status !== 0) {
+    throw new CLIError(
+      'Docker is installed but the daemon is not responding.\n' +
+        '  • Start Docker Desktop (or `colima start`) and try again.\n' +
+        (daemon.stderr ? `  Detail: ${daemon.stderr.trim().split('\n')[0].slice(0, 200)}` : ''),
+    );
+  }
+
+  const compose = spawnSync('docker', ['compose', 'version', '--short'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (compose.error || compose.status !== 0) {
+    throw new CLIError(
+      'Docker Compose v2 is required (the `docker compose` subcommand).\n' +
+        '  • The standalone `docker-compose` v1 binary will not work.\n' +
+        '  • Update Docker Desktop, or install the compose plugin:\n' +
+        '    https://docs.docker.com/compose/install/',
+    );
+  }
+  // The CLI overlay uses the !override merge tag to replace upstream's port
+  // list. Older Compose reads the tag as part of the value and fails with a YAML
+  // error naming neither the file nor the version — check for it here instead.
+  const version = compose.stdout.trim().replace(/^v/, '');
+  if (!atLeast(version, [2, 24, 4])) {
+    throw new CLIError(
+      `Docker Compose 2.24.4 or newer is required (found ${version || 'an unknown version'}).\n` +
+        '  • Update Docker Desktop, or the compose plugin:\n' +
+        '    https://docs.docker.com/compose/install/',
+    );
+  }
+}
+
+/** True when a dotted version is >= the given one. Unparseable reads as new enough:
+ *  a version this cannot compare should not block a start that would have worked. */
+function atLeast(version: string, min: [number, number, number]): boolean {
+  const parts = version.split('.').map((p) => Number.parseInt(p, 10));
+  if (parts.length < 3 || parts.some((p) => !Number.isFinite(p))) return true;
+  for (let i = 0; i < 3; i++) {
+    if (parts[i] > min[i]) return true;
+    if (parts[i] < min[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Total memory the Docker daemon can use, in MB, or null when it can't be read.
+ * Four containers need roughly 1.5 GB; below that Postgres and the backend start
+ * getting OOM-killed in ways that look like random failures.
+ */
+export function dockerMemoryMb(): number | null {
+  const r = spawnSync('docker', ['info', '--format', '{{.MemTotal}}'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (r.error || r.status !== 0) return null;
+  const bytes = Number(r.stdout.trim());
+  return Number.isFinite(bytes) && bytes > 0 ? Math.round(bytes / 1024 / 1024) : null;
+}
+
 export interface BuildOptions {
   dir: string;
   imageRef: string; // e.g. registry.fly.io/<app>:<tag>

--- a/src/lib/guard/risk-registry.test.ts
+++ b/src/lib/guard/risk-registry.test.ts
@@ -211,3 +211,23 @@ describe('assess — trust boundary', () => {
     expect(withOpts.severity).toBe('critical');
   });
 });
+
+describe('assess — local stop', () => {
+  /** The registry keys on the command path and reads deleteData off opts. */
+  const stop = (opts: Record<string, unknown>): OperationContext => ({
+    path: 'local stop',
+    args: [],
+    opts,
+  });
+
+  it('gates --delete-data as critical', () => {
+    const r = assess(stop({ deleteData: true }));
+    expect(r.severity).toBe('critical');
+    expect(r.kind).toBe('local.delete_data');
+  });
+
+  it('leaves a plain stop ungated', () => {
+    // Containers stop, volumes stay — nothing to confirm.
+    expect(assess(stop({})).severity).not.toBe('critical');
+  });
+});

--- a/src/lib/guard/risk-registry.ts
+++ b/src/lib/guard/risk-registry.ts
@@ -210,6 +210,23 @@ const REGISTRY: Record<string, (ctx: OperationContext) => RiskAssessment> = {
     risk: 'Live traffic to this service stops immediately. Not recoverable.',
   }),
 
+  // `local stop` on its own is safe (containers stop, volumes stay). Only the
+  // volume-destroying form is gated — and it is gated even though the target is
+  // a developer's own machine, because an agent running `local stop
+  // --delete-data` wipes a database that has no backup anywhere.
+  'local stop': (ctx) =>
+    ctx.opts.deleteData
+      ? {
+          severity: 'critical',
+          kind: 'local.delete_data',
+          title: 'Delete all data in the local instance',
+          whatHappens:
+            'Stops the local InsForge containers and removes their volumes: database, storage objects, and logs.',
+          blastRadius: 'Every table, row, and uploaded file in this directory\u2019s local backend.',
+          risk: 'Irreversible. Local instances have no backups — nothing restores this.',
+        }
+      : SAFE,
+
   'storage delete-bucket': (ctx) => ({
     severity: 'critical',
     kind: 'storage.delete_bucket',

--- a/src/lib/local/checkout.test.ts
+++ b/src/lib/local/checkout.test.ts
@@ -7,6 +7,7 @@ import {
   checkoutEnvFile,
   checkoutReady,
   ensureCheckout,
+  missingCheckoutFiles,
   readCheckoutEnv,
   upstreamComposeFile,
 } from './checkout.js';
@@ -22,12 +23,32 @@ afterEach(() => {
   while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
 });
 
+/** Every file a start needs, in the layout setup.sh writes them. */
+const CHECKOUT_FILES = [
+  'deploy/docker-compose/docker-compose.yml',
+  'deploy/docker-init/db/db-init.sql',
+  'deploy/docker-init/db/postgresql.conf',
+  'functions/server.ts',
+  'functions/deno.json',
+];
+
 /** What a successful setup.sh run leaves behind. */
 function seedCheckout(cwd: string, env = 'ACCESS_API_KEY=ik_seeded\n'): void {
-  const compose = upstreamComposeFile(cwd);
-  mkdirSync(dirname(compose), { recursive: true });
-  writeFileSync(compose, 'services: {}\n');
+  for (const f of CHECKOUT_FILES) {
+    const path = join(checkoutDir(cwd), f);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, '# seeded\n');
+  }
   writeFileSync(checkoutEnvFile(cwd), env);
+}
+
+/** A fake setup.sh that writes the same set, so ensureCheckout sees a real run. */
+function fakeSetupScript(): string {
+  return (
+    '#!/bin/sh\n# INSFORGE_NO_GIT\nset -e\ncd "$1"\n' +
+    CHECKOUT_FILES.map((f) => `mkdir -p "$(dirname ${f})" && echo seeded > ${f}`).join('\n') +
+    '\n[ -f .env ] || echo "ACCESS_API_KEY=ik_generated" > .env\n'
+  );
 }
 
 describe('paths', () => {
@@ -47,14 +68,19 @@ describe('paths', () => {
 });
 
 describe('checkoutReady', () => {
-  it('needs both the compose file and the env file', () => {
+  it('needs every file the compose mounts, not just the compose file', () => {
     const cwd = tmp();
     expect(checkoutReady(cwd)).toBe(false);
     mkdirSync(dirname(upstreamComposeFile(cwd)), { recursive: true });
     writeFileSync(upstreamComposeFile(cwd), 'services: {}\n');
-    expect(checkoutReady(cwd)).toBe(false);
     writeFileSync(checkoutEnvFile(cwd), 'X=1\n');
+    // An interrupted fetch leaves exactly this: the compose file and .env, with
+    // the init SQL and function host still missing.
+    expect(checkoutReady(cwd)).toBe(false);
+    expect(missingCheckoutFiles(cwd)).toContain('deploy/docker-init/db/db-init.sql');
+    seedCheckout(cwd);
     expect(checkoutReady(cwd)).toBe(true);
+    expect(missingCheckoutFiles(cwd)).toEqual([]);
   });
 });
 
@@ -124,12 +150,9 @@ describe('ensureCheckout', () => {
         ok: true,
         status: 200,
         statusText: 'OK',
-        text: async () =>
-          '#!/bin/sh\n# INSFORGE_NO_GIT\n' +
-          `[ -n "$INSFORGE_NO_GIT" ] && echo yes > ${marker}\n` +
-          'mkdir -p "$1/deploy/docker-compose"\n' +
-          'echo "services: {}" > "$1/deploy/docker-compose/docker-compose.yml"\n' +
-          'echo "ACCESS_API_KEY=ik_x" > "$1/.env"\n',
+          text: async () =>
+            `#!/bin/sh\n[ -n "$INSFORGE_NO_GIT" ] && echo yes > ${marker}\n` +
+            fakeSetupScript(),
       })),
     );
     await ensureCheckout(cwd);
@@ -151,7 +174,7 @@ describe('secrets are not regenerated over existing data', () => {
       ok: true,
       status: 200,
       statusText: 'OK',
-      text: async () => '#!/bin/sh\n# INSFORGE_NO_GIT\n',
+      text: async () => fakeSetupScript(),
     }));
     vi.stubGlobal('fetch', fetchMock);
     await expect(ensureCheckout(cwd, () => ['proj_postgres-data'])).rejects.toThrow(/volume/);
@@ -165,12 +188,8 @@ describe('secrets are not regenerated over existing data', () => {
       vi.fn(async () => ({
         ok: true,
         status: 200,
-        statusText: 'OK',
-        text: async () =>
-          '#!/bin/sh\n# INSFORGE_NO_GIT\n' +
-          'mkdir -p "$1/deploy/docker-compose"\n' +
-          'echo "services: {}" > "$1/deploy/docker-compose/docker-compose.yml"\n' +
-          'echo "ACCESS_API_KEY=ik_x" > "$1/.env"\n',
+          statusText: 'OK',
+          text: async () => fakeSetupScript(),
       })),
     );
     await expect(ensureCheckout(cwd, () => [])).resolves.toBe(checkoutDir(cwd));

--- a/src/lib/local/checkout.test.ts
+++ b/src/lib/local/checkout.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  checkoutDir,
+  checkoutEnvFile,
+  checkoutReady,
+  ensureCheckout,
+  readCheckoutEnv,
+  upstreamComposeFile,
+} from './checkout.js';
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), 'if-checkout-'));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  vi.unstubAllGlobals();
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+/** What a successful setup.sh run leaves behind. */
+function seedCheckout(cwd: string, env = 'ACCESS_API_KEY=ik_seeded\n'): void {
+  const compose = upstreamComposeFile(cwd);
+  mkdirSync(dirname(compose), { recursive: true });
+  writeFileSync(compose, 'services: {}\n');
+  writeFileSync(checkoutEnvFile(cwd), env);
+}
+
+describe('paths', () => {
+  it('puts the checkout inside .insforge, not beside it', () => {
+    const cwd = tmp();
+    expect(checkoutDir(cwd).startsWith(join(cwd, '.insforge'))).toBe(true);
+  });
+
+  it('points at the compose file where upstream keeps it', () => {
+    // The relative mounts inside that file resolve against its own directory, so
+    // this layout is the one the upstream compose expects, not a choice.
+    const cwd = tmp();
+    expect(upstreamComposeFile(cwd).endsWith(join('deploy', 'docker-compose', 'docker-compose.yml'))).toBe(
+      true,
+    );
+  });
+});
+
+describe('checkoutReady', () => {
+  it('needs both the compose file and the env file', () => {
+    const cwd = tmp();
+    expect(checkoutReady(cwd)).toBe(false);
+    mkdirSync(dirname(upstreamComposeFile(cwd)), { recursive: true });
+    writeFileSync(upstreamComposeFile(cwd), 'services: {}\n');
+    expect(checkoutReady(cwd)).toBe(false);
+    writeFileSync(checkoutEnvFile(cwd), 'X=1\n');
+    expect(checkoutReady(cwd)).toBe(true);
+  });
+});
+
+describe('readCheckoutEnv', () => {
+  it('reads what setup.sh generated', () => {
+    const cwd = tmp();
+    seedCheckout(cwd, 'JWT_SECRET=abc\nACCESS_API_KEY=ik_1\n# comment\nBAD LINE\n');
+    const env = readCheckoutEnv(cwd);
+    expect(env.JWT_SECRET).toBe('abc');
+    expect(env.ACCESS_API_KEY).toBe('ik_1');
+    expect(Object.keys(env)).toHaveLength(2);
+  });
+
+  it('is empty rather than throwing when there is no checkout', () => {
+    expect(readCheckoutEnv(tmp())).toEqual({});
+  });
+});
+
+describe('ensureCheckout', () => {
+  it('falls back to an existing checkout when the script cannot be fetched', async () => {
+    // Offline with a stack already in place is a restart, not a failure.
+    const cwd = tmp();
+    seedCheckout(cwd);
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
+    await expect(ensureCheckout(cwd)).resolves.toBe(checkoutDir(cwd));
+  });
+
+  it('fails with the URL when there is nothing to fall back to', async () => {
+    const cwd = tmp();
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
+    await expect(ensureCheckout(cwd)).rejects.toThrow(/setup\.sh/);
+    await expect(ensureCheckout(cwd)).rejects.toThrow(/offline/);
+  });
+
+  it('refuses a response that is not the script it expects', async () => {
+    // A captive portal or proxy answers 200 with HTML. Running that would do
+    // something other than fetch a stack, so it is rejected by content.
+    const cwd = tmp();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => '<html>login</html>' })),
+    );
+    await expect(ensureCheckout(cwd)).rejects.toThrow(/INSFORGE_NO_GIT/);
+  });
+
+  it('runs the fetched script and reports its failure', async () => {
+    const cwd = tmp();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        // Mentions the flag so the content check passes, then fails.
+        text: async () => '#!/bin/sh\n# INSFORGE_NO_GIT\necho boom >&2\nexit 3\n',
+      })),
+    );
+    await expect(ensureCheckout(cwd)).rejects.toThrow(/boom/);
+  });
+
+  it('runs the script with INSFORGE_NO_GIT so git is never required', async () => {
+    const cwd = tmp();
+    const marker = join(cwd, 'saw-no-git');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () =>
+          '#!/bin/sh\n# INSFORGE_NO_GIT\n' +
+          `[ -n "$INSFORGE_NO_GIT" ] && echo yes > ${marker}\n` +
+          'mkdir -p "$1/deploy/docker-compose"\n' +
+          'echo "services: {}" > "$1/deploy/docker-compose/docker-compose.yml"\n' +
+          'echo "ACCESS_API_KEY=ik_x" > "$1/.env"\n',
+      })),
+    );
+    await ensureCheckout(cwd);
+    expect(existsSync(marker)).toBe(true);
+    expect(readFileSync(marker, 'utf-8').trim()).toBe('yes');
+    expect(checkoutReady(cwd)).toBe(true);
+  });
+});
+
+describe('secrets are not regenerated over existing data', () => {
+  it('refuses when volumes exist but the env file is gone', async () => {
+    // setup.sh generates a new Postgres password whenever .env is absent, and
+    // that password is only read when a cluster is created — so against volumes
+    // that already exist the backend ends up locked out of its own database.
+    const cwd = tmp();
+    mkdirSync(dirname(upstreamComposeFile(cwd)), { recursive: true });
+    writeFileSync(upstreamComposeFile(cwd), 'services: {}\n');
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '#!/bin/sh\n# INSFORGE_NO_GIT\n',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(ensureCheckout(cwd, () => ['proj_postgres-data'])).rejects.toThrow(/volume/);
+    await expect(ensureCheckout(cwd, () => ['proj_postgres-data'])).rejects.toThrow(/--delete-data/);
+  });
+
+  it('proceeds when there is no data to strand', async () => {
+    const cwd = tmp();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () =>
+          '#!/bin/sh\n# INSFORGE_NO_GIT\n' +
+          'mkdir -p "$1/deploy/docker-compose"\n' +
+          'echo "services: {}" > "$1/deploy/docker-compose/docker-compose.yml"\n' +
+          'echo "ACCESS_API_KEY=ik_x" > "$1/.env"\n',
+      })),
+    );
+    await expect(ensureCheckout(cwd, () => [])).resolves.toBe(checkoutDir(cwd));
+  });
+
+  it('does not ask about volumes when the env file is already there', async () => {
+    // A normal restart: the secrets exist, so nothing can be stranded.
+    const cwd = tmp();
+    seedCheckout(cwd);
+    const onExisting = vi.fn(() => ['proj_postgres-data']);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => '#!/bin/sh\n# INSFORGE_NO_GIT\nexit 0\n',
+      })),
+    );
+    await ensureCheckout(cwd, onExisting);
+    expect(onExisting).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/local/checkout.test.ts
+++ b/src/lib/local/checkout.test.ts
@@ -27,9 +27,13 @@ afterEach(() => {
 const CHECKOUT_FILES = [
   'deploy/docker-compose/docker-compose.yml',
   'deploy/docker-init/db/db-init.sql',
+  'deploy/docker-init/db/jwt.sql',
   'deploy/docker-init/db/postgresql.conf',
   'functions/server.ts',
   'functions/deno.json',
+  'functions/worker-template.js',
+  'docker-compose.minio.yml',
+  'docker-compose.rustfs.yml',
 ];
 
 /** What a successful setup.sh run leaves behind. */
@@ -81,6 +85,16 @@ describe('checkoutReady', () => {
     seedCheckout(cwd);
     expect(checkoutReady(cwd)).toBe(true);
     expect(missingCheckoutFiles(cwd)).toEqual([]);
+  });
+
+  it('wants the storage overlay only for the backend that uses it', () => {
+    const cwd = tmp();
+    seedCheckout(cwd);
+    rmSync(join(checkoutDir(cwd), 'docker-compose.minio.yml'));
+    expect(checkoutReady(cwd)).toBe(true);
+    expect(checkoutReady(cwd, 'rustfs')).toBe(true);
+    expect(checkoutReady(cwd, 'minio')).toBe(false);
+    expect(missingCheckoutFiles(cwd, 'minio')).toEqual(['docker-compose.minio.yml']);
   });
 });
 

--- a/src/lib/local/checkout.ts
+++ b/src/lib/local/checkout.ts
@@ -47,20 +47,36 @@ export function checkoutEnvFile(cwd?: string): string {
 const REQUIRED_FILES = [
   '.env',
   'deploy/docker-compose/docker-compose.yml',
+  // Both are mounted into /docker-entrypoint-initdb.d. A bind mount whose source
+  // is absent does not fail — Docker creates a directory there, and Postgres init
+  // then chokes on it, which reads as nothing to do with a missing file.
   'deploy/docker-init/db/db-init.sql',
+  'deploy/docker-init/db/jwt.sql',
   'deploy/docker-init/db/postgresql.conf',
   'functions/server.ts',
   'functions/deno.json',
+  // Named in the deno command line's --allow-read, so its absence surfaces when
+  // a function is invoked rather than at boot.
+  'functions/worker-template.js',
 ];
 
+/** Overlay per storage backend, needed only when that backend is selected. */
+const STORAGE_FILES: Record<string, string> = {
+  minio: 'docker-compose.minio.yml',
+  rustfs: 'docker-compose.rustfs.yml',
+};
+
 /** Files a start needs that are not there. Empty means the checkout is usable. */
-export function missingCheckoutFiles(cwd?: string): string[] {
-  return REQUIRED_FILES.filter((f) => !existsSync(join(checkoutDir(cwd), f)));
+export function missingCheckoutFiles(cwd?: string, storage?: string): string[] {
+  const wanted = [...REQUIRED_FILES];
+  const overlay = storage ? STORAGE_FILES[storage] : undefined;
+  if (overlay) wanted.push(overlay);
+  return wanted.filter((f) => !existsSync(join(checkoutDir(cwd), f)));
 }
 
 /** True once the checkout holds what a start needs. */
-export function checkoutReady(cwd?: string): boolean {
-  return missingCheckoutFiles(cwd).length === 0;
+export function checkoutReady(cwd?: string, storage?: string): boolean {
+  return missingCheckoutFiles(cwd, storage).length === 0;
 }
 
 async function fetchSetupScript(): Promise<string> {
@@ -92,13 +108,14 @@ async function fetchSetupScript(): Promise<string> {
 export async function ensureCheckout(
   cwd?: string,
   onExistingData?: () => string[],
+  storage?: string,
 ): Promise<string> {
   const dir = checkoutDir(cwd);
   let script: string;
   try {
     script = await fetchSetupScript();
   } catch (err) {
-    if (checkoutReady(cwd)) return dir;
+    if (checkoutReady(cwd, storage)) return dir;
     throw new CLIError(
       `Could not fetch InsForge's setup script: ${err instanceof Error ? err.message : String(err)}\n` +
         `  ${SETUP_URL}\n\n` +
@@ -148,7 +165,7 @@ export async function ensureCheckout(
         (run.stderr?.trim() || run.stdout?.trim() || '(no output)'),
     );
   }
-  const missing = missingCheckoutFiles(cwd);
+  const missing = missingCheckoutFiles(cwd, storage);
   if (missing.length > 0) {
     throw new CLIError(
       `The setup script reported success but ${dir} is missing:\n` +

--- a/src/lib/local/checkout.ts
+++ b/src/lib/local/checkout.ts
@@ -1,0 +1,140 @@
+/**
+ * Fetch and run InsForge's own setup.sh to populate `.insforge/checkout/`.
+ *
+ * The CLI used to carry a 266-line copy of the compose file plus the four files
+ * it inlines. That copy drifted within a day of being written — the connection
+ * pool alignment added upstream never reached it. So the stack definition comes
+ * from the repository now, through the script the repository already ships for
+ * exactly this: it owns the file list, the layout the compose file's relative
+ * mounts expect, and the secret generation.
+ *
+ * INSFORGE_NO_GIT=1 keeps `docker` the only thing a developer needs installed;
+ * the script falls back to fetching each file over HTTPS.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { CLIError } from '../errors.js';
+import { ensureLocalDir } from './state.js';
+
+const SETUP_URL = 'https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh';
+const FETCH_TIMEOUT_MS = 15_000;
+
+/** Where the stack's files live. One directory, updated in place: the secrets
+ *  sit beside them and have to survive a version change. */
+export function checkoutDir(cwd?: string): string {
+  return join(ensureLocalDir(cwd), 'checkout');
+}
+
+/** The compose file the CLI runs — upstream's, unmodified. */
+export function upstreamComposeFile(cwd?: string): string {
+  return join(checkoutDir(cwd), 'deploy', 'docker-compose', 'docker-compose.yml');
+}
+
+/** The env file setup.sh generates, holding the secrets it made. */
+export function checkoutEnvFile(cwd?: string): string {
+  return join(checkoutDir(cwd), '.env');
+}
+
+/** True once the checkout holds what a start needs. */
+export function checkoutReady(cwd?: string): boolean {
+  return existsSync(upstreamComposeFile(cwd)) && existsSync(checkoutEnvFile(cwd));
+}
+
+async function fetchSetupScript(): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(SETUP_URL, { signal: controller.signal });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const body = await res.text();
+    if (!body.includes('INSFORGE_NO_GIT')) {
+      // Not the script we expect — a proxy login page, or a release predating
+      // the flag. Running it would clone with git, or do something else again.
+      throw new Error('response is not a setup.sh that supports INSFORGE_NO_GIT');
+    }
+    return body;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Make sure `.insforge/checkout/` holds the stack, and return its directory.
+ *
+ * Re-running is how a stale checkout catches up, so this fetches every time
+ * rather than short-circuiting on an existing directory: setup.sh overwrites the
+ * files it owns and leaves `.env` alone, which is the behaviour to inherit.
+ * Offline with a checkout already in place is the one case that skips the fetch.
+ */
+export async function ensureCheckout(
+  cwd?: string,
+  onExistingData?: () => string[],
+): Promise<string> {
+  const dir = checkoutDir(cwd);
+  let script: string;
+  try {
+    script = await fetchSetupScript();
+  } catch (err) {
+    if (checkoutReady(cwd)) return dir;
+    throw new CLIError(
+      `Could not fetch InsForge's setup script: ${err instanceof Error ? err.message : String(err)}\n` +
+        `  ${SETUP_URL}\n\n` +
+        'The stack is defined in that repository rather than bundled with the CLI,\n' +
+        'so a first start needs to reach it. Later starts reuse what it wrote.',
+    );
+  }
+
+  mkdirSync(dir, { recursive: true });
+  // setup.sh generates a fresh set of secrets whenever .env is absent, and the
+  // Postgres password it picks is only read when a cluster is created. Against
+  // volumes that already exist, the new password never reaches the database and
+  // the backend cannot log in to its own data — recoverable only by restoring
+  // the file. Refuse instead, before anything is written.
+  if (!existsSync(checkoutEnvFile(cwd)) && onExistingData) {
+    const kept = onExistingData();
+    if (kept.length > 0) {
+      throw new CLIError(
+        `This directory has data from a previous instance (${kept.length} volume` +
+          `${kept.length === 1 ? '' : 's'}) but ${checkoutEnvFile(cwd)} is gone.\n\n` +
+          'That file holds the only copy of its secrets. Generating new ones would\n' +
+          'leave the database unreachable behind the old password.\n\n' +
+          '  • Restore the file from a backup and start again, or\n' +
+          '  • `insforge local stop --delete-data` to discard the old instance.',
+      );
+    }
+  }
+  const scriptPath = join(dir, '..', 'setup.sh');
+  writeFileSync(scriptPath, script, { mode: 0o700 });
+
+  const run = spawnSync('sh', [scriptPath, dir], {
+    encoding: 'utf-8',
+    env: { ...process.env, INSFORGE_NO_GIT: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (run.status !== 0) {
+    throw new CLIError(
+      'InsForge\'s setup script failed.\n' +
+        (run.stderr?.trim() || run.stdout?.trim() || '(no output)'),
+    );
+  }
+  if (!checkoutReady(cwd)) {
+    throw new CLIError(
+      `The setup script reported success but ${dir} has no compose file or .env.`,
+    );
+  }
+  return dir;
+}
+
+/** Read the env file setup.sh generated into a map. */
+export function readCheckoutEnv(cwd?: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const path = checkoutEnvFile(cwd);
+  if (!existsSync(path)) return out;
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}

--- a/src/lib/local/checkout.ts
+++ b/src/lib/local/checkout.ts
@@ -37,9 +37,30 @@ export function checkoutEnvFile(cwd?: string): string {
   return join(checkoutDir(cwd), '.env');
 }
 
+/**
+ * Every file the compose file mounts or reads, relative to the checkout.
+ *
+ * Mirrors setup.sh's own list. Checking only the compose file and .env let an
+ * interrupted fetch pass as ready, and the start then failed inside Compose on
+ * a missing mount instead of here with something to act on.
+ */
+const REQUIRED_FILES = [
+  '.env',
+  'deploy/docker-compose/docker-compose.yml',
+  'deploy/docker-init/db/db-init.sql',
+  'deploy/docker-init/db/postgresql.conf',
+  'functions/server.ts',
+  'functions/deno.json',
+];
+
+/** Files a start needs that are not there. Empty means the checkout is usable. */
+export function missingCheckoutFiles(cwd?: string): string[] {
+  return REQUIRED_FILES.filter((f) => !existsSync(join(checkoutDir(cwd), f)));
+}
+
 /** True once the checkout holds what a start needs. */
 export function checkoutReady(cwd?: string): boolean {
-  return existsSync(upstreamComposeFile(cwd)) && existsSync(checkoutEnvFile(cwd));
+  return missingCheckoutFiles(cwd).length === 0;
 }
 
 async function fetchSetupScript(): Promise<string> {
@@ -119,9 +140,11 @@ export async function ensureCheckout(
         (run.stderr?.trim() || run.stdout?.trim() || '(no output)'),
     );
   }
-  if (!checkoutReady(cwd)) {
+  const missing = missingCheckoutFiles(cwd);
+  if (missing.length > 0) {
     throw new CLIError(
-      `The setup script reported success but ${dir} has no compose file or .env.`,
+      `The setup script reported success but ${dir} is missing:\n` +
+        missing.map((f) => `  • ${f}`).join('\n'),
     );
   }
   return dir;

--- a/src/lib/local/checkout.ts
+++ b/src/lib/local/checkout.ts
@@ -134,6 +134,14 @@ export async function ensureCheckout(
     env: { ...process.env, INSFORGE_NO_GIT: '1' },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  if (run.error && (run.error as NodeJS.ErrnoException).code === 'ENOENT') {
+    // Plain Windows has no `sh`. Docker Desktop there runs on WSL2 anyway, so
+    // the shell is one terminal away rather than a missing dependency.
+    throw new CLIError(
+      'No `sh` on PATH, so InsForge\'s setup script cannot run.\n\n' +
+        'On Windows, run `insforge local start` from WSL or Git Bash.',
+    );
+  }
   if (run.status !== 0) {
     throw new CLIError(
       'InsForge\'s setup script failed.\n' +

--- a/src/lib/local/checkout.ts
+++ b/src/lib/local/checkout.ts
@@ -13,10 +13,10 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { CLIError } from '../errors.js';
-import { ensureLocalDir } from './state.js';
+import { ensureLocalDir, OVERLAYS } from './state.js';
 
 const SETUP_URL = 'https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh';
 const FETCH_TIMEOUT_MS = 15_000;
@@ -60,18 +60,29 @@ const REQUIRED_FILES = [
   'functions/worker-template.js',
 ];
 
-/** Overlay per storage backend, needed only when that backend is selected. */
-const STORAGE_FILES: Record<string, string> = {
-  minio: 'docker-compose.minio.yml',
-  rustfs: 'docker-compose.rustfs.yml',
-};
-
-/** Files a start needs that are not there. Empty means the checkout is usable. */
+/**
+ * Files a start needs that are not there. Empty means the checkout is usable.
+ *
+ * The storage overlay comes from compose.ts's own map rather than a copy here:
+ * two lists would let validation and the compose invocation disagree about
+ * which file has to exist.
+ *
+ * A regular file, not merely a path that exists. A failed start leaves
+ * directories behind at bind-mount sources — that is what a missing jwt.sql
+ * turns into — and existsSync then reports the broken checkout as ready.
+ */
 export function missingCheckoutFiles(cwd?: string, storage?: string): string[] {
   const wanted = [...REQUIRED_FILES];
-  const overlay = storage ? STORAGE_FILES[storage] : undefined;
+  const overlay =
+    storage && storage !== 'local' ? OVERLAYS[storage as keyof typeof OVERLAYS] : undefined;
   if (overlay) wanted.push(overlay);
-  return wanted.filter((f) => !existsSync(join(checkoutDir(cwd), f)));
+  return wanted.filter((f) => {
+    try {
+      return !statSync(join(checkoutDir(cwd), f)).isFile();
+    } catch {
+      return true;
+    }
+  });
 }
 
 /** True once the checkout holds what a start needs. */

--- a/src/lib/local/compose.ts
+++ b/src/lib/local/compose.ts
@@ -214,21 +214,30 @@ export function removeProjectVolumes(projectName: string): VolumeSweep {
  * is precisely the state a refused start tells people to resolve that way.
  * Labels are enough to find them without any of the files.
  */
-export function forceRemoveProject(projectName: string): { containers: number } {
+export function forceRemoveProject(projectName: string): {
+  containers: number;
+  networks: number;
+} {
   const filter = `label=com.docker.compose.project=${projectName}`;
-  const ls = spawnSync('docker', ['ps', '-aq', '--filter', filter], {
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (ls.status !== 0) {
-    throw new CLIError(
-      `Could not list the containers for ${projectName}.\n` +
-        (ls.stderr?.trim() || 'docker ps failed with no output.'),
-    );
-  }
-  const ids = ls.stdout.split('\n').map((l) => l.trim()).filter(Boolean);
-  if (ids.length > 0) {
-    const rm = spawnSync('docker', ['rm', '-f', ...ids], {
+
+  const listed = (kind: 'ps' | 'network'): string[] => {
+    const args = kind === 'ps' ? ['ps', '-aq'] : ['network', 'ls', '--quiet'];
+    const r = spawnSync('docker', [...args, '--filter', filter], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (r.status !== 0) {
+      throw new CLIError(
+        `Could not list the ${kind === 'ps' ? 'containers' : 'networks'} for ${projectName}.\n` +
+          (r.stderr?.trim() || 'docker failed with no output.'),
+      );
+    }
+    return r.stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+  };
+
+  const containers = listed('ps');
+  if (containers.length > 0) {
+    const rm = spawnSync('docker', ['rm', '-f', ...containers], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -239,7 +248,19 @@ export function forceRemoveProject(projectName: string): { containers: number } 
       );
     }
   }
-  return { containers: ids.length };
+
+  // `compose down` would have taken the network with it. Removing only the
+  // containers leaves it behind, and the next start then joins a network the
+  // old instance created.
+  const networks = listed('network');
+  if (networks.length > 0) {
+    spawnSync('docker', ['network', 'rm', ...networks], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  }
+
+  return { containers: containers.length, networks: networks.length };
 }
 
 export function composePs(ctx: ComposeContext): ServiceStatus[] {

--- a/src/lib/local/compose.ts
+++ b/src/lib/local/compose.ts
@@ -1,0 +1,189 @@
+/**
+ * Thin wrapper around `docker compose` for local instances.
+ *
+ * The compose file is InsForge's own, fetched into `.insforge/checkout/` by its
+ * setup.sh (see checkout.ts) and run unmodified. The CLI adds one overlay, for
+ * the telemetry stamp, and supplies ports and keys through `--env-file`.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CLIError } from '../errors.js';
+import { checkoutDir, checkoutEnvFile, upstreamComposeFile } from './checkout.js';
+import type { StorageBackend } from './state.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const CLI_OVERLAY = 'cli-overlay.yml';
+
+/**
+ * Locate the CLI's own asset directory. `dist/index.js` resolves to
+ * `dist/assets/local/`; running from source (tsx src/index.ts) resolves to
+ * `src/assets/local/`. Both are checked so `npm run dev` behaves like a build.
+ */
+export function assetsDir(): string {
+  const candidates = [
+    join(__dirname, 'assets', 'local'),
+    join(__dirname, '..', 'assets', 'local'),
+    join(__dirname, '..', '..', 'assets', 'local'),
+    join(__dirname, '..', '..', 'src', 'assets', 'local'),
+  ];
+  for (const dir of candidates) {
+    if (existsSync(join(dir, CLI_OVERLAY))) return dir;
+  }
+  throw new CLIError(
+    `${CLI_OVERLAY} is missing from this CLI installation.\n` +
+      'Reinstall with `npm i -g @insforge/cli@latest`, or run via `npx -y @insforge/cli@latest`.',
+  );
+}
+
+const OVERLAYS: Record<Exclude<StorageBackend, 'local'>, string> = {
+  minio: 'docker-compose.minio.yml',
+  rustfs: 'docker-compose.rustfs.yml',
+};
+
+/**
+ * Upstream's compose file, the CLI's overlay, and a storage overlay if selected.
+ *
+ * Order matters: later files win, and the storage overlay has to see the service
+ * definitions it extends. The storage overlays come from the checkout too — they
+ * live in the same repository and setup.sh fetches them.
+ */
+export function composeFiles(storage: StorageBackend, cwd?: string): string[] {
+  const files = [upstreamComposeFile(cwd), join(assetsDir(), CLI_OVERLAY)];
+  if (storage !== 'local') files.push(join(checkoutDir(cwd), OVERLAYS[storage]));
+  return files;
+}
+
+export interface ComposeContext {
+  projectName: string;
+  storage: StorageBackend;
+  /** Directory holding .insforge/. Defaults to cwd. */
+  cwd?: string;
+}
+
+export function composeArgs(ctx: ComposeContext, args: string[]): string[] {
+  const fileArgs = composeFiles(ctx.storage, ctx.cwd).flatMap((f) => ['-f', f]);
+  return [
+    'compose',
+    ...fileArgs,
+    '--env-file',
+    checkoutEnvFile(ctx.cwd),
+    '-p',
+    ctx.projectName,
+    ...args,
+  ];
+}
+
+export interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run a compose subcommand, capturing output. */
+export function composeRun(ctx: ComposeContext, args: string[]): RunResult {
+  const full = composeArgs(ctx, args);
+  const r = spawnSync('docker', full, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  if (r.error) {
+    throw new CLIError(`docker compose could not start: ${r.error.message}`);
+  }
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+/**
+ * Run a compose subcommand, streaming output straight through (pulls, logs).
+ */
+export function composeRunInherit(ctx: ComposeContext, args: string[]): number {
+  const r = spawnSync('docker', composeArgs(ctx, args), {
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (r.error) {
+    throw new CLIError(`docker compose could not start: ${r.error.message}`);
+  }
+  return r.status ?? 1;
+}
+
+export interface ServiceStatus {
+  service: string;
+  state: string;
+  status: string;
+  health: string;
+}
+
+/**
+ * Parse `docker compose ps --format json`. Compose emits either one JSON object
+ * per line or a single JSON array depending on version, so both are handled.
+ */
+export function parsePsJson(stdout: string): ServiceStatus[] {
+  const raw = stdout.trim();
+  if (!raw) return [];
+
+  const records: Record<string, unknown>[] = [];
+  if (raw.startsWith('[')) {
+    try {
+      records.push(...(JSON.parse(raw) as Record<string, unknown>[]));
+    } catch {
+      return [];
+    }
+  } else {
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        records.push(JSON.parse(line) as Record<string, unknown>);
+      } catch {
+        // Skip a malformed line rather than losing the whole listing.
+      }
+    }
+  }
+
+  return records.map((r) => ({
+    service: String(r.Service ?? r.Name ?? '?'),
+    state: String(r.State ?? '?'),
+    status: String(r.Status ?? ''),
+    health: String(r.Health ?? ''),
+  }));
+}
+
+/**
+ * Volumes this project already owns, whether or not anything is running.
+ *
+ * `compose ps` only sees containers, and the case that matters here is a stopped
+ * instance whose data is still on disk.
+ */
+export function projectVolumes(projectName: string): string[] {
+  const r = spawnSync(
+    'docker',
+    ['volume', 'ls', '--quiet', '--filter', `label=com.docker.compose.project=${projectName}`],
+    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  if (r.status !== 0) return [];
+  return r.stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+/**
+ * Remove volumes this project owns that `compose down -v` left behind.
+ *
+ * `down -v` only removes what the compose files it was given declare. Switching
+ * --storage changes which overlay is in play, so the previous backend's volume
+ * stops being named — and `--delete-data` reported success while a minio-data
+ * full of objects stayed on disk.
+ */
+export function removeProjectVolumes(projectName: string): string[] {
+  const left = projectVolumes(projectName);
+  if (left.length === 0) return [];
+  const r = spawnSync('docker', ['volume', 'rm', ...left], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return r.status === 0 ? left : [];
+}
+
+export function composePs(ctx: ComposeContext): ServiceStatus[] {
+  const r = composeRun(ctx, ['ps', '--format', 'json']);
+  if (r.status !== 0) return [];
+  return parsePsJson(r.stdout);
+}

--- a/src/lib/local/compose.ts
+++ b/src/lib/local/compose.ts
@@ -160,7 +160,15 @@ export function projectVolumes(projectName: string): string[] {
     ['volume', 'ls', '--quiet', '--filter', `label=com.docker.compose.project=${projectName}`],
     { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
   );
-  if (r.status !== 0) return [];
+  // Never an empty list on failure. The caller that matters asks this to decide
+  // whether generating fresh secrets would strand a database, and answering
+  // "no volumes" because docker was unreachable is the one wrong answer.
+  if (r.status !== 0) {
+    throw new CLIError(
+      `Could not list the volumes for ${projectName}.\n` +
+        (r.stderr?.trim() || 'docker volume ls failed with no output.'),
+    );
+  }
   return r.stdout.split('\n').map((l) => l.trim()).filter(Boolean);
 }
 
@@ -172,14 +180,66 @@ export function projectVolumes(projectName: string): string[] {
  * stops being named — and `--delete-data` reported success while a minio-data
  * full of objects stayed on disk.
  */
-export function removeProjectVolumes(projectName: string): string[] {
+export interface VolumeSweep {
+  removed: string[];
+  /** Still on disk. Non-empty means the caller must not report a clean delete. */
+  remaining: string[];
+  error?: string;
+}
+
+export function removeProjectVolumes(projectName: string): VolumeSweep {
   const left = projectVolumes(projectName);
-  if (left.length === 0) return [];
+  if (left.length === 0) return { removed: [], remaining: [] };
   const r = spawnSync('docker', ['volume', 'rm', ...left], {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  return r.status === 0 ? left : [];
+  if (r.status === 0) return { removed: left, remaining: [] };
+  // Partial success is normal here: `docker volume rm a b c` removes what it
+  // can and fails on the rest, so re-reading is the only way to know which.
+  // Reporting "removed nothing" would have been wrong in both directions.
+  const remaining = projectVolumes(projectName);
+  return {
+    removed: left.filter((v) => !remaining.includes(v)),
+    remaining,
+    error: r.stderr?.trim() || undefined,
+  };
+}
+
+/**
+ * Tear a project down with plain docker, no compose.
+ *
+ * Every compose call needs --env-file, so losing .insforge/checkout/.env leaves
+ * `local stop --delete-data` unable to remove the containers it created — which
+ * is precisely the state a refused start tells people to resolve that way.
+ * Labels are enough to find them without any of the files.
+ */
+export function forceRemoveProject(projectName: string): { containers: number } {
+  const filter = `label=com.docker.compose.project=${projectName}`;
+  const ls = spawnSync('docker', ['ps', '-aq', '--filter', filter], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (ls.status !== 0) {
+    throw new CLIError(
+      `Could not list the containers for ${projectName}.\n` +
+        (ls.stderr?.trim() || 'docker ps failed with no output.'),
+    );
+  }
+  const ids = ls.stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+  if (ids.length > 0) {
+    const rm = spawnSync('docker', ['rm', '-f', ...ids], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (rm.status !== 0) {
+      throw new CLIError(
+        `Could not remove the containers for ${projectName}.\n` +
+          (rm.stderr?.trim() || 'docker rm failed with no output.'),
+      );
+    }
+  }
+  return { containers: ids.length };
 }
 
 export function composePs(ctx: ComposeContext): ServiceStatus[] {

--- a/src/lib/local/compose.ts
+++ b/src/lib/local/compose.ts
@@ -12,7 +12,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CLIError } from '../errors.js';
 import { checkoutDir, checkoutEnvFile, upstreamComposeFile } from './checkout.js';
-import type { StorageBackend } from './state.js';
+import { OVERLAYS, type StorageBackend } from './state.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -39,10 +39,6 @@ export function assetsDir(): string {
   );
 }
 
-const OVERLAYS: Record<Exclude<StorageBackend, 'local'>, string> = {
-  minio: 'docker-compose.minio.yml',
-  rustfs: 'docker-compose.rustfs.yml',
-};
 
 /**
  * Upstream's compose file, the CLI's overlay, and a storage overlay if selected.
@@ -254,10 +250,16 @@ export function forceRemoveProject(projectName: string): {
   // old instance created.
   const networks = listed('network');
   if (networks.length > 0) {
-    spawnSync('docker', ['network', 'rm', ...networks], {
+    const rm = spawnSync('docker', ['network', 'rm', ...networks], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    if (rm.status !== 0) {
+      throw new CLIError(
+        `Could not remove the networks for ${projectName}.\n` +
+          (rm.stderr?.trim() || 'docker network rm failed with no output.'),
+      );
+    }
   }
 
   return { containers: containers.length, networks: networks.length };

--- a/src/lib/local/overlay.test.ts
+++ b/src/lib/local/overlay.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { assetsDir } from './compose.js';
+
+const overlay = readFileSync(join(assetsDir(), 'cli-overlay.yml'), 'utf-8');
+
+describe('cli-overlay.yml', () => {
+  it('binds every published port to loopback', () => {
+    const published = [...overlay.matchAll(/^\s*-\s*"([^"]+:\d+)"/gm)].map((m) => m[1]);
+    expect(published.length).toBeGreaterThan(0);
+    for (const p of published) expect(p).toMatch(/^127\.0\.0\.1:/);
+  });
+
+  it('replaces the upstream port list rather than appending to it', () => {
+    // Without !override, Compose merges the two lists and upstream's 0.0.0.0
+    // entry keeps listening alongside the loopback one this file adds.
+    expect(overlay).toMatch(/ports:\s*!override/);
+  });
+
+  it('stamps the deployment method so telemetry can tell local starts apart', () => {
+    expect(overlay).toMatch(/INSFORGE_DEPLOYMENT_METHOD:\s*cli-local/);
+  });
+});

--- a/src/lib/local/overlay.test.ts
+++ b/src/lib/local/overlay.test.ts
@@ -7,7 +7,11 @@ const overlay = readFileSync(join(assetsDir(), 'cli-overlay.yml'), 'utf-8');
 
 describe('cli-overlay.yml', () => {
   it('binds every published port to loopback', () => {
-    const published = [...overlay.matchAll(/^\s*-\s*"([^"]+:\d+)"/gm)].map((m) => m[1]);
+    // Quoted or not, single or double: a rewrite that drops the quotes must not
+    // slip past the check this test exists to be.
+    const published = [...overlay.matchAll(/^\s*-\s*["']?([^"'\n]*:\d+)["']?\s*$/gm)].map(
+      (m) => m[1].trim(),
+    );
     expect(published.length).toBeGreaterThan(0);
     for (const p of published) expect(p).toMatch(/^127\.0\.0\.1:/);
   });

--- a/src/lib/local/ports.test.ts
+++ b/src/lib/local/ports.test.ts
@@ -133,6 +133,14 @@ describe('allocatePorts', () => {
     expect(got.auth).toBe(FREE + 1 + PORT_BLOCK_STEP);
   });
 
+  it('refuses two services on one port', async () => {
+    const clashing = { ...base(), auth: FREE };
+    await expect(allocatePorts(clashing, new Set(['app', 'auth']))).rejects.toThrow(CLIError);
+    await expect(allocatePorts(clashing, new Set(['app', 'auth']))).rejects.toThrow(
+      String(FREE),
+    );
+  });
+
   it('treats a port the caller owns as available', async () => {
     await occupy(FREE);
     const { ports: got, moved } = await allocatePorts(base(), new Set(), new Set([FREE]));

--- a/src/lib/local/ports.test.ts
+++ b/src/lib/local/ports.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:net';
+import { CLIError } from '../errors.js';
+import { checkPorts, ensurePortsAvailable, isPortFree, resolvePorts } from './ports.js';
+import { DEFAULT_PORTS, type LocalPorts } from './state.js';
+
+const servers: Server[] = [];
+
+function occupy(port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    servers.push(s);
+    s.once('error', reject);
+    s.listen(port, '127.0.0.1', () => resolve());
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => s.close(() => r()))));
+});
+
+/** A high port unlikely to collide with anything on a dev machine or CI. */
+const FREE = 47_921;
+
+describe('isPortFree', () => {
+  it('is true for an unbound port', async () => {
+    expect(await isPortFree(FREE)).toBe(true);
+  });
+
+  it('is false once something is listening', async () => {
+    await occupy(FREE);
+    expect(await isPortFree(FREE)).toBe(false);
+  });
+});
+
+describe('resolvePorts', () => {
+  it('defaults to the documented ports so existing URLs keep working', () => {
+    expect(resolvePorts()).toEqual(DEFAULT_PORTS);
+    expect(resolvePorts().app).toBe(7130);
+  });
+
+  it('applies only the overrides given', () => {
+    expect(resolvePorts({ app: 8130 })).toEqual({ ...DEFAULT_PORTS, app: 8130 });
+  });
+});
+
+describe('ensurePortsAvailable', () => {
+  const ports = (over: Partial<LocalPorts> = {}): LocalPorts => resolvePorts(over);
+
+  it('passes when everything is free', async () => {
+    await expect(ensurePortsAvailable(ports({ app: FREE, auth: FREE + 1, deno: FREE + 2, postgres: FREE + 3, postgrest: FREE + 4 }))).resolves.toBeUndefined();
+  });
+
+  it('names the occupied port and the override flag', async () => {
+    await occupy(FREE);
+    const p = ports({ app: FREE, auth: FREE + 1, deno: FREE + 2, postgres: FREE + 3, postgrest: FREE + 4 });
+    await expect(ensurePortsAvailable(p)).rejects.toThrow(CLIError);
+    await expect(ensurePortsAvailable(p)).rejects.toThrow(String(FREE));
+    // The message must say how to fix it, not just that it failed.
+    await expect(ensurePortsAvailable(p)).rejects.toThrow('--port-app');
+  });
+
+  it('ignores ports the caller knows are its own', async () => {
+    await occupy(FREE);
+    const p = ports({ app: FREE, auth: FREE + 1, deno: FREE + 2, postgres: FREE + 3, postgrest: FREE + 4 });
+    await expect(ensurePortsAvailable(p, new Set([FREE]))).resolves.toBeUndefined();
+  });
+});
+
+describe('checkPorts', () => {
+  it('reports one result per port', async () => {
+    const results = await checkPorts(resolvePorts({ app: FREE }));
+    expect(results).toHaveLength(5);
+    expect(results.map((r) => r.name).sort()).toEqual([
+      'app',
+      'auth',
+      'deno',
+      'postgres',
+      'postgrest',
+    ]);
+  });
+});

--- a/src/lib/local/ports.test.ts
+++ b/src/lib/local/ports.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { createServer, type Server } from 'node:net';
 import { CLIError } from '../errors.js';
-import { checkPorts, ensurePortsAvailable, isPortFree, resolvePorts } from './ports.js';
+import {
+  allocatePorts,
+  checkPorts,
+  ensurePortsAvailable,
+  isPortFree,
+  PORT_BLOCK_STEP,
+  resolvePorts,
+} from './ports.js';
 import { DEFAULT_PORTS, type LocalPorts } from './state.js';
 
 const servers: Server[] = [];
@@ -78,5 +85,58 @@ describe('checkPorts', () => {
       'postgres',
       'postgrest',
     ]);
+  });
+});
+
+describe('allocatePorts', () => {
+  const base = (): LocalPorts =>
+    resolvePorts({
+      app: FREE,
+      auth: FREE + 1,
+      deno: FREE + 2,
+      postgres: FREE + 3,
+      postgrest: FREE + 4,
+    });
+
+  it('keeps the defaults when they are free', async () => {
+    const { ports: got, moved } = await allocatePorts(base());
+    expect(got).toEqual(base());
+    expect(moved).toEqual([]);
+  });
+
+  it('shifts the whole block when one port is taken', async () => {
+    await occupy(FREE + 2);
+    const { ports: got, moved } = await allocatePorts(base());
+    expect(got.app).toBe(FREE + PORT_BLOCK_STEP);
+    expect(got.deno).toBe(FREE + 2 + PORT_BLOCK_STEP);
+    // The whole block moves together, so the offset stays legible.
+    expect(moved).toHaveLength(5);
+  });
+
+  it('keeps shifting past a second occupied block', async () => {
+    await occupy(FREE);
+    await occupy(FREE + PORT_BLOCK_STEP);
+    const { ports: got } = await allocatePorts(base());
+    expect(got.app).toBe(FREE + 2 * PORT_BLOCK_STEP);
+  });
+
+  it('never moves a port the caller fixed, and says so when it is taken', async () => {
+    await occupy(FREE);
+    await expect(allocatePorts(base(), new Set(['app']))).rejects.toThrow(CLIError);
+    await expect(allocatePorts(base(), new Set(['app']))).rejects.toThrow('--port-app');
+  });
+
+  it('shifts the unfixed ports around a fixed one', async () => {
+    await occupy(FREE + 1);
+    const { ports: got } = await allocatePorts(base(), new Set(['app']));
+    expect(got.app).toBe(FREE);
+    expect(got.auth).toBe(FREE + 1 + PORT_BLOCK_STEP);
+  });
+
+  it('treats a port the caller owns as available', async () => {
+    await occupy(FREE);
+    const { ports: got, moved } = await allocatePorts(base(), new Set(), new Set([FREE]));
+    expect(got.app).toBe(FREE);
+    expect(moved).toEqual([]);
   });
 });

--- a/src/lib/local/ports.test.ts
+++ b/src/lib/local/ports.test.ts
@@ -150,13 +150,15 @@ describe('allocatePorts', () => {
   });
 
   it('shifts past a block where a moving port meets a fixed one', async () => {
-    // app pinned to where auth's default lands one block along. That block is
-    // unusable; the next one is fine, and rejecting outright would refuse a
-    // request that has an answer.
-    const desired = { ...base(), app: FREE + 1 + PORT_BLOCK_STEP };
+    // app pinned onto auth's own default, so block 0 puts two services on one
+    // port with only one of them free to move. That block is unusable; the next
+    // is fine, and rejecting outright would refuse a request that has an answer.
+    const desired = { ...base(), app: FREE + 1 };
     const { ports: got } = await allocatePorts(desired, new Set(['app']));
-    expect(got.app).toBe(FREE + 1 + PORT_BLOCK_STEP);
-    expect(got.auth).not.toBe(got.app);
+    expect(got.app).toBe(FREE + 1);
+    // The evidence that block 0 was skipped rather than used: at block 0 auth
+    // is FREE + 1. Only the collision branch moves it.
+    expect(got.auth).toBe(FREE + 1 + PORT_BLOCK_STEP);
     expect(new Set(Object.values(got)).size).toBe(5);
   });
 

--- a/src/lib/local/ports.test.ts
+++ b/src/lib/local/ports.test.ts
@@ -88,6 +88,14 @@ describe('checkPorts', () => {
   });
 });
 
+describe('privileged ports', () => {
+  it('does not call a low port occupied just because this process cannot bind it', async () => {
+    // Docker runs privileged and can publish 80; the probe here cannot bind it,
+    // and reporting that as "in use" rejected a config that would have worked.
+    expect(await isPortFree(80)).toBe(true);
+  });
+});
+
 describe('allocatePorts', () => {
   const base = (): LocalPorts =>
     resolvePorts({

--- a/src/lib/local/ports.test.ts
+++ b/src/lib/local/ports.test.ts
@@ -149,6 +149,17 @@ describe('allocatePorts', () => {
     );
   });
 
+  it('shifts past a block where a moving port meets a fixed one', async () => {
+    // app pinned to where auth's default lands one block along. That block is
+    // unusable; the next one is fine, and rejecting outright would refuse a
+    // request that has an answer.
+    const desired = { ...base(), app: FREE + 1 + PORT_BLOCK_STEP };
+    const { ports: got } = await allocatePorts(desired, new Set(['app']));
+    expect(got.app).toBe(FREE + 1 + PORT_BLOCK_STEP);
+    expect(got.auth).not.toBe(got.app);
+    expect(new Set(Object.values(got)).size).toBe(5);
+  });
+
   it('treats a port the caller owns as available', async () => {
     await occupy(FREE);
     const { ports: got, moved } = await allocatePorts(base(), new Set(), new Set([FREE]));

--- a/src/lib/local/ports.ts
+++ b/src/lib/local/ports.ts
@@ -1,10 +1,20 @@
 /**
- * Port availability for a local instance.
+ * Port allocation for a local instance.
  *
  * The defaults match every existing InsForge doc (7130 for the API and
- * dashboard, 5432 for Postgres, …), so URLs a user has already seen keep
- * working. When one is taken we report exactly which and stop, rather than
- * silently relocating the instance to ports nothing else knows about.
+ * dashboard, 5432 for Postgres, …), so the first instance on a machine keeps the
+ * URLs a user has already seen. A second one cannot have them, and refusing to
+ * start would make "one instance per directory" true only for the first
+ * directory — so the block shifts by ten until it finds a free set.
+ *
+ * Shifting the whole block rather than each port separately keeps the offset
+ * legible: 7140/7141/7143 is recognisably the second instance, where a per-port
+ * scan would land on whatever happened to be free.
+ *
+ * Two kinds of port never move. An explicit --port-app is an answer, not a
+ * preference. A port already in this directory's state belongs to an instance
+ * that has data and an .env.local pointing at it; relocating on a restart would
+ * strand both.
  */
 
 import { createServer } from 'node:net';
@@ -85,4 +95,63 @@ export async function ensurePortsAvailable(
 
 export function resolvePorts(overrides: Partial<LocalPorts> = {}): LocalPorts {
   return { ...DEFAULT_PORTS, ...overrides };
+}
+
+export const PORT_BLOCK_STEP = 10;
+const MAX_BLOCKS = 20;
+
+export interface PortAllocation {
+  ports: LocalPorts;
+  /** Ports that could not stay at their default, for reporting. */
+  moved: { name: keyof LocalPorts; from: number; to: number }[];
+}
+
+/**
+ * Find a set of free ports, shifting the block by ten at a time.
+ *
+ * `fixed` names the ports that must be used as given — explicit flags and
+ * anything this directory already recorded. When one of those is taken there is
+ * nowhere to move it to, so this reports it the same way a single-instance
+ * conflict was always reported.
+ */
+export async function allocatePorts(
+  desired: LocalPorts,
+  fixed: Set<keyof LocalPorts> = new Set(),
+  ignore: Set<number> = new Set(),
+): Promise<PortAllocation> {
+  const names = Object.keys(desired) as (keyof LocalPorts)[];
+
+  for (let block = 0; block < MAX_BLOCKS; block++) {
+    const candidate = {} as LocalPorts;
+    for (const name of names) {
+      candidate[name] = fixed.has(name)
+        ? desired[name]
+        : desired[name] + block * PORT_BLOCK_STEP;
+    }
+    const checks = await checkPorts(candidate);
+    if (checks.every((c) => c.free || ignore.has(c.port))) {
+      const moved = names
+        .filter((n) => candidate[n] !== desired[n])
+        .map((n) => ({ name: n, from: desired[n], to: candidate[n] }));
+      return { ports: candidate, moved };
+    }
+    // A fixed port is taken, so no offset will help — every block reuses it.
+    const stuck = checks.filter((c) => !c.free && !ignore.has(c.port) && fixed.has(c.name));
+    if (stuck.length > 0) {
+      const detail = stuck.map((c) => `  • ${c.port} (${LABELS[c.name]})`).join('\n');
+      const flags = stuck.map((c) => `--port-${c.name} <n>`).join(' ');
+      throw new CLIError(
+        `Port${stuck.length > 1 ? 's' : ''} already in use:\n${detail}\n\n` +
+          'These were set explicitly, or belong to this directory\'s existing\n' +
+          'instance, so they were not relocated. Free them, or pick others:\n' +
+          `  insforge local start ${flags}`,
+      );
+    }
+  }
+
+  throw new CLIError(
+    `No free port block found after trying ${MAX_BLOCKS} of them, starting at ` +
+      `${desired.app}. Something is occupying a very wide range; pass ports ` +
+      'explicitly with --port-app and friends.',
+  );
 }

--- a/src/lib/local/ports.ts
+++ b/src/lib/local/ports.ts
@@ -48,6 +48,10 @@ export function bindable(port: number, host: string): Promise<boolean> {
  * port to run on there at all. macOS never showed it.
  */
 export async function isPortFree(port: number): Promise<boolean> {
+  // Binding below 1024 needs privileges this process usually lacks, while the
+  // Docker daemon has them. Probing says "in use" for a port that is free and
+  // would have worked, so leave those to compose, which reports the real answer.
+  if (port < 1024) return true;
   if (!(await bindable(port, '0.0.0.0'))) return false;
   return bindable(port, '127.0.0.1');
 }

--- a/src/lib/local/ports.ts
+++ b/src/lib/local/ports.ts
@@ -137,10 +137,20 @@ export async function allocatePorts(
     // Two services on one port passes every free check and then fails inside
     // compose with "port is already allocated" — `--port-app 7131` collides with
     // the auth default without either value being wrong on its own.
+    //
+    // Only fatal when both sides are fixed, since nothing can move them apart.
+    // A collision that involves a shifting port belongs to this block alone: a
+    // fixed 7141 meets the auth default once on the way past it, and throwing
+    // there would reject a request the next block satisfies.
     const seen = new Map<number, keyof LocalPorts>();
+    let blockClash = false;
     for (const name of names) {
       const clash = seen.get(candidate[name]);
       if (clash) {
+        if (!fixed.has(clash) || !fixed.has(name)) {
+          blockClash = true;
+          break;
+        }
         throw new CLIError(
           `${LABELS[clash]} and ${LABELS[name]} would both use port ${candidate[name]}.\n` +
             'Give one of them a port of its own with --port-' +
@@ -149,6 +159,7 @@ export async function allocatePorts(
       }
       seen.set(candidate[name], name);
     }
+    if (blockClash) continue;
 
     const checks = await checkPorts(candidate);
     if (checks.every((c) => c.free || ignore.has(c.port))) {

--- a/src/lib/local/ports.ts
+++ b/src/lib/local/ports.ts
@@ -41,13 +41,15 @@ export function bindable(port: number, host: string): Promise<boolean> {
  * instance passed this check and then died in `docker compose up` with "port is
  * already allocated". Checking only the wildcard would miss a service bound to
  * loopback alone, which a container publish would also collide with.
+ *
+ * One at a time, never Promise.all. 0.0.0.0:P and 127.0.0.1:P overlap, and Linux
+ * refuses the second bind while BSD accepts it — so probing them together
+ * reported every free port as taken on Linux, and `local start` could not find a
+ * port to run on there at all. macOS never showed it.
  */
 export async function isPortFree(port: number): Promise<boolean> {
-  const [wildcard, loopback] = await Promise.all([
-    bindable(port, '0.0.0.0'),
-    bindable(port, '127.0.0.1'),
-  ]);
-  return wildcard && loopback;
+  if (!(await bindable(port, '0.0.0.0'))) return false;
+  return bindable(port, '127.0.0.1');
 }
 
 export interface PortCheck {
@@ -128,6 +130,22 @@ export async function allocatePorts(
         ? desired[name]
         : desired[name] + block * PORT_BLOCK_STEP;
     }
+    // Two services on one port passes every free check and then fails inside
+    // compose with "port is already allocated" — `--port-app 7131` collides with
+    // the auth default without either value being wrong on its own.
+    const seen = new Map<number, keyof LocalPorts>();
+    for (const name of names) {
+      const clash = seen.get(candidate[name]);
+      if (clash) {
+        throw new CLIError(
+          `${LABELS[clash]} and ${LABELS[name]} would both use port ${candidate[name]}.\n` +
+            'Give one of them a port of its own with --port-' +
+            `${clash} or --port-${name}.`,
+        );
+      }
+      seen.set(candidate[name], name);
+    }
+
     const checks = await checkPorts(candidate);
     if (checks.every((c) => c.free || ignore.has(c.port))) {
       const moved = names

--- a/src/lib/local/ports.ts
+++ b/src/lib/local/ports.ts
@@ -1,0 +1,88 @@
+/**
+ * Port availability for a local instance.
+ *
+ * The defaults match every existing InsForge doc (7130 for the API and
+ * dashboard, 5432 for Postgres, …), so URLs a user has already seen keep
+ * working. When one is taken we report exactly which and stop, rather than
+ * silently relocating the instance to ports nothing else knows about.
+ */
+
+import { createServer } from 'node:net';
+import { CLIError } from '../errors.js';
+import { DEFAULT_PORTS, type LocalPorts } from './state.js';
+
+export function bindable(port: number, host: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, host);
+  });
+}
+
+/**
+ * Free means bindable on both the wildcard address and loopback.
+ *
+ * Checking only loopback misses the collisions that matter most here. Docker
+ * publishes on 0.0.0.0, and on macOS a container holding 0.0.0.0:5432 still
+ * leaves a Node bind to 127.0.0.1:5432 succeeding — so a second InsForge
+ * instance passed this check and then died in `docker compose up` with "port is
+ * already allocated". Checking only the wildcard would miss a service bound to
+ * loopback alone, which a container publish would also collide with.
+ */
+export async function isPortFree(port: number): Promise<boolean> {
+  const [wildcard, loopback] = await Promise.all([
+    bindable(port, '0.0.0.0'),
+    bindable(port, '127.0.0.1'),
+  ]);
+  return wildcard && loopback;
+}
+
+export interface PortCheck {
+  name: keyof LocalPorts;
+  port: number;
+  free: boolean;
+}
+
+export async function checkPorts(ports: LocalPorts): Promise<PortCheck[]> {
+  const entries = Object.entries(ports) as [keyof LocalPorts, number][];
+  return Promise.all(
+    entries.map(async ([name, port]) => ({ name, port, free: await isPortFree(port) })),
+  );
+}
+
+const LABELS: Record<keyof LocalPorts, string> = {
+  app: 'API + dashboard',
+  auth: 'auth service',
+  deno: 'edge functions runtime',
+  postgres: 'Postgres',
+  postgrest: 'PostgREST',
+};
+
+/**
+ * Throw with the occupied ports named and the override spelled out. Ports
+ * already bound by THIS instance's own containers are expected during a restart
+ * and are passed in via `ignore`.
+ */
+export async function ensurePortsAvailable(
+  ports: LocalPorts,
+  ignore: Set<number> = new Set(),
+): Promise<void> {
+  const checks = await checkPorts(ports);
+  const taken = checks.filter((c) => !c.free && !ignore.has(c.port));
+  if (taken.length === 0) return;
+
+  const detail = taken.map((c) => `  • ${c.port} (${LABELS[c.name]})`).join('\n');
+  const flags = taken.map((c) => `--port-${c.name} <n>`).join(' ');
+  throw new CLIError(
+    `Port${taken.length > 1 ? 's' : ''} already in use:\n${detail}\n\n` +
+      'Another InsForge instance or an unrelated service is bound there. Either\n' +
+      `stop it, or pick different ports: insforge local start ${flags}`,
+  );
+}
+
+export function resolvePorts(overrides: Partial<LocalPorts> = {}): LocalPorts {
+  return { ...DEFAULT_PORTS, ...overrides };
+}

--- a/src/lib/local/secrets.ts
+++ b/src/lib/local/secrets.ts
@@ -13,7 +13,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { CLIError } from '../errors.js';
 import { checkoutEnvFile } from './checkout.js';
 import type { LocalPorts, StorageBackend } from './state.js';
@@ -58,7 +58,11 @@ export function setEnvVars(vars: Record<string, string>, cwd?: string): void {
     if (i === -1) lines.push(`${key}=${value}`);
     else lines[i] = `${key}=${value}`;
   }
+  // mode only applies when writeFileSync creates the file. This one already
+  // exists — setup.sh made it — so the permissions have to be set outright, or
+  // a stricter umask elsewhere is the only thing keeping the secrets private.
   writeFileSync(path, lines.join('\n'), { mode: 0o600 });
+  chmodSync(path, 0o600);
 }
 
 /** Read what setup.sh generated. Null when a value it should have written is absent. */

--- a/src/lib/local/secrets.ts
+++ b/src/lib/local/secrets.ts
@@ -24,6 +24,7 @@ export interface LocalSecrets {
   anonKey: string;
   adminUsername: string;
   adminPassword: string;
+  postgresPassword: string;
 }
 
 function hex(bytes: number): string {
@@ -69,8 +70,20 @@ export function readSecrets(cwd?: string): LocalSecrets | null {
   const anonKey = env.ACCESS_ANON_KEY;
   const adminUsername = env.ROOT_ADMIN_USERNAME;
   const adminPassword = env.ROOT_ADMIN_PASSWORD;
-  if (!apiKey || !anonKey || !adminUsername || !adminPassword) return null;
-  return { apiKey, anonKey, adminUsername, adminPassword };
+  const postgresPassword = env.POSTGRES_PASSWORD;
+  if (!apiKey || !anonKey || !adminUsername || !adminPassword || !postgresPassword) return null;
+  return { apiKey, anonKey, adminUsername, adminPassword, postgresPassword };
+}
+
+/**
+ * The connection string for a local instance.
+ *
+ * The password is setup.sh's, not a known default: an earlier version printed
+ * `postgres:postgres` from when the CLI generated its own env, and that URL
+ * failed authentication for everyone who copied it.
+ */
+export function databaseUrl(password: string, port: number): string {
+  return `postgresql://postgres:${password}@localhost:${port}/insforge`;
 }
 
 export interface EnvDeltaInput {

--- a/src/lib/local/secrets.ts
+++ b/src/lib/local/secrets.ts
@@ -1,0 +1,109 @@
+/**
+ * The env file the local stack runs on.
+ *
+ * InsForge's setup.sh generates the secrets — JWT, encryption key, Postgres and
+ * admin passwords, and the two access keys — into `.insforge/checkout/.env`, and
+ * leaves that file alone on re-runs. The CLI reads them back for wiring and adds
+ * what only it knows: the ports this directory chose, and the store credentials
+ * a storage overlay needs.
+ *
+ * Generating them here as well would be a second implementation of something the
+ * script already does fail-closed, and would make the two disagree about what an
+ * instance's keys are.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { CLIError } from '../errors.js';
+import { checkoutEnvFile } from './checkout.js';
+import type { LocalPorts, StorageBackend } from './state.js';
+
+/** What the CLI needs to know about a running instance to wire a directory to it. */
+export interface LocalSecrets {
+  apiKey: string;
+  anonKey: string;
+  adminUsername: string;
+  adminPassword: string;
+}
+
+function hex(bytes: number): string {
+  return randomBytes(bytes).toString('hex');
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+/**
+ * Set variables in the checkout's env file, leaving everything else in place.
+ *
+ * The same shape as setup.sh's own set_var: replace a key that is there, append
+ * one that is not. That is what lets the script and the CLI write to one file
+ * without either clobbering the other's values.
+ */
+export function setEnvVars(vars: Record<string, string>, cwd?: string): void {
+  const path = checkoutEnvFile(cwd);
+  if (!existsSync(path)) {
+    throw new CLIError(`${path} is missing. Run \`insforge local start\` to create it.`);
+  }
+  const lines = readFileSync(path, 'utf-8').split('\n');
+  for (const [key, value] of Object.entries(vars)) {
+    const i = lines.findIndex((l) => l.startsWith(`${key}=`));
+    if (i === -1) lines.push(`${key}=${value}`);
+    else lines[i] = `${key}=${value}`;
+  }
+  writeFileSync(path, lines.join('\n'), { mode: 0o600 });
+}
+
+/** Read what setup.sh generated. Null when a value it should have written is absent. */
+export function readSecrets(cwd?: string): LocalSecrets | null {
+  const path = checkoutEnvFile(cwd);
+  if (!existsSync(path)) return null;
+  const env = parseEnvFile(readFileSync(path, 'utf-8'));
+  const apiKey = env.ACCESS_API_KEY;
+  const anonKey = env.ACCESS_ANON_KEY;
+  const adminUsername = env.ROOT_ADMIN_USERNAME;
+  const adminPassword = env.ROOT_ADMIN_PASSWORD;
+  if (!apiKey || !anonKey || !adminUsername || !adminPassword) return null;
+  return { apiKey, anonKey, adminUsername, adminPassword };
+}
+
+export interface EnvDeltaInput {
+  ports: LocalPorts;
+  storage: StorageBackend;
+  cwd?: string;
+}
+
+/**
+ * Write the values setup.sh does not know about.
+ *
+ * Store credentials are generated once and then read back, so a restart does not
+ * rotate them out from under a MinIO volume that already has data under the old
+ * ones.
+ */
+export function writeEnvDeltas({ ports, storage, cwd }: EnvDeltaInput): void {
+  const existing = parseEnvFile(readFileSync(checkoutEnvFile(cwd), 'utf-8'));
+  const vars: Record<string, string> = {
+    POSTGRES_PORT: String(ports.postgres),
+    POSTGREST_PORT: String(ports.postgrest),
+    APP_PORT: String(ports.app),
+    AUTH_PORT: String(ports.auth),
+    DENO_PORT: String(ports.deno),
+    API_BASE_URL: `http://localhost:${ports.app}`,
+    VITE_API_BASE_URL: `http://localhost:${ports.app}`,
+  };
+
+  if (storage === 'minio' || storage === 'rustfs') {
+    const user = storage === 'minio' ? 'MINIO_ROOT_USER' : 'RUSTFS_ACCESS_KEY';
+    const pass = storage === 'minio' ? 'MINIO_ROOT_PASSWORD' : 'RUSTFS_SECRET_KEY';
+    vars[user] = existing[user] || 'insforge';
+    vars[pass] = existing[pass] || hex(16);
+  }
+
+  setEnvVars(vars, cwd);
+}

--- a/src/lib/local/state.test.ts
+++ b/src/lib/local/state.test.ts
@@ -6,7 +6,6 @@ import {
   composeProjectName,
   clearLocalState,
   ensureLocalGitignore,
-  localEnvFile,
   localStateFile,
   readLocalState,
   writeLocalState,
@@ -71,10 +70,8 @@ describe('local state file', () => {
   it('clearLocalState removes both state and secrets', () => {
     const cwd = tmp();
     writeLocalState(STATE, cwd);
-    writeFileSync(localEnvFile(cwd), 'JWT_SECRET=x\n');
     clearLocalState(cwd);
     expect(existsSync(localStateFile(cwd))).toBe(false);
-    expect(existsSync(localEnvFile(cwd))).toBe(false);
   });
 });
 
@@ -83,7 +80,9 @@ describe('ensureLocalGitignore', () => {
     const cwd = tmp();
     ensureLocalGitignore(cwd);
     const body = readFileSync(join(cwd, '.insforge', '.gitignore'), 'utf-8');
-    expect(body.split('\n')).toContain('local.env');
+    // checkout/ is where the generated .env lives — the entry that actually
+    // keeps the instance's secrets out of a commit.
+    expect(body.split('\n')).toContain('checkout/');
     expect(body.split('\n')).toContain('local.json');
   });
 
@@ -96,7 +95,7 @@ describe('ensureLocalGitignore', () => {
     const lines = readFileSync(join(cwd, '.insforge', '.gitignore'), 'utf-8')
       .split('\n')
       .filter(Boolean);
-    expect(lines).toEqual(['something-else', 'local.env', 'local.json', 'local-compose.yml']);
+    expect(lines).toEqual(['something-else', 'checkout/', 'setup.sh', 'local.json']);
   });
 
   // project.json holds a cloud api_key and is not ours to start ignoring.

--- a/src/lib/local/state.test.ts
+++ b/src/lib/local/state.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  composeProjectName,
+  clearLocalState,
+  ensureLocalGitignore,
+  localEnvFile,
+  localStateFile,
+  readLocalState,
+  writeLocalState,
+  type LocalState,
+} from './state.js';
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), 'if-local-'));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+const STATE: LocalState = {
+  version: 1,
+  projectName: 'insforge-app-abc12345',
+  storage: 'local',
+  ports: { app: 7130, auth: 7131, deno: 7133, postgres: 5432, postgrest: 5430 },
+  createdAt: '2026-08-05T00:00:00.000Z',
+};
+
+describe('composeProjectName', () => {
+  it('gives two directories with the same basename different names', () => {
+    // Without the path hash, ~/a/api and ~/b/api would share containers and one
+    // would silently attach to the other's database.
+    expect(composeProjectName('/home/u/a/api')).not.toBe(composeProjectName('/home/u/b/api'));
+  });
+
+  it('is stable for the same directory', () => {
+    expect(composeProjectName('/home/u/app')).toBe(composeProjectName('/home/u/app'));
+  });
+
+  it('produces a docker-legal project name', () => {
+    for (const dir of ['/tmp/My App!', '/tmp/___weird', '/tmp/9lives', '/']) {
+      expect(composeProjectName(dir)).toMatch(/^insforge-[a-z0-9][a-z0-9_-]*$/);
+    }
+  });
+});
+
+describe('local state file', () => {
+  it('round-trips', () => {
+    const cwd = tmp();
+    writeLocalState(STATE, cwd);
+    expect(readLocalState(cwd)).toEqual(STATE);
+  });
+
+  it('returns null when absent', () => {
+    expect(readLocalState(tmp())).toBeNull();
+  });
+
+  it('returns null on a corrupt file rather than throwing', () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, '.insforge'), { recursive: true });
+    writeFileSync(localStateFile(cwd), '{not json');
+    expect(readLocalState(cwd)).toBeNull();
+  });
+
+  it('clearLocalState removes both state and secrets', () => {
+    const cwd = tmp();
+    writeLocalState(STATE, cwd);
+    writeFileSync(localEnvFile(cwd), 'JWT_SECRET=x\n');
+    clearLocalState(cwd);
+    expect(existsSync(localStateFile(cwd))).toBe(false);
+    expect(existsSync(localEnvFile(cwd))).toBe(false);
+  });
+});
+
+describe('ensureLocalGitignore', () => {
+  it('ignores the secrets and state files', () => {
+    const cwd = tmp();
+    ensureLocalGitignore(cwd);
+    const body = readFileSync(join(cwd, '.insforge', '.gitignore'), 'utf-8');
+    expect(body.split('\n')).toContain('local.env');
+    expect(body.split('\n')).toContain('local.json');
+  });
+
+  it('is idempotent and preserves existing entries', () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, '.insforge'), { recursive: true });
+    writeFileSync(join(cwd, '.insforge', '.gitignore'), 'something-else\n');
+    ensureLocalGitignore(cwd);
+    ensureLocalGitignore(cwd);
+    const lines = readFileSync(join(cwd, '.insforge', '.gitignore'), 'utf-8')
+      .split('\n')
+      .filter(Boolean);
+    expect(lines).toEqual(['something-else', 'local.env', 'local.json', 'local-compose.yml']);
+  });
+
+  // project.json holds a cloud api_key and is not ours to start ignoring.
+  it('does not ignore project.json', () => {
+    const cwd = tmp();
+    ensureLocalGitignore(cwd);
+    const body = readFileSync(join(cwd, '.insforge', '.gitignore'), 'utf-8');
+    expect(body).not.toContain('project.json');
+    expect(body).not.toMatch(/^\*$/m);
+  });
+});
+
+describe('composeProjectName across platforms', () => {
+  it('takes the last segment of a Windows path too', () => {
+    // split('/') returns the whole string on Windows, so the project name became
+    // the entire path flattened — d-users-me-work-app rather than app.
+    expect(composeProjectName('C:\\Users\\me\\work\\app')).toMatch(/^insforge-app-[0-9a-f]{8}$/);
+    expect(composeProjectName('/home/me/work/app')).toMatch(/^insforge-app-[0-9a-f]{8}$/);
+  });
+
+  it('still separates two directories that share a basename', () => {
+    expect(composeProjectName('/a/api')).not.toBe(composeProjectName('/b/api'));
+  });
+
+  it('falls back when there is no usable segment', () => {
+    expect(composeProjectName('/')).toMatch(/^insforge-(app|insforge)-[0-9a-f]{8}$/);
+  });
+});

--- a/src/lib/local/state.test.ts
+++ b/src/lib/local/state.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   composeProjectName,
   clearLocalState,
@@ -67,11 +67,18 @@ describe('local state file', () => {
     expect(readLocalState(cwd)).toBeNull();
   });
 
-  it('clearLocalState removes both state and secrets', () => {
+  it('clearLocalState removes the state file and leaves the checkout alone', () => {
     const cwd = tmp();
     writeLocalState(STATE, cwd);
+    // The secrets live in .insforge/checkout/.env now, and the checkout is
+    // whole directories of upstream's files — `local stop --delete-data`
+    // removes containers and volumes, not the stack definition.
+    const checkoutMarker = join(cwd, '.insforge', 'checkout', '.env');
+    mkdirSync(dirname(checkoutMarker), { recursive: true });
+    writeFileSync(checkoutMarker, 'X=1\n');
     clearLocalState(cwd);
     expect(existsSync(localStateFile(cwd))).toBe(false);
+    expect(existsSync(checkoutMarker)).toBe(true);
   });
 });
 
@@ -95,7 +102,13 @@ describe('ensureLocalGitignore', () => {
     const lines = readFileSync(join(cwd, '.insforge', '.gitignore'), 'utf-8')
       .split('\n')
       .filter(Boolean);
-    expect(lines).toEqual(['something-else', 'checkout/', 'setup.sh', 'local.json']);
+    expect(lines).toEqual([
+      'something-else',
+      'checkout/',
+      'setup.sh',
+      'local.json',
+      'project.cloud.json',
+    ]);
   });
 
   // project.json holds a cloud api_key and is not ours to start ignoring.

--- a/src/lib/local/state.ts
+++ b/src/lib/local/state.ts
@@ -60,19 +60,6 @@ export function localStateFile(cwd?: string): string {
   return join(localDir(cwd), 'local.json');
 }
 
-export function localEnvFile(cwd?: string): string {
-  return join(localDir(cwd), 'local.env');
-}
-
-/**
- * The rendered compose file. Generated on every start from the CLI's template so
- * a CLI upgrade always runs its own spec, and readable on disk so a user can
- * inspect or hand-run exactly what the CLI ran.
- */
-export function localComposeFile(cwd?: string): string {
-  return join(localDir(cwd), 'local-compose.yml');
-}
-
 /**
  * Compose project name for a directory. Docker requires lowercase
  * `[a-z0-9][a-z0-9_-]*`, so the basename is sanitized and suffixed with a hash
@@ -92,15 +79,29 @@ export function composeProjectName(cwd: string = process.cwd()): string {
   return `insforge-${base || 'app'}-${hash}`;
 }
 
+function isLocalState(v: unknown): v is LocalState {
+  if (typeof v !== 'object' || v === null) return false;
+  const s = v as Record<string, unknown>;
+  if (typeof s.projectName !== 'string' || !s.projectName) return false;
+  if (typeof s.storage !== 'string') return false;
+  const ports = s.ports;
+  if (typeof ports !== 'object' || ports === null) return false;
+  const p = ports as Record<string, unknown>;
+  return (['app', 'auth', 'deno', 'postgres', 'postgrest'] as const).every(
+    (k) => Number.isInteger(p[k]),
+  );
+}
+
 export function readLocalState(cwd?: string): LocalState | null {
   const file = localStateFile(cwd);
   if (!existsSync(file)) return null;
   try {
-    return JSON.parse(readFileSync(file, 'utf-8')) as LocalState;
+    const parsed: unknown = JSON.parse(readFileSync(file, 'utf-8'));
+    // Valid JSON of the wrong shape is the case that got through: `{}` parses,
+    // and the first `state.ports.postgres` then throws somewhere with no
+    // mention of this file. Callers treat null as "no instance recorded".
+    return isLocalState(parsed) ? parsed : null;
   } catch {
-    // A truncated or hand-edited file shouldn't wedge `local stop`; callers
-    // treat null as "no instance recorded" and can still be pointed at one
-    // by re-running `local start`.
     return null;
   }
 }
@@ -112,9 +113,8 @@ export function writeLocalState(state: LocalState, cwd?: string): void {
 }
 
 export function clearLocalState(cwd?: string): void {
-  for (const file of [localStateFile(cwd), localEnvFile(cwd), localComposeFile(cwd)]) {
-    if (existsSync(file)) unlinkSync(file);
-  }
+  const file = localStateFile(cwd);
+  if (existsSync(file)) unlinkSync(file);
 }
 
 /**
@@ -125,7 +125,10 @@ export function clearLocalState(cwd?: string): void {
 export function ensureLocalGitignore(cwd?: string): void {
   const dir = ensureLocalDir(cwd);
   const file = join(dir, '.gitignore');
-  const wanted = ['local.env', 'local.json', 'local-compose.yml'];
+  // checkout/ holds the .env setup.sh generated — the instance's only copy of
+  // its secrets. It was not listed while the entries here still named files from
+  // an earlier layout, so `git add .` would have committed them.
+  const wanted = ['checkout/', 'setup.sh', 'local.json'];
   const existing = existsSync(file)
     ? readFileSync(file, 'utf-8').split('\n').map((l) => l.trim())
     : [];

--- a/src/lib/local/state.ts
+++ b/src/lib/local/state.ts
@@ -26,6 +26,16 @@ export interface LocalPorts {
   postgrest: number;
 }
 
+/**
+ * Compose overlay per storage backend. Here rather than in compose.ts because
+ * checkout.ts validates the same files, and compose.ts already imports from
+ * checkout.ts — a second edge the other way would close the cycle.
+ */
+export const OVERLAYS: Record<Exclude<StorageBackend, 'local'>, string> = {
+  minio: 'docker-compose.minio.yml',
+  rustfs: 'docker-compose.rustfs.yml',
+};
+
 export interface LocalState {
   /** Schema version, so a future change can migrate rather than misread. */
   version: 1;

--- a/src/lib/local/state.ts
+++ b/src/lib/local/state.ts
@@ -128,7 +128,9 @@ export function ensureLocalGitignore(cwd?: string): void {
   // checkout/ holds the .env setup.sh generated — the instance's only copy of
   // its secrets. It was not listed while the entries here still named files from
   // an earlier layout, so `git add .` would have committed them.
-  const wanted = ['checkout/', 'setup.sh', 'local.json'];
+  // project.cloud.json is a copy of the displaced cloud link, api_key and all —
+  // written by `local start`, so it is this feature's to keep out of a commit.
+  const wanted = ['checkout/', 'setup.sh', 'local.json', 'project.cloud.json'];
   const existing = existsSync(file)
     ? readFileSync(file, 'utf-8').split('\n').map((l) => l.trim())
     : [];

--- a/src/lib/local/state.ts
+++ b/src/lib/local/state.ts
@@ -1,0 +1,136 @@
+/**
+ * On-disk state for a local InsForge instance.
+ *
+ * One instance per directory: the compose project name is derived from the
+ * directory path, so two app folders get separate containers, volumes, and
+ * databases without any configuration.
+ *
+ * Two files, split by what they hold:
+ *   .insforge/local.json — non-secret machine state (ports, resolved version)
+ *   .insforge/local.env  — generated secrets, mode 0600, fed to `--env-file`
+ * Both are gitignored via .insforge/.gitignore so a `git add -A` can't commit
+ * the keys.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type StorageBackend = 'local' | 'minio' | 'rustfs';
+
+export interface LocalPorts {
+  app: number;
+  auth: number;
+  deno: number;
+  postgres: number;
+  postgrest: number;
+}
+
+export interface LocalState {
+  /** Schema version, so a future change can migrate rather than misread. */
+  version: 1;
+  /** `docker compose -p` value. Derived from the directory, stored so a later
+   *  `local stop` targets the same containers even if the directory moved. */
+  projectName: string;
+  storage: StorageBackend;
+  ports: LocalPorts;
+  createdAt: string;
+}
+
+export const DEFAULT_PORTS: LocalPorts = {
+  app: 7130,
+  auth: 7131,
+  deno: 7133,
+  postgres: 5432,
+  postgrest: 5430,
+};
+
+function localDir(cwd: string = process.cwd()): string {
+  return join(cwd, '.insforge');
+}
+
+/** Create `.insforge/` if needed. Callers write into it without ordering rules. */
+export function ensureLocalDir(cwd?: string): string {
+  const dir = localDir(cwd);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function localStateFile(cwd?: string): string {
+  return join(localDir(cwd), 'local.json');
+}
+
+export function localEnvFile(cwd?: string): string {
+  return join(localDir(cwd), 'local.env');
+}
+
+/**
+ * The rendered compose file. Generated on every start from the CLI's template so
+ * a CLI upgrade always runs its own spec, and readable on disk so a user can
+ * inspect or hand-run exactly what the CLI ran.
+ */
+export function localComposeFile(cwd?: string): string {
+  return join(localDir(cwd), 'local-compose.yml');
+}
+
+/**
+ * Compose project name for a directory. Docker requires lowercase
+ * `[a-z0-9][a-z0-9_-]*`, so the basename is sanitized and suffixed with a hash
+ * of the absolute path — the hash is what keeps two directories with the same
+ * basename (`~/a/api` and `~/b/api`) from sharing containers.
+ */
+export function composeProjectName(cwd: string = process.cwd()): string {
+  // Both separators, not node:path's basename: that one is platform-specific, so
+  // a Windows path handed to a POSIX build keeps its backslashes and the whole
+  // path becomes the name.
+  const base = (cwd.split(/[\\/]/).filter(Boolean).pop() ?? 'insforge')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '-')
+    .replace(/^[^a-z0-9]+/, '')
+    .slice(0, 24);
+  const hash = createHash('sha256').update(cwd).digest('hex').slice(0, 8);
+  return `insforge-${base || 'app'}-${hash}`;
+}
+
+export function readLocalState(cwd?: string): LocalState | null {
+  const file = localStateFile(cwd);
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, 'utf-8')) as LocalState;
+  } catch {
+    // A truncated or hand-edited file shouldn't wedge `local stop`; callers
+    // treat null as "no instance recorded" and can still be pointed at one
+    // by re-running `local start`.
+    return null;
+  }
+}
+
+export function writeLocalState(state: LocalState, cwd?: string): void {
+  ensureLocalDir(cwd);
+  ensureLocalGitignore(cwd);
+  writeFileSync(localStateFile(cwd), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+export function clearLocalState(cwd?: string): void {
+  for (const file of [localStateFile(cwd), localEnvFile(cwd), localComposeFile(cwd)]) {
+    if (existsSync(file)) unlinkSync(file);
+  }
+}
+
+/**
+ * Keep the generated secrets and machine state out of git. Scoped to the two
+ * files this feature adds — deliberately not `*`, which would also start
+ * ignoring project.json for existing cloud-linked repos.
+ */
+export function ensureLocalGitignore(cwd?: string): void {
+  const dir = ensureLocalDir(cwd);
+  const file = join(dir, '.gitignore');
+  const wanted = ['local.env', 'local.json', 'local-compose.yml'];
+  const existing = existsSync(file)
+    ? readFileSync(file, 'utf-8').split('\n').map((l) => l.trim())
+    : [];
+  const missing = wanted.filter((w) => !existing.includes(w));
+  if (missing.length === 0) return;
+  const body = existing.filter(Boolean).concat(missing).join('\n');
+  writeFileSync(file, `${body}\n`);
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   },
   esbuildPlugins: [
     {
-      name: 'copy-forger-asset',
+      name: 'copy-assets',
       setup(build) {
         build.onEnd((result) => {
           if (result.errors.length > 0) return;
@@ -31,6 +31,20 @@ export default defineConfig({
           const assetsDir = join(outDir, 'assets');
           mkdirSync(assetsDir, { recursive: true });
           copyFileSync('src/assets/forger.json', join(assetsDir, 'forger.json'));
+
+          // Compose files for `insforge local start`. They reference only
+          // published images and named volumes, so they run correctly from
+          // inside the installed package.
+          const localDir = join(assetsDir, 'local');
+          mkdirSync(localDir, { recursive: true });
+          for (const file of [
+              // The stack comes from InsForge's repository via its setup.sh. The
+              // only compose the CLI ships is the overlay carrying the telemetry
+              // stamp — see src/lib/local/checkout.ts.
+              'cli-overlay.yml',
+          ]) {
+            copyFileSync(join('src/assets/local', file), join(localDir, file));
+          }
         });
       },
     },


### PR DESCRIPTION
Replaces #222, which accumulated several superseded approaches. Same feature, rebased on current `main`, three reviewable commits.

`insforge local start` brings up a full InsForge backend in Docker — Postgres, PostgREST, the backend, the edge-functions runtime — with no account and no repository clone.

## Where the stack comes from

The CLI does not define the stack. The first start fetches [`deploy/setup.sh`](https://github.com/InsForge/InsForge/blob/main/deploy/setup.sh) from the InsForge repository and runs it with `INSFORGE_NO_GIT=1` into `.insforge/checkout/`, then runs the compose file it wrote.

That is the same script self-hosting uses, so a local instance runs the same compose file, init SQL, and images as a deployed one. It already owns the file list, the layout the compose file's relative mounts expect, and the secret generation.

The earlier approach carried a 266-line copy of the compose file plus the four files it inlines. That copy drifted within a day of being written — the connection-pool alignment added upstream never reached it.

## What the CLI adds

One overlay, `src/assets/local/cli-overlay.yml`:

- `INSFORGE_DEPLOYMENT_METHOD: cli-local`, so telemetry can tell a local start apart from a self-hosted compose. Compose only passes variables a file names, and the upstream file does not name this one, so an env file cannot carry it.
- `ports: !override` binding the published ports to loopback. Upstream publishes the API and dashboard on every interface, which is what a self-hosted install wants and a laptop that joins untrusted networks does not. `!override` because Compose merges port lists by appending — without it the `0.0.0.0` entry keeps listening alongside the loopback one.

Plus the values setup.sh cannot know: the ports this directory chose, and store credentials when a storage overlay is used.

## Secrets

`setup.sh` generates them into `.insforge/checkout/.env`; the CLI reads them back. Generating them here as well would be a second implementation of something the script already does fail-closed, and would make the two disagree about what an instance's keys are.

The API key is read from that file rather than obtained by logging in with the admin credentials.

If `.env` is missing while volumes still exist, `local start` refuses instead of generating new secrets. Postgres reads its password only when the cluster is created, so fresh secrets leave the database unreachable behind the old one — recoverable only by restoring the file.

## Commands

| | |
| --- | --- |
| `local start` | Start, wait for health, link the directory, seed `.env.local` |
| `local stop` | Stop; `--delete-data` destroys volumes, `--unlink` restores a previous cloud link |
| `local status` | Health, ports, backend version, per-container state; keys masked unless `--show-keys` |

One instance per directory — the compose project name carries a hash of the directory path, so two folders sharing a basename still get separate containers, volumes, and databases.

`stop --delete-data` is registered `critical` with the human-in-the-loop guard. A plain `stop` never prompts.

## Docker

A requirement, not a fallback. Without it the error lists the runtimes that satisfy it and mentions `insforge create` and `insforge link` as the other ways to get a backend — nothing switches to a hosted project on its own, since that is not what someone who typed `local start` asked for.

`ensureDocker` now also requires Compose 2.24.4, the version that understands `!override`. Older Compose fails on the tag with a YAML error naming neither the file nor the version.

## Verification

- 762 tests pass, lint and build clean, `cli-overlay.yml` ships in `dist/assets/local/`
- `docker compose config` against the real upstream file confirms all five published ports resolve to `127.0.0.1` and the stamp is set
- The upstream `setup.sh` path was verified end-to-end on bare EC2, Coolify, and Dokploy while it was being landed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `insforge local start` to run a full InsForge backend on your machine in Docker, plus `local stop` and `local status`. Uses the upstream stack, binds published ports to `127.0.0.1`, allocates ports reliably, and prints a working DB URL with safer secrets and cleanup.

- **New Features**
  - Commands: `local start|stop|status`. Start waits for health, links the directory, seeds `.env.local`; stop supports `--delete-data` and `--unlink`; status shows health/ports/version with `--json` and masks keys unless `--show-keys`.
  - Stack/Isolation/Ports: fetches and runs upstream `deploy/setup.sh` into `.insforge/checkout/`; overlay at `dist/assets/local/cli-overlay.yml` stamps `INSFORGE_DEPLOYMENT_METHOD=cli-local` and binds published ports to loopback. One instance per directory via a hashed compose project. Default ports shift by +10 when taken; explicit or remembered ports never move. Requires Docker with Compose ≥ 2.24.4. First start pulls `:latest`; later starts skip unless `--pull`.
  - Secrets/Env: reads secrets from `.insforge/checkout/.env` (mode 0600); refuses to regenerate over existing volumes. Seeds `NEXT_PUBLIC_*`/`VITE_*` in `.env.local` without overwriting user values. Prints a usable DB URL from the generated password; `status` masks keys and DB URL unless `--show-keys`, and `--json` omits secrets unless explicitly requested.
  - Docs/Packaging: README leads with hosted quick start and moves local to “Local Instances”; ships overlay in the published package; bumps `@insforge/cli` to `0.2.6`.

- **Bug Fixes**
  - Ports: serialize 0.0.0.0/127.0.0.1 checks on Linux; don’t treat <1024 as occupied; prevent duplicate service ports; handle block collisions so a second directory can start.
  - Cleanup: `up -d`/`down` use `--remove-orphans`; `stop --delete-data` sweeps volumes and networks, reports any remaining, and falls back to removing containers/networks by label if the checkout env is missing; no false success on network removal failures.
  - Secrets/Privacy: ensure checkout `.env` is 0600; `.insforge/.gitignore` covers `checkout/`, `setup.sh`, `local.json`, and `project.cloud.json`; fully mask admin password and DB URL in `status`.
  - Robustness: verify required checkout files (incl. `jwt.sql`, `worker-template.js`, and the selected storage overlay); treat non-regular bind sources as missing; stricter local state parsing; clearer, pasteable health-timeout hint; clearer error when no `sh` is available on Windows. Tests updated to cover port-collision skip.

<sup>Written for commit 0f190cf9fbd0cfe58267ad557ba892b41ab1db64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker-based commands to start, stop, and check the status of local InsForge instances.
  * Supports configurable ports and local, MinIO, or RustFS storage.
  * Shows service health, URLs, ports, and instance details, with JSON output available.
  * Preserves cloud links and local settings during setup and shutdown.
  * Added safeguards for port conflicts, Docker requirements, credentials, and data deletion.

* **Documentation**
  * Added comprehensive guidance for local setup, configuration, health checks, storage, ports, and secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `insforge local start|stop|status` commands to run a local InsForge backend via Docker Compose
> - Adds three new CLI subcommands under `local`: `start`, `stop`, and `status`, registered via [`src/commands/local/index.ts`](https://github.com/InsForge/CLI/pull/226/files#diff-decc8a9c5e3f9c184e71893e87b9c0b2480816e26f77caca7f20abf8d65d3c0f) and wired into the CLI entry point.
> - `local start` fetches and runs an upstream setup script to populate a checkout under `.insforge/`, allocates free host ports in blocks, writes Docker Compose env deltas (ports, storage credentials), brings up the stack, waits up to 240s for health, and links the working directory to the local instance.
> - `local stop` tears down the compose stack; with `--delete-data` it removes all associated volumes and sweeps leftovers, failing if any volumes remain; with `--unlink` it restores a previously backed-up cloud project link.
> - `local status` reports container states, backend health, URLs, and (with `--show-keys`) full credentials.
> - Supports three storage backends (`local`, `minio`, `rustfs`) via `--storage`; selects the appropriate compose overlay from [`src/assets/local/cli-overlay.yml`](https://github.com/InsForge/CLI/pull/226/files#diff-fd863746956df1c1168fd623c59ed0647cf396de88eb057f764f0e2051411c92), which binds ports to loopback and stamps `INSFORGE_DEPLOYMENT_METHOD=cli-local`.
> - Adds `docker.ensureDockerReady` to preflight Docker CLI, daemon, and Compose ≥ 2.24.4 before any local command runs.
> - Risk: `local start` writes generated secrets to `.insforge/local.json` and the checkout `.env` (mode 0600); it refuses to regenerate secrets when volumes already exist to prevent credential drift.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #226 opened
>
> - Removed local backend startup instructions from Quick Start section [0f190cf]
> - Added clarification about default hosted setup and local alternatives [0f190cf]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9757cd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->