### PR TITLE
fix(skills): gitignore .env.local on the link/create path

### DIFF
--- a/src/commands/ai/setup.ts
+++ b/src/commands/ai/setup.ts
@@ -1,15 +1,18 @@
 import type { Command } from 'commander';
-import { appendFileSync, existsSync, readFileSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import * as clack from '@clack/prompts';
 import pc from 'picocolors';
 import { captureEvent, shutdownAnalytics } from '../../lib/analytics.js';
 import { getOpenRouterApiKey } from '../../lib/api/ai.js';
 import { getProjectConfig } from '../../lib/config.js';
 import { getRootOpts, handleError, ProjectNotLinkedError } from '../../lib/errors.js';
-import { upsertEnvFile } from '../../lib/env-writer.js';
+import { ensureLocalEnvIgnored, isLocalEnvFile, upsertEnvFile } from '../../lib/env-writer.js';
 import { outputInfo, outputJson, outputSuccess } from '../../lib/output.js';
 import { isInteractive } from '../../lib/prompts.js';
+
+// Re-exported from its new home in lib so `./setup.js` stays a valid import
+// path for it (setup.test.ts and any external callers are unaffected).
+export { ensureLocalEnvIgnored };
 
 const DEFAULT_ENV_FILE = '.env.local';
 const OPENROUTER_ENV_KEY = 'OPENROUTER_API_KEY';
@@ -136,36 +139,3 @@ function displayPath(path: string): string {
   return rel;
 }
 
-function isLocalEnvFile(envFile: string): boolean {
-  const normalized = envFile.replace(/\\/g, '/');
-  const basename = normalized.split('/').pop() ?? normalized;
-  return basename === '.env.local' || /^\.env\..+\.local$/.test(basename);
-}
-
-export function ensureLocalEnvIgnored(cwd: string, envFile: string): boolean {
-  if (!isLocalEnvFile(envFile)) return false;
-
-  const envPath = resolve(cwd, envFile);
-  const relEnvPath = relative(cwd, envPath);
-  if (!relEnvPath || relEnvPath.startsWith('..') || isAbsolute(relEnvPath)) {
-    return false;
-  }
-
-  const gitignorePath = join(cwd, '.gitignore');
-  const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : '';
-  const lines = new Set(existing.split(/\r?\n/).map((line) => line.trim()));
-  const envBasename = envFile.replace(/\\/g, '/').split('/').pop() ?? envFile;
-  if (
-    lines.has('.env*') ||
-    lines.has('.env.*') ||
-    lines.has('.env*.local') ||
-    (lines.has('.env.local') && envBasename === '.env.local')
-  ) {
-    return false;
-  }
-
-  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
-  const spacer = existing.length > 0 ? '\n' : '';
-  appendFileSync(gitignorePath, `${prefix}${spacer}# Local environment secrets\n.env*.local\n`);
-  return true;
-}

--- a/src/lib/env-writer.ts
+++ b/src/lib/env-writer.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 export interface EnvUpdateResult {
   /** Variables that were appended (key was not already set). */
@@ -77,4 +78,51 @@ export function upsertEnvFile(
   }
 
   return result;
+}
+
+/** True for the local env files git is expected to ignore: `.env.local` and
+ *  `.env.<name>.local`. A plain `.env` is deliberately excluded — some projects
+ *  commit a non-secret one on purpose, so we never touch it. */
+export function isLocalEnvFile(envFile: string): boolean {
+  const normalized = envFile.replace(/\\/g, '/');
+  const basename = normalized.split('/').pop() ?? normalized;
+  return basename === '.env.local' || /^\.env\..+\.local$/.test(basename);
+}
+
+/**
+ * Make sure a local env file we just wrote credentials into is gitignored.
+ * Shared by `ai setup` (which writes OPENROUTER_API_KEY) and the skills
+ * install used by `link`/`create` (which seed .env.local and then point
+ * AGENTS.md at it), so the ignore rule lives in exactly one place.
+ *
+ * No-ops when the file is not a local env file, when it resolves outside
+ * `cwd` (nothing we should be editing a .gitignore for), or when an existing
+ * pattern already covers it. Returns `true` only if .gitignore was written.
+ */
+export function ensureLocalEnvIgnored(cwd: string, envFile: string): boolean {
+  if (!isLocalEnvFile(envFile)) return false;
+
+  const envPath = resolve(cwd, envFile);
+  const relEnvPath = relative(cwd, envPath);
+  if (!relEnvPath || relEnvPath.startsWith('..') || isAbsolute(relEnvPath)) {
+    return false;
+  }
+
+  const gitignorePath = join(cwd, '.gitignore');
+  const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : '';
+  const lines = new Set(existing.split(/\r?\n/).map((line) => line.trim()));
+  const envBasename = envFile.replace(/\\/g, '/').split('/').pop() ?? envFile;
+  if (
+    lines.has('.env*') ||
+    lines.has('.env.*') ||
+    lines.has('.env*.local') ||
+    (lines.has('.env.local') && envBasename === '.env.local')
+  ) {
+    return false;
+  }
+
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const spacer = existing.length > 0 ? '\n' : '';
+  appendFileSync(gitignorePath, `${prefix}${spacer}# Local environment secrets\n.env*.local\n`);
+  return true;
 }

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -193,6 +193,10 @@ describe('updateGitignore', () => {
     );
     updateGitignore();
 
+    // Guards the precondition: if GITIGNORE_ENTRIES grows and the fixture above
+    // goes stale, the agent block gets appended and this fails, rather than the
+    // test quietly passing while no longer exercising the early-return path.
+    expect(read()).not.toContain('# InsForge & AI agent skills');
     expect(read()).toContain('.env*.local');
   });
 

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
-import { describeExecError, reportCliUsage, PROVIDER_SKILLS } from './skills.js';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describeExecError, reportCliUsage, updateGitignore, PROVIDER_SKILLS } from './skills.js';
 
 test('apify provider installs apify/agent-skills', () => {
   expect(PROVIDER_SKILLS.apify).toEqual({ repo: 'apify/agent-skills', label: 'Apify skills' });
@@ -146,5 +149,58 @@ describe('reportCliUsage', () => {
     await reportCliUsage('cli.link', false, 1, explicitConfig);
     const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
     expect(body.success).toBe(false);
+  });
+});
+
+describe('updateGitignore', () => {
+  let dir: string;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cli-gitignore-'));
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(dir);
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const read = (): string => readFileSync(join(dir, '.gitignore'), 'utf-8');
+
+  it('ignores .env.local alongside the agent directories', () => {
+    updateGitignore();
+
+    const gitignore = read();
+    expect(gitignore).toContain('.insforge');
+    expect(gitignore).toContain('.env*.local');
+  });
+
+  it('does not add an env pattern when one already covers the file', () => {
+    writeFileSync(join(dir, '.gitignore'), '.env*\n');
+    updateGitignore();
+
+    expect(read().match(/^\.env.*$/gm)).toEqual(['.env*']);
+  });
+
+  it('still ignores .env.local when every agent entry is already present', () => {
+    writeFileSync(
+      join(dir, '.gitignore'),
+      [
+        '.insforge', '.agent', '.agents', '.augment', '.claude', '.cline',
+        '.github/copilot*', '.kilocode', '.qoder', '.qwen', '.roo', '.trae', '.windsurf',
+      ].join('\n') + '\n',
+    );
+    updateGitignore();
+
+    expect(read()).toContain('.env*.local');
+  });
+
+  it('is idempotent across repeated runs', () => {
+    updateGitignore();
+    const afterFirst = read();
+    updateGitignore();
+
+    expect(read()).toBe(afterFirst);
   });
 });

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 import * as clack from '@clack/prompts';
 import { writeLocalAgentsMd } from './agents-md.js';
 import { getProjectConfig } from './config.js';
+import { ensureLocalEnvIgnored } from './env-writer.js';
 
 const execAsync = promisify(exec);
 
@@ -57,16 +58,25 @@ const GITIGNORE_ENTRIES = [
   '.windsurf',
 ];
 
-function updateGitignore(): void {
+/** Exported for tests; call sites go through `installSkills`. */
+export function updateGitignore(): void {
   const gitignorePath = join(process.cwd(), '.gitignore');
   const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : '';
   const lines = new Set(existing.split('\n').map((l) => l.trim()));
 
   const missing = GITIGNORE_ENTRIES.filter((entry) => !lines.has(entry));
-  if (!missing.length) return;
+  if (missing.length) {
+    const block = `\n# InsForge & AI agent skills\n${missing.join('\n')}\n`;
+    appendFileSync(gitignorePath, block);
+  }
 
-  const block = `\n# InsForge & AI agent skills\n${missing.join('\n')}\n`;
-  appendFileSync(gitignorePath, block);
+  // `create` seeds .env.local with the project URL and anon key, and the
+  // AGENTS.md we write next tells app code to read its keys from there — so it
+  // needs the same protection `ai setup` already gives it. Shared helper rather
+  // than a GITIGNORE_ENTRIES entry: it knows the existing patterns that already
+  // cover the file, which the exact-match filter above does not. Runs even when
+  // every agent entry is present, since those are unrelated to the env file.
+  ensureLocalEnvIgnored(process.cwd(), '.env.local');
 }
 
 // Agents that the `npx skills add -a <agent>` CLI knows how to target. Kept


### PR DESCRIPTION
Closes #289.

`ai setup` already gitignores `.env.local` through `ensureLocalEnvIgnored()`. `link` and `create` write credentials to the same file and never call it. This routes them through the same helper instead of adding a second implementation.

### What changed

`ensureLocalEnvIgnored` and its `isLocalEnvFile` companion move from `src/commands/ai/setup.ts` into `src/lib/env-writer.ts`, next to `upsertEnvFile`. That pairs the two halves of the same job: `upsertEnvFile` writes the secret, `ensureLocalEnvIgnored` keeps it out of git.

The move is what makes the reuse possible. `src/lib/` imports from `src/commands/` nowhere in the tree today, so calling the helper from `skills.ts` at its old address would have inverted the layering. `setup.ts` imports it from the new location and re-exports it, so `./setup.js` stays a valid import path and `setup.test.ts` needs no changes.

`updateGitignore()` in `src/lib/skills.ts` then calls `ensureLocalEnvIgnored(process.cwd(), '.env.local')` after its existing `GITIGNORE_ENTRIES` append. Two details there, both easy to get wrong:

- The early `return` when no agent entries are missing became an `if` block. Without that, a project that already had all thirteen agent directories in `.gitignore` would skip the env check entirely, which is exactly the repeat-`link` case.
- The two writes stay separate, under their own headers (`# InsForge & AI agent skills` and `# Local environment secrets`). That matches what a user who runs both `link` and `ai setup` already ends up with today.

`updateGitignore` is now exported. It was internal, and the behavior above is worth testing directly rather than through `installSkills`, which shells out to `npx`.

### Why reuse instead of adding entries to `GITIGNORE_ENTRIES`

Adding `.env.local` to that array looked like the one-line version, and it is worse in two ways. `updateGitignore` matches with `lines.has(entry)`, an exact match on trimmed lines, so a project whose `.gitignore` already says `.env*` or `.env.*` would get a redundant `.env.local` appended. And it would leave two different answers in the tree to the same question. `ensureLocalEnvIgnored` already checks `.env*`, `.env.*`, `.env*.local`, and `.env.local` before writing, and already refuses paths that resolve outside `cwd`.

### Scope

Only `.env*.local`, which is what the helper already writes and what this CLI actually creates. Bare `.env` is left alone: some projects commit a non-secret one deliberately, and that call belongs to you rather than to this PR. Say the word if you want it included and I will add it here.

### Tests

`npm run lint` passes: 830 tests, eslint clean, and `npm run build` succeeds.

The existing `ensureLocalEnvIgnored` coverage in `src/commands/ai/setup.test.ts` is untouched and still passing, which is the signal that the move is behavior-preserving. Four cases added to `src/lib/skills.test.ts` cover the new path:

- `.env.local` is ignored alongside the agent directories
- no second env pattern is added when `.env*` already covers the file
- `.env.local` is still ignored when every agent entry is already present, the case the early `return` used to swallow
- repeated runs are idempotent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #289. `link` and `create` write credentials to `.env.local` but never gitignore it, unlike `ai setup`. This routes them through the same `ensureLocalEnvIgnored` helper so the file stays out of git.

- Moves `ensureLocalEnvIgnored` and `isLocalEnvFile` to `src/lib/env-writer.ts`, next to the writer that creates the file; `setup.ts` re-exports them to keep imports valid.
- `updateGitignore()` now calls the helper after appending agent entries, and its early return became an `if` so the env check runs even when all agent entries are already present — the repeat-`link` case.
- Reuses the helper instead of adding `.env.local` to the entries list: the exact-match check would append a redundant entry when `.env*` or `.env.*` already covers it.
- Leaves bare `.env` alone; only `.env*.local` files are handled.
- Exports `updateGitignore` so the behavior is testable directly; tests verify the ignore rule, dedup, idempotency, and the all-agent-entries-present case.

<sup>Written for commit 3e5f1c81b7e04646a4ad82948d0bbfbf89be4b2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local environment files are now consistently protected from accidental Git commits.
  * Gitignore updates remain safe to run repeatedly without creating duplicate entries.
  * Environment-file protections are added even when other required Gitignore entries already exist.

* **Tests**
  * Added coverage for Gitignore updates, including existing entries, missing entries, and repeated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->