### PR TITLE
Fix(#297) : Enhance project creation with recovery tests and error handling

### DIFF
--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -3,7 +3,6 @@ import { CLIError } from '../lib/errors.js';
 
 vi.mock('../lib/api/platform.js', () => ({
   listOrganizations: vi.fn(),
-  listProjects: vi.fn(),
   createProject: vi.fn(),
   getProject: vi.fn(),
   getProjectApiKey: vi.fn(),
@@ -11,7 +10,7 @@ vi.mock('../lib/api/platform.js', () => ({
 }));
 
 import {
-  createProjectOrAdopt,
+  createProjectOrReportAmbiguousResult,
   isAmbiguousProjectCreateFailure,
   waitForProjectActive,
 } from './create.js';
@@ -35,59 +34,21 @@ describe('create project recovery', () => {
     vi.clearAllMocks();
     const platform = await import('../lib/api/platform.js');
     (platform.createProject as Mock).mockResolvedValue(createdProject);
-    (platform.listProjects as Mock).mockResolvedValue([]);
     (platform.getProject as Mock).mockResolvedValue({ ...createdProject, status: 'active' });
   });
 
-  it('adopts a project created despite a gateway 502', async () => {
+  it('reports an unknown result after a gateway failure without adopting a project', async () => {
     const platform = await import('../lib/api/platform.js');
     (platform.createProject as Mock).mockRejectedValueOnce(
       new CLIError('Request failed: 502', 1, undefined, 502),
     );
-    (platform.listProjects as Mock).mockResolvedValueOnce([createdProject]);
 
-    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
-      .resolves.toEqual(createdProject);
-    expect(platform.listProjects).toHaveBeenCalledWith('org-id', undefined);
-  });
-
-  it('does not adopt an older or differently-regioned project', async () => {
-    const platform = await import('../lib/api/platform.js');
-    const failure = new CLIError('Request failed: 502', 1, undefined, 502);
-    (platform.createProject as Mock).mockRejectedValueOnce(failure);
-    (platform.listProjects as Mock).mockResolvedValueOnce([
-      { ...createdProject, created_at: '2020-01-01T00:00:00.000Z' },
-      { ...createdProject, id: 'other-project', region: 'us-east' },
-    ]);
-
-    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
-      .rejects.toBe(failure);
-  });
-
-  it('does not guess when multiple matching projects were created in the recovery window', async () => {
-    const platform = await import('../lib/api/platform.js');
-    const failure = new CLIError('Request failed: 502', 1, undefined, 502);
-    (platform.createProject as Mock).mockRejectedValueOnce(failure);
-    (platform.listProjects as Mock).mockResolvedValueOnce([
-      createdProject,
-      { ...createdProject, id: 'other-project' },
-    ]);
-
-    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
-      .rejects.toBe(failure);
-  });
-
-  it('does not adopt a same-named project when the requested region is unknown', async () => {
-    const platform = await import('../lib/api/platform.js');
-    const failure = new CLIError('Request failed: 502', 1, undefined, 502);
-    (platform.createProject as Mock).mockRejectedValueOnce(failure);
-    (platform.listProjects as Mock).mockResolvedValueOnce([
-      { ...createdProject, created_at: new Date(Date.now() - 30_000).toISOString() },
-    ]);
-
-    await expect(createProjectOrAdopt('org-id', 'demo', undefined, undefined))
-      .rejects.toBe(failure);
-    expect(platform.listProjects).not.toHaveBeenCalled();
+    await expect(createProjectOrReportAmbiguousResult('org-id', 'demo', 'eu-central', undefined))
+      .rejects.toMatchObject({
+        code: 'PROJECT_CREATE_RESULT_UNKNOWN',
+        statusCode: 502,
+        message: expect.stringContaining('insforge list --json'),
+      });
   });
 
   it('never reconciles an ordinary API 500', async () => {
@@ -95,9 +56,8 @@ describe('create project recovery', () => {
     const failure = new CLIError('Internal server error', 1, undefined, 500);
     (platform.createProject as Mock).mockRejectedValueOnce(failure);
 
-    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
+    await expect(createProjectOrReportAmbiguousResult('org-id', 'demo', 'eu-central', undefined))
       .rejects.toBe(failure);
-    expect(platform.listProjects).not.toHaveBeenCalled();
   });
 
   it('recognizes only gateway and transport failures as ambiguous', () => {
@@ -121,5 +81,24 @@ describe('create project recovery', () => {
       vi.useRealTimers();
     }
     expect(platform.getProject).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves an actionable error after three consecutive transient activation-read failures', async () => {
+    const platform = await import('../lib/api/platform.js');
+    (platform.getProject as Mock).mockRejectedValue(
+      new CLIError('Request failed: 502', 1, undefined, 502),
+    );
+    vi.useFakeTimers();
+    try {
+      const expected = expect(waitForProjectActive('project-id')).rejects.toMatchObject({
+        message: expect.stringContaining('after 3 transient control-plane failures'),
+        statusCode: 502,
+      });
+      await vi.runAllTimersAsync();
+      await expected;
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(platform.getProject).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -72,9 +72,22 @@ describe('create project recovery', () => {
       'org-id', 'demo', 'eu-central', 'https://platform.example.test',
     )).rejects.toMatchObject({
       message: expect.stringContaining(
-        'npx @insforge/cli --api-url "https://platform.example.test" list --json',
+        "npx @insforge/cli --api-url 'https://platform.example.test' list --json",
       ),
     });
+  });
+
+  it('prevents shell expansion in a custom endpoint', async () => {
+    const platform = await import('../lib/api/platform.js');
+    (platform.createProject as Mock).mockRejectedValueOnce(
+      new CLIError('Request failed: 502', 1, undefined, 502),
+    );
+    const apiUrl = 'https://platform.example.test/$(whoami)`touch-pwned`';
+
+    await expect(createProjectOrReportAmbiguousResult('org-id', 'demo', 'eu-central', apiUrl))
+      .rejects.toMatchObject({
+        message: expect.stringContaining(`--api-url '${apiUrl}'`),
+      });
   });
 
   it('never reconciles an ordinary API 500', async () => {

--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
-import { CLIError } from '../lib/errors.js';
+import { CLIError, isTransientApiError } from '../lib/errors.js';
 
 vi.mock('../lib/api/platform.js', () => ({
   listOrganizations: vi.fn(),
@@ -92,12 +92,16 @@ describe('create project recovery', () => {
     );
     vi.useFakeTimers();
     try {
-      const expected = expect(waitForProjectActive('project-id', undefined, 10_000)).rejects.toMatchObject({
-        message: expect.stringContaining('Last control-plane error: Request failed: 502'),
-        statusCode: 502,
-      });
+      const pending = waitForProjectActive('project-id', undefined, 10_000)
+        .catch(err => err as CLIError);
       await vi.runAllTimersAsync();
-      await expected;
+      const timeout = await pending;
+      expect(timeout).toMatchObject({
+        code: 'PROJECT_ACTIVATION_TIMEOUT',
+        message: expect.stringContaining('Last control-plane error: Request failed: 502'),
+      });
+      expect(timeout.statusCode).toBeUndefined();
+      expect(isTransientApiError(timeout)).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -72,7 +72,7 @@ describe('create project recovery', () => {
       'org-id', 'demo', 'eu-central', 'https://platform.example.test',
     )).rejects.toMatchObject({
       message: expect.stringContaining(
-        'npx @insforge/cli --api-url <the exact API URL used for create> list --json',
+        'npx @insforge/cli --api-url YOUR_API_URL list --json',
       ),
     });
   });
@@ -88,8 +88,9 @@ describe('create project recovery', () => {
       .catch(err => err as CLIError);
 
     expect(error.message).toContain(
-      'npx @insforge/cli --api-url <the exact API URL used for create> list --json',
+      'npx @insforge/cli --api-url YOUR_API_URL list --json',
     );
+    expect(error.message).toContain('replacing `YOUR_API_URL` with the exact value used for creation');
     expect(error.message).not.toContain(apiUrl);
   });
 

--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -47,8 +47,34 @@ describe('create project recovery', () => {
       .rejects.toMatchObject({
         code: 'PROJECT_CREATE_RESULT_UNKNOWN',
         statusCode: 502,
-        message: expect.stringContaining('insforge list --json'),
+        message: expect.stringContaining('npx @insforge/cli list --json'),
       });
+  });
+
+  it('reports an unknown result when the create response cannot be decoded', async () => {
+    const platform = await import('../lib/api/platform.js');
+    (platform.createProject as Mock).mockRejectedValueOnce(new SyntaxError('Unexpected end of JSON input'));
+
+    await expect(createProjectOrReportAmbiguousResult('org-id', 'demo', 'eu-central', undefined))
+      .rejects.toMatchObject({
+        code: 'PROJECT_CREATE_RESULT_UNKNOWN',
+        message: expect.stringContaining('npx @insforge/cli list --json'),
+      });
+  });
+
+  it('keeps a one-off Platform endpoint in the recovery command', async () => {
+    const platform = await import('../lib/api/platform.js');
+    (platform.createProject as Mock).mockRejectedValueOnce(
+      new CLIError('Request failed: 502', 1, undefined, 502),
+    );
+
+    await expect(createProjectOrReportAmbiguousResult(
+      'org-id', 'demo', 'eu-central', 'https://platform.example.test',
+    )).rejects.toMatchObject({
+      message: expect.stringContaining(
+        'npx @insforge/cli --api-url "https://platform.example.test" list --json',
+      ),
+    });
   });
 
   it('never reconciles an ordinary API 500', async () => {
@@ -65,6 +91,7 @@ describe('create project recovery', () => {
     expect(isAmbiguousProjectCreateFailure(new CLIError('gateway', 1, undefined, 503))).toBe(true);
     expect(isAmbiguousProjectCreateFailure(new CLIError('invalid request', 1, undefined, 400))).toBe(false);
     expect(isAmbiguousProjectCreateFailure(new CLIError('server error', 1, undefined, 500))).toBe(false);
+    expect(isAmbiguousProjectCreateFailure(new SyntaxError('Unexpected end of JSON input'))).toBe(true);
   });
 
   it('continues polling through three transient activation-read failures when the project recovers', async () => {
@@ -92,6 +119,7 @@ describe('create project recovery', () => {
     );
     vi.useFakeTimers();
     try {
+      const startedAt = Date.now();
       const pending = waitForProjectActive('project-id', undefined, 10_000)
         .catch(err => err as CLIError);
       await vi.runAllTimersAsync();
@@ -102,9 +130,36 @@ describe('create project recovery', () => {
       });
       expect(timeout.statusCode).toBeUndefined();
       expect(isTransientApiError(timeout)).toBe(false);
+      expect(Date.now() - startedAt).toBe(10_000);
     } finally {
       vi.useRealTimers();
     }
     expect(platform.getProject).toHaveBeenCalledTimes(4);
+  });
+
+  it('aborts an in-flight status request at the activation deadline', async () => {
+    const platform = await import('../lib/api/platform.js');
+    let requestSignal: AbortSignal | undefined;
+    (platform.getProject as Mock).mockImplementation(
+      (_projectId: string, _apiUrl: string | undefined, signal: AbortSignal) => new Promise((_, reject) => {
+        requestSignal = signal;
+        signal.addEventListener('abort', () => {
+          reject(new CLIError('Request aborted', 1, 'NETWORK_ERROR'));
+        });
+      }),
+    );
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.now();
+      const pending = waitForProjectActive('project-id', undefined, 10_000)
+        .catch(err => err as CLIError);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const timeout = await pending;
+      expect(timeout.code).toBe('PROJECT_ACTIVATION_TIMEOUT');
+      expect(requestSignal?.aborted).toBe(true);
+      expect(Date.now() - startedAt).toBe(10_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { CLIError } from '../lib/errors.js';
+
+vi.mock('../lib/api/platform.js', () => ({
+  listOrganizations: vi.fn(),
+  listProjects: vi.fn(),
+  createProject: vi.fn(),
+  getProject: vi.fn(),
+  getProjectApiKey: vi.fn(),
+  NETWORK_ERROR_CODE: 'NETWORK_ERROR',
+}));
+
+import {
+  createProjectOrAdopt,
+  isAmbiguousProjectCreateFailure,
+  waitForProjectActive,
+} from './create.js';
+
+const createdProject = {
+  id: 'project-id',
+  organization_id: 'org-id',
+  name: 'demo',
+  appkey: 'demo-appkey',
+  region: 'eu-central',
+  status: 'creating',
+  instance_type: 'shared',
+  service_version: null,
+  customized_domain: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+describe('create project recovery', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const platform = await import('../lib/api/platform.js');
+    (platform.createProject as Mock).mockResolvedValue(createdProject);
+    (platform.listProjects as Mock).mockResolvedValue([]);
+    (platform.getProject as Mock).mockResolvedValue({ ...createdProject, status: 'active' });
+  });
+
+  it('adopts a project created despite a gateway 502', async () => {
+    const platform = await import('../lib/api/platform.js');
+    (platform.createProject as Mock).mockRejectedValueOnce(
+      new CLIError('Request failed: 502', 1, undefined, 502),
+    );
+    (platform.listProjects as Mock).mockResolvedValueOnce([createdProject]);
+
+    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
+      .resolves.toEqual(createdProject);
+    expect(platform.listProjects).toHaveBeenCalledWith('org-id', undefined);
+  });
+
+  it('does not adopt an older or differently-regioned project', async () => {
+    const platform = await import('../lib/api/platform.js');
+    const failure = new CLIError('Request failed: 502', 1, undefined, 502);
+    (platform.createProject as Mock).mockRejectedValueOnce(failure);
+    (platform.listProjects as Mock).mockResolvedValueOnce([
+      { ...createdProject, created_at: '2020-01-01T00:00:00.000Z' },
+      { ...createdProject, id: 'other-project', region: 'us-east' },
+    ]);
+
+    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
+      .rejects.toBe(failure);
+  });
+
+  it('does not guess when multiple matching projects were created in the recovery window', async () => {
+    const platform = await import('../lib/api/platform.js');
+    const failure = new CLIError('Request failed: 502', 1, undefined, 502);
+    (platform.createProject as Mock).mockRejectedValueOnce(failure);
+    (platform.listProjects as Mock).mockResolvedValueOnce([
+      createdProject,
+      { ...createdProject, id: 'other-project' },
+    ]);
+
+    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
+      .rejects.toBe(failure);
+  });
+
+  it('does not adopt a same-named project when the requested region is unknown', async () => {
+    const platform = await import('../lib/api/platform.js');
+    const failure = new CLIError('Request failed: 502', 1, undefined, 502);
+    (platform.createProject as Mock).mockRejectedValueOnce(failure);
+    (platform.listProjects as Mock).mockResolvedValueOnce([
+      { ...createdProject, created_at: new Date(Date.now() - 30_000).toISOString() },
+    ]);
+
+    await expect(createProjectOrAdopt('org-id', 'demo', undefined, undefined))
+      .rejects.toBe(failure);
+    expect(platform.listProjects).not.toHaveBeenCalled();
+  });
+
+  it('never reconciles an ordinary API 500', async () => {
+    const platform = await import('../lib/api/platform.js');
+    const failure = new CLIError('Internal server error', 1, undefined, 500);
+    (platform.createProject as Mock).mockRejectedValueOnce(failure);
+
+    await expect(createProjectOrAdopt('org-id', 'demo', 'eu-central', undefined))
+      .rejects.toBe(failure);
+    expect(platform.listProjects).not.toHaveBeenCalled();
+  });
+
+  it('recognizes only gateway and transport failures as ambiguous', () => {
+    expect(isAmbiguousProjectCreateFailure(new CLIError('network', 1, 'NETWORK_ERROR'))).toBe(true);
+    expect(isAmbiguousProjectCreateFailure(new CLIError('gateway', 1, undefined, 503))).toBe(true);
+    expect(isAmbiguousProjectCreateFailure(new CLIError('invalid request', 1, undefined, 400))).toBe(false);
+    expect(isAmbiguousProjectCreateFailure(new CLIError('server error', 1, undefined, 500))).toBe(false);
+  });
+
+  it('continues polling after a transient activation-read failure', async () => {
+    const platform = await import('../lib/api/platform.js');
+    (platform.getProject as Mock)
+      .mockRejectedValueOnce(new CLIError('Request failed: 502', 1, undefined, 502))
+      .mockResolvedValueOnce({ ...createdProject, status: 'active' });
+    vi.useFakeTimers();
+    try {
+      const pending = waitForProjectActive('project-id');
+      await vi.runAllTimersAsync();
+      await expect(pending).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(platform.getProject).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -67,9 +67,11 @@ describe('create project recovery', () => {
     expect(isAmbiguousProjectCreateFailure(new CLIError('server error', 1, undefined, 500))).toBe(false);
   });
 
-  it('continues polling after a transient activation-read failure', async () => {
+  it('continues polling through three transient activation-read failures when the project recovers', async () => {
     const platform = await import('../lib/api/platform.js');
     (platform.getProject as Mock)
+      .mockRejectedValueOnce(new CLIError('Request failed: 502', 1, undefined, 502))
+      .mockRejectedValueOnce(new CLIError('Request failed: 502', 1, undefined, 502))
       .mockRejectedValueOnce(new CLIError('Request failed: 502', 1, undefined, 502))
       .mockResolvedValueOnce({ ...createdProject, status: 'active' });
     vi.useFakeTimers();
@@ -80,18 +82,18 @@ describe('create project recovery', () => {
     } finally {
       vi.useRealTimers();
     }
-    expect(platform.getProject).toHaveBeenCalledTimes(2);
+    expect(platform.getProject).toHaveBeenCalledTimes(4);
   });
 
-  it('preserves an actionable error after three consecutive transient activation-read failures', async () => {
+  it('preserves the last actionable error when the activation deadline expires', async () => {
     const platform = await import('../lib/api/platform.js');
     (platform.getProject as Mock).mockRejectedValue(
       new CLIError('Request failed: 502', 1, undefined, 502),
     );
     vi.useFakeTimers();
     try {
-      const expected = expect(waitForProjectActive('project-id')).rejects.toMatchObject({
-        message: expect.stringContaining('after 3 transient control-plane failures'),
+      const expected = expect(waitForProjectActive('project-id', undefined, 10_000)).rejects.toMatchObject({
+        message: expect.stringContaining('Last control-plane error: Request failed: 502'),
         statusCode: 502,
       });
       await vi.runAllTimersAsync();
@@ -99,6 +101,6 @@ describe('create project recovery', () => {
     } finally {
       vi.useRealTimers();
     }
-    expect(platform.getProject).toHaveBeenCalledTimes(3);
+    expect(platform.getProject).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/commands/create.recovery.test.ts
+++ b/src/commands/create.recovery.test.ts
@@ -72,7 +72,7 @@ describe('create project recovery', () => {
       'org-id', 'demo', 'eu-central', 'https://platform.example.test',
     )).rejects.toMatchObject({
       message: expect.stringContaining(
-        "npx @insforge/cli --api-url 'https://platform.example.test' list --json",
+        'npx @insforge/cli --api-url <the exact API URL used for create> list --json',
       ),
     });
   });
@@ -84,10 +84,13 @@ describe('create project recovery', () => {
     );
     const apiUrl = 'https://platform.example.test/$(whoami)`touch-pwned`';
 
-    await expect(createProjectOrReportAmbiguousResult('org-id', 'demo', 'eu-central', apiUrl))
-      .rejects.toMatchObject({
-        message: expect.stringContaining(`--api-url '${apiUrl}'`),
-      });
+    const error = await createProjectOrReportAmbiguousResult('org-id', 'demo', 'eu-central', apiUrl)
+      .catch(err => err as CLIError);
+
+    expect(error.message).toContain(
+      'npx @insforge/cli --api-url <the exact API URL used for create> list --json',
+    );
+    expect(error.message).not.toContain(apiUrl);
   });
 
   it('never reconciles an ordinary API 500', async () => {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -8,7 +8,6 @@ import * as clack from '@clack/prompts';
 import * as prompts from '../lib/prompts.js';
 import {
   listOrganizations,
-  listProjects,
   createProject,
   getProject,
   getProjectApiKey,
@@ -24,7 +23,7 @@ import { readEnvFile } from '../lib/env.js';
 import { installSkills, reportCliUsage } from '../lib/skills.js';
 import { captureEvent, trackCommand, shutdownAnalytics } from '../lib/analytics.js';
 import { deployProject } from './deployments/deploy.js';
-import type { Project, ProjectConfig } from '../types.js';
+import type { ProjectConfig } from '../types.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -41,16 +40,12 @@ export type Framework = 'react' | 'nextjs';
 
 const PROJECT_POLL_INTERVAL_MS = 3_000;
 const PROJECT_POLL_TIMEOUT_MS = 120_000;
+const MAX_CONSECUTIVE_TRANSIENT_PROJECT_READ_ERRORS = 3;
 const PROXY_STATUSES = new Set([502, 503, 504]);
-// Platform timestamps may be rounded more coarsely than the client clock. A
-// short window avoids rejecting the project we just created for that reason;
-// ambiguity inside the window is rejected below instead of guessed at.
-const CREATED_AT_SKEW_MS = 60_000;
 
 /**
  * Wait for project provisioning without mistaking a transient control-plane
- * read failure for a failed creation. The POST response can also be lost; that
- * case is handled by createProjectOrAdopt below.
+ * read failure for a failed creation.
  */
 export async function waitForProjectActive(
   projectId: string,
@@ -58,12 +53,27 @@ export async function waitForProjectActive(
   timeoutMs = PROJECT_POLL_TIMEOUT_MS,
 ): Promise<void> {
   const start = Date.now();
+  let consecutiveTransientErrors = 0;
   while (Date.now() - start < timeoutMs) {
     try {
       const project = await getProject(projectId, apiUrl);
+      consecutiveTransientErrors = 0;
       if (project.status === 'active') return;
     } catch (err) {
       if (!isTransientApiError(err)) throw err;
+      consecutiveTransientErrors += 1;
+      if (consecutiveTransientErrors >= MAX_CONSECUTIVE_TRANSIENT_PROJECT_READ_ERRORS) {
+        // isTransientApiError only accepts CLIError instances. Retain its
+        // status/code so a persistent rate limit or gateway failure remains
+        // actionable instead of degrading into a generic timeout.
+        const apiError = err as CLIError;
+        throw new CLIError(
+          `Could not confirm project activation after ${consecutiveTransientErrors} transient control-plane failures: ${apiError.message}`,
+          apiError.exitCode,
+          apiError.code,
+          apiError.statusCode,
+        );
+      }
     }
     await new Promise((r) => setTimeout(r, PROJECT_POLL_INTERVAL_MS));
   }
@@ -78,40 +88,29 @@ export function isAmbiguousProjectCreateFailure(err: unknown): boolean {
 }
 
 /**
- * Find only a project that could have been created by the immediately prior
- * request. Recovery requires an explicit region: without it, a same-named
- * project created by another organization member inside the clock-skew window
- * is indistinguishable from ours. This mirrors branch create's lost-response
- * recovery safeguards.
+ * A gateway or transport failure can arrive after the platform accepted the
+ * POST. The create-project API exposes no request correlation or idempotency
+ * key, so a later project-list result cannot prove ownership. Never adopt a
+ * name/time match: that could attach the caller to a collaborator's project.
  */
-export async function createProjectOrAdopt(
+export async function createProjectOrReportAmbiguousResult(
   orgId: string,
   name: string,
   region: string | undefined,
   apiUrl: string | undefined,
-): Promise<Project> {
-  const requestedAt = Date.now();
+): Promise<Awaited<ReturnType<typeof createProject>>> {
   try {
     return await createProject(orgId, name, region, apiUrl);
   } catch (err) {
     if (!isAmbiguousProjectCreateFailure(err)) throw err;
-    if (!region) throw err;
-
-    const existing = await listProjects(orgId, apiUrl)
-      .then(projects => {
-        const candidates = projects.filter(project =>
-          project.name === name &&
-          project.region === region &&
-          Date.parse(project.created_at) >= requestedAt - CREATED_AT_SKEW_MS,
-        );
-        // A concurrent matching create is indistinguishable from ours. Do not
-        // risk adopting another project's credentials or billing resource.
-        return candidates.length === 1 ? candidates[0] : undefined;
-      })
-      .catch(() => undefined);
-
-    if (!existing) throw err;
-    return existing;
+    const apiError = err as CLIError;
+    throw new CLIError(
+      'Project creation may have succeeded, but the platform did not return a result. ' +
+      'Run `insforge list --json` before retrying to avoid creating a duplicate project.',
+      apiError.exitCode,
+      'PROJECT_CREATE_RESULT_UNKNOWN',
+      apiError.statusCode,
+    );
   }
 }
 
@@ -416,7 +415,7 @@ export function registerCreateCommand(program: Command): void {
         try {
           s?.start('Creating project...');
 
-        const project = await createProjectOrAdopt(orgId, projectName, opts.region, apiUrl);
+        const project = await createProjectOrReportAmbiguousResult(orgId, projectName, opts.region, apiUrl);
 
         s?.message('Waiting for project to become active...');
         await waitForProjectActive(project.id, apiUrl);

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -40,7 +40,6 @@ export type Framework = 'react' | 'nextjs';
 
 const PROJECT_POLL_INTERVAL_MS = 3_000;
 const PROJECT_POLL_TIMEOUT_MS = 120_000;
-const MAX_CONSECUTIVE_TRANSIENT_PROJECT_READ_ERRORS = 3;
 const PROXY_STATUSES = new Set([502, 503, 504]);
 
 /**
@@ -53,29 +52,30 @@ export async function waitForProjectActive(
   timeoutMs = PROJECT_POLL_TIMEOUT_MS,
 ): Promise<void> {
   const start = Date.now();
-  let consecutiveTransientErrors = 0;
+  let lastTransientError: CLIError | undefined;
   while (Date.now() - start < timeoutMs) {
     try {
       const project = await getProject(projectId, apiUrl);
-      consecutiveTransientErrors = 0;
+      // A successful control-plane read means a previous transient error is
+      // no longer useful when explaining a later provisioning timeout.
+      lastTransientError = undefined;
       if (project.status === 'active') return;
     } catch (err) {
       if (!isTransientApiError(err)) throw err;
-      consecutiveTransientErrors += 1;
-      if (consecutiveTransientErrors >= MAX_CONSECUTIVE_TRANSIENT_PROJECT_READ_ERRORS) {
-        // isTransientApiError only accepts CLIError instances. Retain its
-        // status/code so a persistent rate limit or gateway failure remains
-        // actionable instead of degrading into a generic timeout.
-        const apiError = err as CLIError;
-        throw new CLIError(
-          `Could not confirm project activation after ${consecutiveTransientErrors} transient control-plane failures: ${apiError.message}`,
-          apiError.exitCode,
-          apiError.code,
-          apiError.statusCode,
-        );
-      }
+      // Keep polling through the configured deadline: a temporary control
+      // plane outage must not turn into an early create failure. If it never
+      // recovers, preserve the last classified API error at the deadline.
+      lastTransientError = err as CLIError;
     }
     await new Promise((r) => setTimeout(r, PROJECT_POLL_INTERVAL_MS));
+  }
+  if (lastTransientError) {
+    throw new CLIError(
+      `Project activation timed out. Last control-plane error: ${lastTransientError.message}`,
+      lastTransientError.exitCode,
+      lastTransientError.code,
+      lastTransientError.statusCode,
+    );
   }
   throw new CLIError('Project creation timed out. Check the dashboard for status.');
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -128,9 +128,12 @@ export async function createProjectOrReportAmbiguousResult(
   } catch (err) {
     if (!isAmbiguousProjectCreateFailure(err)) throw err;
     const apiError = err instanceof CLIError ? err : undefined;
+    const apiUrlReplacement = apiUrl
+      ? ', replacing `YOUR_API_URL` with the exact value used for creation'
+      : '';
     throw new CLIError(
       'Project creation may have succeeded, but the platform did not return a result. ' +
-      `Run \`${getProjectVerificationCommand(apiUrl)}\` before retrying to avoid creating a duplicate project.`,
+      `Run \`${getProjectVerificationCommand(apiUrl)}\`${apiUrlReplacement} before retrying to avoid creating a duplicate project.`,
       apiError?.exitCode ?? 1,
       'PROJECT_CREATE_RESULT_UNKNOWN',
       apiError?.statusCode,
@@ -139,7 +142,7 @@ export async function createProjectOrReportAmbiguousResult(
 }
 
 function getProjectVerificationCommand(apiUrl?: string): string {
-  const apiUrlArg = apiUrl ? ' --api-url <the exact API URL used for create>' : '';
+  const apiUrlArg = apiUrl ? ' --api-url YOUR_API_URL' : '';
   return `npx @insforge/cli${apiUrlArg} list --json`;
 }
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -51,23 +51,41 @@ export async function waitForProjectActive(
   apiUrl?: string,
   timeoutMs = PROJECT_POLL_TIMEOUT_MS,
 ): Promise<void> {
-  const start = Date.now();
+  const deadline = Date.now() + timeoutMs;
   let lastTransientError: CLIError | undefined;
-  while (Date.now() - start < timeoutMs) {
+  while (true) {
+    const remainingBeforeRequest = deadline - Date.now();
+    if (remainingBeforeRequest <= 0) break;
+
+    const controller = new AbortController();
+    let requestTimedOut = false;
+    const abortTimer = setTimeout(() => {
+      requestTimedOut = true;
+      controller.abort();
+    }, remainingBeforeRequest);
     try {
-      const project = await getProject(projectId, apiUrl);
+      const project = await getProject(projectId, apiUrl, controller.signal);
+      // A request that completes after the deadline cannot establish that the
+      // project became active within the configured activation window.
+      if (Date.now() >= deadline) break;
       // A successful control-plane read means a previous transient error is
       // no longer useful when explaining a later provisioning timeout.
       lastTransientError = undefined;
       if (project.status === 'active') return;
     } catch (err) {
+      if (requestTimedOut || Date.now() >= deadline) break;
       if (!isTransientApiError(err)) throw err;
       // Keep polling through the configured deadline: a temporary control
       // plane outage must not turn into an early create failure. If it never
       // recovers, preserve the last classified API error at the deadline.
       lastTransientError = err as CLIError;
+    } finally {
+      clearTimeout(abortTimer);
     }
-    await new Promise((r) => setTimeout(r, PROJECT_POLL_INTERVAL_MS));
+
+    const remainingBeforeSleep = deadline - Date.now();
+    if (remainingBeforeSleep <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(PROJECT_POLL_INTERVAL_MS, remainingBeforeSleep)));
   }
   if (lastTransientError) {
     throw new CLIError(
@@ -76,11 +94,18 @@ export async function waitForProjectActive(
       'PROJECT_ACTIVATION_TIMEOUT',
     );
   }
-  throw new CLIError('Project creation timed out. Check the dashboard for status.');
+  throw new CLIError(
+    'Project activation timed out. Check the dashboard for status.',
+    1,
+    'PROJECT_ACTIVATION_TIMEOUT',
+  );
 }
 
 /** A 502/503/504 or a lost transport response says nothing reliable about the POST outcome. */
 export function isAmbiguousProjectCreateFailure(err: unknown): boolean {
+  // createProject parses the response after a POST. A malformed body means
+  // the server may have created the project even though no result reached us.
+  if (err instanceof SyntaxError) return true;
   if (!(err instanceof CLIError)) return false;
   return err.code === NETWORK_ERROR_CODE ||
     (err.statusCode !== undefined && PROXY_STATUSES.has(err.statusCode));
@@ -102,15 +127,23 @@ export async function createProjectOrReportAmbiguousResult(
     return await createProject(orgId, name, region, apiUrl);
   } catch (err) {
     if (!isAmbiguousProjectCreateFailure(err)) throw err;
-    const apiError = err as CLIError;
+    const apiError = err instanceof CLIError ? err : undefined;
     throw new CLIError(
       'Project creation may have succeeded, but the platform did not return a result. ' +
-      'Run `insforge list --json` before retrying to avoid creating a duplicate project.',
-      apiError.exitCode,
+      `Run \`${getProjectVerificationCommand(apiUrl)}\` before retrying to avoid creating a duplicate project.`,
+      apiError?.exitCode ?? 1,
       'PROJECT_CREATE_RESULT_UNKNOWN',
-      apiError.statusCode,
+      apiError?.statusCode,
     );
   }
+}
+
+function getProjectVerificationCommand(apiUrl?: string): string {
+  // JSON string quoting is accepted by the supported shells for normal URLs
+  // and prevents a custom endpoint containing shell metacharacters from
+  // changing the suggested command.
+  const apiUrlArg = apiUrl ? ` --api-url ${JSON.stringify(apiUrl)}` : '';
+  return `npx @insforge/cli${apiUrlArg} list --json`;
 }
 
 const INSFORGE_BANNER = [

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -8,21 +8,23 @@ import * as clack from '@clack/prompts';
 import * as prompts from '../lib/prompts.js';
 import {
   listOrganizations,
+  listProjects,
   createProject,
   getProject,
   getProjectApiKey,
+  NETWORK_ERROR_CODE,
 } from '../lib/api/platform.js';
 import { getAnonKey, runRawSql } from '../lib/api/oss.js';
 import { applyAuthProvider, VALID_AUTH_PROVIDERS, type AuthProvider } from '../auth-providers/apply.js';
 import { getGlobalConfig, saveGlobalConfig, saveProjectConfig, getFrontendUrl, buildOssHost } from '../lib/config.js';
 import { requireAuth } from '../lib/credentials.js';
-import { handleError, getRootOpts, CLIError } from '../lib/errors.js';
+import { handleError, getRootOpts, CLIError, isTransientApiError } from '../lib/errors.js';
 import { outputJson } from '../lib/output.js';
 import { readEnvFile } from '../lib/env.js';
 import { installSkills, reportCliUsage } from '../lib/skills.js';
 import { captureEvent, trackCommand, shutdownAnalytics } from '../lib/analytics.js';
 import { deployProject } from './deployments/deploy.js';
-import type { ProjectConfig } from '../types.js';
+import type { Project, ProjectConfig } from '../types.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -37,14 +39,80 @@ const SAFE_MARKETPLACE_SLUG = /^[a-z0-9][a-z0-9-]{0,99}$/;
 
 export type Framework = 'react' | 'nextjs';
 
-async function waitForProjectActive(projectId: string, apiUrl?: string, timeoutMs = 120_000): Promise<void> {
+const PROJECT_POLL_INTERVAL_MS = 3_000;
+const PROJECT_POLL_TIMEOUT_MS = 120_000;
+const PROXY_STATUSES = new Set([502, 503, 504]);
+// Platform timestamps may be rounded more coarsely than the client clock. A
+// short window avoids rejecting the project we just created for that reason;
+// ambiguity inside the window is rejected below instead of guessed at.
+const CREATED_AT_SKEW_MS = 60_000;
+
+/**
+ * Wait for project provisioning without mistaking a transient control-plane
+ * read failure for a failed creation. The POST response can also be lost; that
+ * case is handled by createProjectOrAdopt below.
+ */
+export async function waitForProjectActive(
+  projectId: string,
+  apiUrl?: string,
+  timeoutMs = PROJECT_POLL_TIMEOUT_MS,
+): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const project = await getProject(projectId, apiUrl);
-    if (project.status === 'active') return;
-    await new Promise((r) => setTimeout(r, 3000));
+    try {
+      const project = await getProject(projectId, apiUrl);
+      if (project.status === 'active') return;
+    } catch (err) {
+      if (!isTransientApiError(err)) throw err;
+    }
+    await new Promise((r) => setTimeout(r, PROJECT_POLL_INTERVAL_MS));
   }
   throw new CLIError('Project creation timed out. Check the dashboard for status.');
+}
+
+/** A 502/503/504 or a lost transport response says nothing reliable about the POST outcome. */
+export function isAmbiguousProjectCreateFailure(err: unknown): boolean {
+  if (!(err instanceof CLIError)) return false;
+  return err.code === NETWORK_ERROR_CODE ||
+    (err.statusCode !== undefined && PROXY_STATUSES.has(err.statusCode));
+}
+
+/**
+ * Find only a project that could have been created by the immediately prior
+ * request. Recovery requires an explicit region: without it, a same-named
+ * project created by another organization member inside the clock-skew window
+ * is indistinguishable from ours. This mirrors branch create's lost-response
+ * recovery safeguards.
+ */
+export async function createProjectOrAdopt(
+  orgId: string,
+  name: string,
+  region: string | undefined,
+  apiUrl: string | undefined,
+): Promise<Project> {
+  const requestedAt = Date.now();
+  try {
+    return await createProject(orgId, name, region, apiUrl);
+  } catch (err) {
+    if (!isAmbiguousProjectCreateFailure(err)) throw err;
+    if (!region) throw err;
+
+    const existing = await listProjects(orgId, apiUrl)
+      .then(projects => {
+        const candidates = projects.filter(project =>
+          project.name === name &&
+          project.region === region &&
+          Date.parse(project.created_at) >= requestedAt - CREATED_AT_SKEW_MS,
+        );
+        // A concurrent matching create is indistinguishable from ours. Do not
+        // risk adopting another project's credentials or billing resource.
+        return candidates.length === 1 ? candidates[0] : undefined;
+      })
+      .catch(() => undefined);
+
+    if (!existing) throw err;
+    return existing;
+  }
 }
 
 const INSFORGE_BANNER = [
@@ -348,7 +416,7 @@ export function registerCreateCommand(program: Command): void {
         try {
           s?.start('Creating project...');
 
-        const project = await createProject(orgId, projectName, opts.region, apiUrl);
+        const project = await createProjectOrAdopt(orgId, projectName, opts.region, apiUrl);
 
         s?.message('Waiting for project to become active...');
         await waitForProjectActive(project.id, apiUrl);

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -72,9 +72,8 @@ export async function waitForProjectActive(
   if (lastTransientError) {
     throw new CLIError(
       `Project activation timed out. Last control-plane error: ${lastTransientError.message}`,
-      lastTransientError.exitCode,
-      lastTransientError.code,
-      lastTransientError.statusCode,
+      1,
+      'PROJECT_ACTIVATION_TIMEOUT',
     );
   }
   throw new CLIError('Project creation timed out. Check the dashboard for status.');

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -139,15 +139,8 @@ export async function createProjectOrReportAmbiguousResult(
 }
 
 function getProjectVerificationCommand(apiUrl?: string): string {
-  const apiUrlArg = apiUrl ? ` --api-url ${quoteForShell(apiUrl)}` : '';
+  const apiUrlArg = apiUrl ? ' --api-url <the exact API URL used for create>' : '';
   return `npx @insforge/cli${apiUrlArg} list --json`;
-}
-
-function quoteForShell(value: string): string {
-  // Both POSIX shells and PowerShell leave expansions disabled inside single
-  // quotes. The two shells escape an embedded quote differently.
-  if (process.platform === 'win32') return `'${value.replaceAll("'", "''")}'`;
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 const INSFORGE_BANNER = [

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -139,11 +139,15 @@ export async function createProjectOrReportAmbiguousResult(
 }
 
 function getProjectVerificationCommand(apiUrl?: string): string {
-  // JSON string quoting is accepted by the supported shells for normal URLs
-  // and prevents a custom endpoint containing shell metacharacters from
-  // changing the suggested command.
-  const apiUrlArg = apiUrl ? ` --api-url ${JSON.stringify(apiUrl)}` : '';
+  const apiUrlArg = apiUrl ? ` --api-url ${quoteForShell(apiUrl)}` : '';
   return `npx @insforge/cli${apiUrlArg} list --json`;
+}
+
+function quoteForShell(value: string): string {
+  // Both POSIX shells and PowerShell leave expansions disabled inside single
+  // quotes. The two shells escape an embedded quote differently.
+  if (process.platform === 'win32') return `'${value.replaceAll("'", "''")}'`;
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 const INSFORGE_BANNER = [

--- a/src/lib/api/platform.abort.test.ts
+++ b/src/lib/api/platform.abort.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configMock = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+  getCredentials: vi.fn(),
+  getPlatformApiUrl: vi.fn(),
+}));
+const credentialsMock = vi.hoisted(() => ({
+  refreshAccessToken: vi.fn(),
+}));
+
+vi.mock('../config.js', () => configMock);
+vi.mock('../credentials.js', () => credentialsMock);
+
+import { platformFetch } from './platform.js';
+
+describe('platformFetch cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configMock.getAccessToken.mockReturnValue('expired-token');
+    configMock.getPlatformApiUrl.mockReturnValue('https://platform.example.test');
+  });
+
+  it('passes the request signal to a 401 token refresh', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+    const controller = new AbortController();
+    credentialsMock.refreshAccessToken.mockImplementation(
+      (_apiUrl: string | undefined, signal: AbortSignal) => new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('Refresh aborted')));
+      }),
+    );
+
+    const pending = platformFetch('/projects/v1/project-id', { signal: controller.signal });
+    await vi.waitFor(() => expect(credentialsMock.refreshAccessToken).toHaveBeenCalledTimes(1));
+    controller.abort();
+
+    await expect(pending).rejects.toThrow('Refresh aborted');
+    expect(credentialsMock.refreshAccessToken).toHaveBeenCalledWith(undefined, controller.signal);
+  });
+});

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -192,8 +192,12 @@ export async function listProjects(orgId: string, apiUrl?: string): Promise<Proj
   return data.projects ?? (data as unknown as Project[]);
 }
 
-export async function getProject(projectId: string, apiUrl?: string): Promise<Project> {
-  const res = await platformFetch(`/projects/v1/${projectId}`, {}, apiUrl);
+export async function getProject(
+  projectId: string,
+  apiUrl?: string,
+  signal?: AbortSignal,
+): Promise<Project> {
+  const res = await platformFetch(`/projects/v1/${projectId}`, { signal }, apiUrl);
   const data = await res.json() as { project?: Project };
   return data.project ?? (data as unknown as Project);
 }

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -70,7 +70,7 @@ export async function platformFetch(
     // cleared) but a refresh token can mint one. Direct-API-key logins never
     // reach here — getAccessToken returns the uak_ itself.
     if (getCredentials()?.refresh_token) {
-      token = await refreshAccessToken(apiUrl);
+      token = await refreshAccessToken(apiUrl, fetchOptions.signal ?? undefined);
     }
   }
   if (!token) {
@@ -108,7 +108,7 @@ export async function platformFetch(
 
   // Auto-refresh on 401
   if (res.status === 401) {
-    const newToken = await refreshAccessToken(apiUrl);
+    const newToken = await refreshAccessToken(apiUrl, fetchOptions.signal ?? undefined);
     headers.Authorization = `Bearer ${newToken}`;
     let retryRes: Response;
     try {
@@ -170,8 +170,8 @@ export async function login(email: string, password: string, apiUrl?: string): P
   } as LoginResponse & { _refreshToken?: string };
 }
 
-export async function getProfile(apiUrl?: string): Promise<User> {
-  const res = await platformFetch('/auth/v1/profile', {}, apiUrl);
+export async function getProfile(apiUrl?: string, signal?: AbortSignal): Promise<User> {
+  const res = await platformFetch('/auth/v1/profile', { signal }, apiUrl);
   const data = await res.json() as { user?: User };
   return data.user ?? (data as unknown as User);
 }

--- a/src/lib/auth.abort.test.ts
+++ b/src/lib/auth.abort.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const httpMock = vi.hoisted(() => {
+  const state: { handler?: (req: { url?: string }, res: { writeHead: () => void; end: () => void }) => void } = {};
+  const server = {
+    listen: vi.fn((_port: number, _host: string, onListening: () => void) => onListening()),
+    address: vi.fn(() => ({ port: 4567 })),
+    close: vi.fn(),
+    closeAllConnections: vi.fn(),
+  };
+  return {
+    state,
+    server,
+    createServer: vi.fn((handler) => {
+      state.handler = handler;
+      return server;
+    }),
+  };
+});
+const configMock = vi.hoisted(() => ({
+  getGlobalConfig: vi.fn(),
+  getPlatformApiUrl: vi.fn(),
+  saveCredentials: vi.fn(),
+  getPendingDeviceLogin: vi.fn(),
+  savePendingDeviceLogin: vi.fn(),
+  clearPendingDeviceLogin: vi.fn(),
+}));
+const platformMock = vi.hoisted(() => ({ getProfile: vi.fn() }));
+const openMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:http', () => ({ createServer: httpMock.createServer }));
+vi.mock('./config.js', () => configMock);
+vi.mock('./api/platform.js', () => platformMock);
+vi.mock('open', () => ({ default: openMock }));
+
+import { performOAuthLogin, startCallbackServer } from './auth.js';
+
+describe('OAuth login cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configMock.getGlobalConfig.mockReturnValue({});
+    configMock.getPlatformApiUrl.mockReturnValue('https://platform.example.test');
+  });
+
+  it('cancels the callback timeout when the callback server is closed', async () => {
+    vi.useFakeTimers();
+    try {
+      const callback = await startCallbackServer();
+      const onRejection = vi.fn();
+      void callback.result.catch(onRejection);
+
+      callback.close();
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+
+      expect(onRejection).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates an abort that occurs while fetching the authenticated profile', async () => {
+    openMock.mockImplementation(async (authUrl: string) => {
+      const url = new URL(authUrl);
+      httpMock.state.handler!(
+        { url: `/callback?code=test-code&state=${url.searchParams.get('state')}` },
+        { writeHead: vi.fn(), end: vi.fn() },
+      );
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+    }), { status: 200 })));
+    const controller = new AbortController();
+    platformMock.getProfile.mockImplementation(
+      (_apiUrl: string | undefined, signal: AbortSignal) => new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('Profile request aborted')), { once: true });
+      }),
+    );
+
+    const pending = performOAuthLogin(undefined, controller.signal);
+    await vi.waitFor(() => expect(platformMock.getProfile).toHaveBeenCalledTimes(1));
+    controller.abort(new Error('Profile request aborted'));
+
+    await expect(pending).rejects.toThrow('Profile request aborted');
+  });
+});

--- a/src/lib/auth.abort.test.ts
+++ b/src/lib/auth.abort.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const httpMock = vi.hoisted(() => {
   const state: { handler?: (req: { url?: string }, res: { writeHead: () => void; end: () => void }) => void } = {};
@@ -40,6 +40,10 @@ describe('OAuth login cancellation', () => {
     vi.clearAllMocks();
     configMock.getGlobalConfig.mockReturnValue({});
     configMock.getPlatformApiUrl.mockReturnValue('https://platform.example.test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('cancels the callback timeout when the callback server is closed', async () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -216,20 +216,34 @@ export function startCallbackServer(): Promise<{
       }
     });
 
+    let closed = false;
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      clearTimeout(timeout);
+      server.close();
+      server.closeAllConnections();
+    };
+
+    // A callback can reject before performOAuthLogin starts awaiting it (for
+    // example, when opening the browser is cancelled). Mark it handled here
+    // so that path cannot produce an unhandled rejection.
+    void resultPromise.catch(() => {});
+
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address();
       const port = typeof addr === 'object' ? addr!.port : 0;
       resolveServer({
         port,
         result: resultPromise,
-        close: () => { server.close(); server.closeAllConnections(); },
+        close,
       });
     });
 
     // Timeout after 5 minutes (unref so it doesn't keep the process alive)
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       rejectResult!(new Error('Authentication timed out. Please try again.'));
-      server.close();
+      close();
     }, 5 * 60 * 1000).unref();
   });
 }
@@ -323,12 +337,14 @@ export async function performOAuthLogin(apiUrl?: string, signal?: AbortSignal): 
     saveCredentials(creds);
 
     try {
-      const profile = await getProfile(apiUrl, signal);
+      const profile = await waitForAbort(getProfile(apiUrl, signal), signal);
+      throwIfAborted(signal);
       creds.user = profile;
       saveCredentials(creds);
       s?.stop(`Authenticated as ${profile.email}`);
       if (!isInteractive) process.stderr.write(`Authenticated as ${profile.email}\n`);
-    } catch {
+    } catch (err) {
+      if (signal?.aborted) throw err;
       s?.stop('Authenticated successfully');
       if (!isInteractive) process.stderr.write('Authenticated successfully\n');
     }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -222,7 +222,9 @@ export function startCallbackServer(): Promise<{
       closed = true;
       clearTimeout(timeout);
       server.close();
-      server.closeAllConnections();
+      if (typeof server.closeAllConnections === 'function') {
+        server.closeAllConnections();
+      }
     };
 
     // A callback can reject before performOAuthLogin starts awaiting it (for
@@ -337,6 +339,7 @@ export async function performOAuthLogin(apiUrl?: string, signal?: AbortSignal): 
     saveCredentials(creds);
 
     try {
+      throwIfAborted(signal);
       const profile = await waitForAbort(getProfile(apiUrl, signal), signal);
       throwIfAborted(signal);
       creds.user = profile;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,6 +30,34 @@ export interface OAuthCallbackResult {
   state: string;
 }
 
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error('Authentication aborted.');
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw abortError(signal);
+}
+
+function waitForAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  throwIfAborted(signal);
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(abortError(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
 /**
  * Generate PKCE code_verifier and code_challenge (S256).
  */
@@ -77,6 +105,7 @@ export async function exchangeCodeForTokens(params: {
   redirectUri: string;
   clientId: string;
   codeVerifier: string;
+  signal?: AbortSignal;
 }): Promise<{ access_token: string; refresh_token: string; expires_in: number; scope: string }> {
   const tokenUrl = `${params.platformUrl}/api/oauth/v1/token`;
   let res: Response;
@@ -84,6 +113,7 @@ export async function exchangeCodeForTokens(params: {
     res = await fetch(tokenUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: params.signal,
       body: JSON.stringify({
         grant_type: 'authorization_code',
         code: params.code,
@@ -111,6 +141,7 @@ export async function refreshOAuthToken(params: {
   platformUrl: string;
   refreshToken: string;
   clientId: string;
+  signal?: AbortSignal;
 }): Promise<{ access_token: string; refresh_token?: string; expires_in: number }> {
   const tokenUrl = `${params.platformUrl}/api/oauth/v1/token`;
   let res: Response;
@@ -118,6 +149,7 @@ export async function refreshOAuthToken(params: {
     res = await fetch(tokenUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: params.signal,
       body: JSON.stringify({
         grant_type: 'refresh_token',
         refresh_token: params.refreshToken,
@@ -207,7 +239,8 @@ export function startCallbackServer(): Promise<{
  * generate PKCE + state, start callback server, open browser, exchange code, save credentials.
  * Returns the stored credentials on success.
  */
-export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredentials> {
+export async function performOAuthLogin(apiUrl?: string, signal?: AbortSignal): Promise<StoredCredentials> {
+  throwIfAborted(signal);
   const platformUrl = getPlatformApiUrl(apiUrl);
   const config = getGlobalConfig();
   const clientId = config.oauth_client_id ?? DEFAULT_CLIENT_ID;
@@ -218,6 +251,10 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
 
   // 2. Start local callback server
   const { port, result, close } = await startCallbackServer();
+  if (signal?.aborted) {
+    close();
+    throw abortError(signal);
+  }
   const redirectUri = `http://127.0.0.1:${port}/callback`;
 
   // 3. Build authorization URL
@@ -242,8 +279,12 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
   // 4. Open browser (best effort — often works even from agent shells since we're on the same machine)
   try {
     const open = (await import('open')).default;
-    await open(authUrl);
-  } catch {
+    await waitForAbort(open(authUrl), signal);
+  } catch (err) {
+    if (signal?.aborted) {
+      close();
+      throw err;
+    }
     if (isInteractive) clack.log.warn('Could not open browser. Please visit the URL above.');
   }
 
@@ -253,7 +294,7 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
   if (!isInteractive) process.stderr.write('Waiting for authentication...\n');
 
   try {
-    const callbackResult = await result;
+    const callbackResult = await waitForAbort(result, signal);
     close();
 
     // Verify state
@@ -270,6 +311,7 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
       redirectUri,
       clientId,
       codeVerifier: pkce.code_verifier,
+      signal,
     });
 
     // 7. Save credentials and fetch profile
@@ -281,7 +323,7 @@ export async function performOAuthLogin(apiUrl?: string): Promise<StoredCredenti
     saveCredentials(creds);
 
     try {
-      const profile = await getProfile(apiUrl);
+      const profile = await getProfile(apiUrl, signal);
       creds.user = profile;
       saveCredentials(creds);
       s?.stop(`Authenticated as ${profile.email}`);

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -61,7 +61,7 @@ export async function requireAuth(apiUrl?: string, allowOssBypass = true): Promi
   }
 }
 
-export async function refreshAccessToken(apiUrl?: string): Promise<string> {
+export async function refreshAccessToken(apiUrl?: string, signal?: AbortSignal): Promise<string> {
   const creds = getCredentials();
   if (!creds) {
     throw new AuthError('Not logged in. Run `npx @insforge/cli login` first.');
@@ -100,6 +100,7 @@ export async function refreshAccessToken(apiUrl?: string): Promise<string> {
       platformUrl,
       refreshToken: creds.refresh_token,
       clientId,
+      signal,
     });
 
     const updated: StoredCredentials = {
@@ -110,11 +111,12 @@ export async function refreshAccessToken(apiUrl?: string): Promise<string> {
     };
     saveCredentials(updated);
     return data.access_token;
-  } catch {
+  } catch (err) {
+    if (signal?.aborted) throw err;
     // Token refresh failed — try re-authenticating interactively
     if (process.stdout.isTTY) {
       clack.log.warn('Session expired. Please log in again.');
-      const newCreds = await performOAuthLogin(apiUrl);
+      const newCreds = await performOAuthLogin(apiUrl, signal);
       return newCreds.access_token;
     }
     throw new AuthError('Failed to refresh token. Run `npx @insforge/cli login` again.');


### PR DESCRIPTION
Closes #297 
This pull request improves the reliability and safety of project creation in the CLI by introducing robust error handling for ambiguous API failures, especially around network and gateway errors. New logic ensures that transient errors during project creation and activation are handled gracefully, preventing accidental duplicate projects and providing clearer feedback to users.

**Key changes include:**

### Error Handling & Recovery Improvements

* Added `isAmbiguousProjectCreateFailure` to classify ambiguous project creation failures (e.g., network errors, 502/503/504 responses) and prevent unsafe project adoption after such errors.
* Introduced `createProjectOrReportAmbiguousResult`, which throws a specific error message instructing users to check for existing projects before retrying, thus avoiding accidental duplicates. [[1]](diffhunk://#diff-b6d810b0306723c2b160e529addd463ae24be806303358ff1f6a2209bc13357dL40-R115) [[2]](diffhunk://#diff-b6d810b0306723c2b160e529addd463ae24be806303358ff1f6a2209bc13357dL351-R417)
* Updated the main create command to use the new error-safe project creation flow.

### Project Activation Polling

* Refactored `waitForProjectActive` to continue polling through transient errors, only failing after a timeout and preserving the last actionable error for user feedback.

### Testing

* Added comprehensive tests in `create.recovery.test.ts` to verify ambiguous failure handling, polling through transient errors, and correct error reporting on timeouts.

### Utilities & Imports

* Updated imports to include new error-handling utilities and constants.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes project creation recover from ambiguous API failures and adds abort-signal support across authentication and token-refresh flows.

- Treats gateway and transport failures during project creation as unknown results, prompting users to check for existing projects before retrying.
- Keeps polling for project activation through transient read errors, failing only after the timeout and reporting the last actionable error.
- Propagates abort signals through token refresh, OAuth login, and project status reads so in-flight requests cancel cleanly.
- Adds tests for ambiguous creation failures, transient polling errors, timeout reporting, and request cancellation.

<sup>Written for commit 320bad5d34ddd9f754824c5454b1e2abbb156e95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/CLI/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project provisioning recovery during temporary control-plane or network failures.
  - Continued checking project activation after transient errors instead of failing immediately.
  - Added clearer timeout reporting with the latest encountered error.
  - Prevented uncertain project-creation results from being silently retried, helping avoid duplicate projects.
  - Added guidance to verify project status before retrying when the creation result is unknown.
  - Improved cancellation handling for project status checks, API requests, token refresh, and OAuth login.

- **Tests**
  - Added coverage for ambiguous creation results, transient activation failures, timeout behavior, and cancellation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->